### PR TITLE
fix(ui): offer a resume only while something is left to skip

### DIFF
--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -752,6 +752,19 @@ which is the entire full-re-fetch + full-re-apply arm — the stamps are the fet
 `sync_runs` history is deliberately **preserved** (#1318): it feeds no skip gate and is the source of the "Last sync"
 display, so deleting it forced nothing and only blanked the panel to "Never" right after a reset.
 
+That preservation is also why the panel's **"Resume Sync" offer is derived from the surviving stamps, not from the run
+history** (#1789). A resume is a resume because a completion stamp survives for the next run to skip; the history says
+only that a run ended without completing, and after a Force Full Sync it says that while every stamp it implied is gone
+— so a history-derived offer promised to continue progress that had just been discarded. `get_sync_stats` therefore
+carries two additive counts alongside the display fields, `stamped_platforms` and `stamped_collections`
+(`PlatformSyncStateRepository.count` / `CollectionSyncStateRepository.count`, both read in the read UoW that already
+scans `roms`, so the panel mount pays nothing measurable). Collections count exactly as platforms do: a collection unit
+is part of a sync's enabled scope and carries its own stamp, so a library synced only through collections holds no
+platform stamp at all and a platforms-only rule would withdraw its resume offer. The counts are of what is **done**,
+never of what is left: `enabled_platforms` is keyed by RomM platform id and the stamps by slug, and nothing persisted
+bridges the two, so naming the remainder would take a server round-trip on every panel mount — the QAM line under the
+button states what a resume would skip instead.
+
 **Single-owner run lifecycle (#1202).** The run-lifecycle pair — `sync_state` (idle/running/cancelling) and
 `current_sync_id` — is mutated **only** through four verb methods on `LibrarySyncStateBox`, never by direct field
 assignment from a sub-service. Confining those two writes to the box makes run admission, cancellation, and termination

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -752,18 +752,36 @@ which is the entire full-re-fetch + full-re-apply arm — the stamps are the fet
 `sync_runs` history is deliberately **preserved** (#1318): it feeds no skip gate and is the source of the "Last sync"
 display, so deleting it forced nothing and only blanked the panel to "Never" right after a reset.
 
-That preservation is also why the panel's **"Resume Sync" offer is derived from the surviving stamps, not from the run
-history** (#1789). A resume is a resume because a completion stamp survives for the next run to skip; the history says
-only that a run ended without completing, and after a Force Full Sync it says that while every stamp it implied is gone
-— so a history-derived offer promised to continue progress that had just been discarded. `get_sync_stats` therefore
-carries two additive counts alongside the display fields, `stamped_platforms` and `stamped_collections`
-(`PlatformSyncStateRepository.count` / `CollectionSyncStateRepository.count`, both read in the read UoW that already
-scans `roms`, so the panel mount pays nothing measurable). Collections count exactly as platforms do: a collection unit
-is part of a sync's enabled scope and carries its own stamp, so a library synced only through collections holds no
-platform stamp at all and a platforms-only rule would withdraw its resume offer. The counts are of what is **done**,
-never of what is left: `enabled_platforms` is keyed by RomM platform id and the stamps by slug, and nothing persisted
-bridges the two, so naming the remainder would take a server round-trip on every panel mount — the QAM line under the
-button states what a resume would skip instead.
+That preservation is also why the panel's **"Resume Sync" offer is derived from the surviving skip authority, not from
+the run history** (#1789). The history says only that a run ended without completing, and after a Force Full Sync it
+says that while everything it implied is gone — so a history-derived offer promised to continue progress that had just
+been discarded. The condition it replaced measured the wrong thing in the same way: it paired the incomplete attempt
+with "bound shortcuts exist", but Force Full Sync does not delete shortcuts, it deletes the stamps and the recorded
+launch options.
+
+A resume rests on **skip authority**, and this plugin keeps two kinds, cleared together by that one reset: a
+**completion stamp** (whole platform or collection skipped at fetch time, ADR-0023) or a **recorded
+`applied_launch_options`** (one game skipped at apply time, ADR-0025). Neither subsumes the other, so the offer reads
+both. A run cancelled inside its first platform unit reached no final chunk and holds no stamp, but its committed chunks
+wrote shortcuts and recorded their launch commands — the next run genuinely does less work, so that is a resume. A row
+predating migration 015 carries a NULL recorded value while its platform's stamp survives, so an upgraded install can
+hold stamps and zero recorded games and still skip those platforms wholesale.
+
+`get_sync_stats` therefore carries two additive fields alongside the display ones: `resumable_games` (bound rows with a
+non-NULL `applied_launch_options`) and `has_completion_stamp` (`PlatformSyncStateRepository.has_any()` or
+`CollectionSyncStateRepository.has_any()`). Both ride in the read UoW that already scans `roms` — the game count is one
+more condition inside that loop, since `iter_all` already selects the column, and each stamp probe is a
+`SELECT 1 … LIMIT 1` over a leaf table — so the panel mount pays nothing measurable.
+
+**The game count is bound-AND-recorded, never recorded alone.** `classify_sync_roms` sends an unbound row down the NEW
+branch before it reads the recorded value, because the next run has to mint the shortcut regardless. Requiring the
+binding is what makes the count fall to zero after a DangerZone remove-all, where unbinding deliberately keeps the row
+and its recorded command (ADR-0007) — a count over every row would keep offering to resume shortcuts that no longer
+exist. The panel keeps `roms > 0` as a conjunct on top: implied by both branches today, but it states the rule that a
+run stopped before a single shortcut was written begins from scratch, and it is what would still catch the wipe if the
+destructive flows ever stopped deleting a platform's stamp in the same write UoW as the unbind. `resumable_games` is a
+count of what is **done**, never of what is left — naming the remainder needs the server's library — so the QAM line
+under the button states what a resume would skip, and is omitted when the count is zero.
 
 **Single-owner run lifecycle (#1202).** The run-lifecycle pair — `sync_state` (idle/running/cancelling) and
 `current_sync_id` — is mutated **only** through four verb methods on `LibrarySyncStateBox`, never by direct field

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -519,31 +519,34 @@ while paused) so the number tracks the climbing RSS and the blue paused banner n
 memory. That notice is driven by `resume_ready` on the callable (`domain.session_budget.resume_would_proceed`:
 `rss + RESUME_HEADROOM_CHUNKS × FULL_CHUNK_WORST_KB < ceiling` — room for TWO worst-case chunks, ≈1.2 GB bar, because a
 one-chunk bar sits exactly on the pause point where Steam's own small frees flicker the verdict; `None` when RSS is
-unreadable) — when it flips `true` the blue banner reads "Steam memory is free again — press Resume Sync" and hides the
-restart button. The callable also carries the paused run's progress (`run_done_items` / `run_total_items`), so that
-banner reads "1200 of 2001 games done": the counters are run-scoped fields on `LibrarySyncStateBox`, stamped with the
-plan's ROM total and grown by the delta-restricted apply's SKIPPED entries (already correct on their shortcut), each
-wholesale-skipped unit's ROMs, and every COMMITTED chunk's acked items — an emitted-but-uncommitted chunk (cancel /
-heartbeat timeout / the pause itself) never counts, so the number can't over-report. They live in the backend
-deliberately: the plugin process survives the Steam restart the banner asks for, while the frontend reloads. In-memory
-only — a plugin reload wipes them and both come back `None`, which the banner renders by dropping the sentence rather
-than showing a zero. That row also shows the **last run's signed RSS growth**, appended inline after the value ("X.X GB
-· last run ±Y"), measured at EVERY terminal (completed / paused / cancelled / interrupted) so a paused run reads as _its
-own_ consumption-so-far rather than a prior clean run's: a RAW read taken unconditionally at run start is the baseline
-(`run_start_rss_kb` — captured before any chunk, so even a fully-incremental-skip run still records one and reports ≈
-+0.0 GB), the terminal RSS read is the end, and `session_memory_delta` differences them (an approximation for
-information only, which a raw start baseline is fine for). The value is retained in `last_run_delta_kb` so
-`get_session_budget_status` surfaces it on a QAM remount (in-memory only, lost on reload, no migration; `None` when
-either endpoint was unmeasurable, so a stale delta is never shown); the UI reads it from that callable, so it is
-deliberately NOT put on the `sync_complete` wire. Both banners also offer a **Restart Steam now** button that calls
-`SteamClient.User.StartRestart` directly from the frontend — a deterministic full client restart that resets the
-renderer's per-session budget to the ~430 MB baseline. The button is disabled while a game is running and hard-guarded
-on click (`isAnyAppRunning`) so a restart can never close a game. The RSS reader and GC trigger are wired through
-`SessionBudgetMonitorConfig`; the gate's per-item cost is a parameter, and because the apply now pushes each created
-shortcut's cover through Steam's artwork API (`SetCustomArtworkForApp`, transiently resident but GC-reclaimable — hence
-the GC-before-measure), the monitor prices each create at the worst-case create rate **plus** the transient cover term
-(`COVER_TRANSIENT_KB`) at both the chunk gate and the preview prognosis, while a changed item stays at the lighter
-update rate.
+unreadable) — when it flips `true` the blue banner announces memory is free and hides the restart button. The callable
+also carries the paused run's progress (`run_done_items` / `run_total_items`), so that banner can read "1200 of 2001
+games done": the counters are run-scoped fields on `LibrarySyncStateBox`, stamped with the plan's ROM total and grown by
+the delta-restricted apply's SKIPPED entries (already correct on their shortcut), each wholesale-skipped unit's ROMs,
+and every COMMITTED chunk's acked items — an emitted-but-uncommitted chunk (cancel / heartbeat timeout / the pause
+itself) never counts, so the number can't over-report. They live in the backend deliberately: the plugin process
+survives the Steam restart the banner asks for, while the frontend reloads. In-memory only — a plugin reload wipes them
+and both come back `None`, which the banner renders by dropping the sentence rather than showing a zero. The banner
+**names no button of its own** (#1789): the panel hands it the sync button as one value — the label and whether pressing
+it resumes — so it quotes "Resume Sync" or "Sync Library" as the panel actually rendered it, rather than deciding from
+the paused status, which survives a Force Full Sync that the resume does not. When nothing can be resumed it also drops
+the progress sentence, because "1200 of 2001 games done" promises a head start the clear has just discarded. That row
+also shows the **last run's signed RSS growth**, appended inline after the value ("X.X GB · last run ±Y"), measured at
+EVERY terminal (completed / paused / cancelled / interrupted) so a paused run reads as _its own_ consumption-so-far
+rather than a prior clean run's: a RAW read taken unconditionally at run start is the baseline (`run_start_rss_kb` —
+captured before any chunk, so even a fully-incremental-skip run still records one and reports ≈ +0.0 GB), the terminal
+RSS read is the end, and `session_memory_delta` differences them (an approximation for information only, which a raw
+start baseline is fine for). The value is retained in `last_run_delta_kb` so `get_session_budget_status` surfaces it on
+a QAM remount (in-memory only, lost on reload, no migration; `None` when either endpoint was unmeasurable, so a stale
+delta is never shown); the UI reads it from that callable, so it is deliberately NOT put on the `sync_complete` wire.
+Both banners also offer a **Restart Steam now** button that calls `SteamClient.User.StartRestart` directly from the
+frontend — a deterministic full client restart that resets the renderer's per-session budget to the ~430 MB baseline.
+The button is disabled while a game is running and hard-guarded on click (`isAnyAppRunning`) so a restart can never
+close a game. The RSS reader and GC trigger are wired through `SessionBudgetMonitorConfig`; the gate's per-item cost is
+a parameter, and because the apply now pushes each created shortcut's cover through Steam's artwork API
+(`SetCustomArtworkForApp`, transiently resident but GC-reclaimable — hence the GC-before-measure), the monitor prices
+each create at the worst-case create rate **plus** the transient cover term (`COVER_TRANSIENT_KB`) at both the chunk
+gate and the preview prognosis, while a changed item stays at the lighter update rate.
 
 **Run/unit/chunk identity on the ack (#1041).** Every `sync_apply_unit` event carries the `run_id` (the run's
 `current_sync_id` UUID), the `unit_id` (the `WorkUnit.id`), and the `chunk_index`; the frontend echoes all three back on
@@ -773,15 +776,22 @@ non-NULL `applied_launch_options`) and `has_completion_stamp` (`PlatformSyncStat
 more condition inside that loop, since `iter_all` already selects the column, and each stamp probe is a
 `SELECT 1 … LIMIT 1` over a leaf table — so the panel mount pays nothing measurable.
 
-**The game count is bound-AND-recorded, never recorded alone.** `classify_sync_roms` sends an unbound row down the NEW
-branch before it reads the recorded value, because the next run has to mint the shortcut regardless. Requiring the
-binding is what makes the count fall to zero after a DangerZone remove-all, where unbinding deliberately keeps the row
-and its recorded command (ADR-0007) — a count over every row would keep offering to resume shortcuts that no longer
-exist. The panel keeps `roms > 0` as a conjunct on top: implied by both branches today, but it states the rule that a
-run stopped before a single shortcut was written begins from scratch, and it is what would still catch the wipe if the
-destructive flows ever stopped deleting a platform's stamp in the same write UoW as the unbind. `resumable_games` is a
-count of what is **done**, never of what is left — naming the remainder needs the server's library — so the QAM line
-under the button states what a resume would skip, and is omitted when the count is zero.
+**The game count is bound-AND-recorded, never recorded alone.** `classify_roms` (`domain/sync_diff.py`) sends an unbound
+row down the NEW branch — `if not reg or not reg.get("app_id")` — before it reads the recorded value, because the next
+run has to mint the shortcut regardless. Requiring the binding is what makes the count fall to zero after a DangerZone
+remove-all, where unbinding deliberately keeps the row and its recorded command (ADR-0007) — a count over every row
+would keep offering to resume shortcuts that no longer exist. The panel keeps `roms > 0` as a conjunct on top, and it is
+**load-bearing rather than a restatement**: `has_completion_stamp` asks whether any stamp survives anywhere, while the
+removal path is surgical — it deletes only the platform slugs its removed rows name, and only the collection stamps
+whose member set intersects those rows. A stamp naming nothing the `roms` table still holds outlives a remove-all. Prune
+makes that reachable: it deletes `roms` rows and never touches `platform_sync_state` (`PruneRegistry.delete_rows`
+invalidates intersecting collection stamps only), so a platform whose games RomM dropped keeps its stamp with no rows
+left to name it, and the next remove-all cannot see that slug to invalidate it. Verified end to end: with such a stamp
+standing, a remove-all leaves `roms == 0` and `has_completion_stamp == true`, so without the conjunct the panel would
+offer a resume over zero shortcuts. It carries the boundary rule too — a run stopped before a single shortcut was
+written begins from scratch. `resumable_games` is a count of what is **done**, never of what is left — naming the
+remainder needs the server's library — so the QAM line under the button states what a resume would skip, and is omitted
+when the count is zero.
 
 **Single-owner run lifecycle (#1202).** The run-lifecycle pair — `sync_state` (idle/running/cancelling) and
 `current_sync_id` — is mutated **only** through four verb methods on `LibrarySyncStateBox`, never by direct field

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -156,9 +156,10 @@ complete the job.
   remaining work. This is true whether or not you restart Steam in between. Once a run finishes in full, the button goes
   back to **Sync Library**.
   - **A run that stopped early still counts.** Even a run cancelled inside its very first platform had already added
-    games and would skip them next time, so that is a resume too. The button only stays **Sync Library** when nothing
-    survives for the next run to skip — a first run stopped before a single game was added, or a **Force Full Sync**
-    since (see below).
+    games and would skip them next time, so that is a resume too. The button stays **Sync Library** whenever there is
+    nothing for the next run to skip — for instance a first run stopped before a single game was added, a **Force Full
+    Sync** since (see below), or removing your shortcuts in the meantime. A run that ended in an **error** also keeps
+    the plain label: those usually fail before adding anything, so "resume" would be the wrong word for it.
   - **The line under the button says how much a resume would skip** — for example "1200 games already synced — a resume
     continues from there." It counts what is already done, not what is left: the plugin can only know the finished side
     without asking your server, so no total is shown. It is left out in the one case where the plugin knows a resume is

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -121,6 +121,11 @@ A few things worth knowing for a large library:
   button, so you know a resume will actually work now rather than pausing again. Nothing is lost, and you are never
   forced out of what you were doing. After a big run finishes with memory still high, a **yellow banner** recommends a
   Steam restart before your next large sync; it clears itself once you restart.
+  - **The banner names whichever button is actually there.** If you press **Force Full Sync** while a paused run is
+    showing, there is no longer anything to resume — so the banner stops saying "Resume Sync" and names **Sync Library**
+    instead ("Restart Steam, then Sync Library.", or "Press Sync Library to start over." once memory is free). It also
+    drops the "1200 of 2001 games done" sentence there, because that head start is exactly what the force-clear
+    discarded: the next run does all of it again.
 - **Tap "Restart Steam now" to free the memory.** Both banners include a **Restart Steam now** button. It restarts the
   Steam client (Steam closes and reopens) — the reliable way to reset its memory — and you can Resume Sync once it comes
   back. The button is disabled while a game is running (a restart would close your game), so close your game first; it

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -144,12 +144,16 @@ complete the job.
   "Never". The end-of-run toast and the sync status line make the same distinction: a run stopped by a crash or Steam
   reload reads "Sync interrupted — … so far." rather than blaming a Cancel you never pressed, and the status line
   compares progress against the run's planned total (e.g. "3 of 10 games processed").
-- **The Sync button becomes "Resume Sync".** When a run was cancelled, interrupted, or paused and left games in your
-  library, the **Sync Library** button changes to **Resume Sync**. Pressing it completes the library: the platforms that
-  already synced in full are skipped, and even in the platform that stopped, only the games it hadn't finished are
-  processed — the ones already correct are skipped, so a resume finishes quickly and the counter shows just the
-  remaining work. This is true whether or not you restart Steam in between. Once a run finishes in full, the button goes
-  back to **Sync Library**.
+- **The Sync button becomes "Resume Sync".** When a run was cancelled, interrupted, or paused, left games in your
+  library, and left at least one platform or collection synced in full, the **Sync Library** button changes to **Resume
+  Sync**. Pressing it completes the library: the platforms that already synced in full are skipped, and even in the
+  platform that stopped, only the games it hadn't finished are processed — the ones already correct are skipped, so a
+  resume finishes quickly and the counter shows just the remaining work. This is true whether or not you restart Steam
+  in between. Once a run finishes in full, the button goes back to **Sync Library**.
+  - **The line under the button says what a resume would skip** — for example "3 platforms · 1 collection already synced
+    in full". Those are the platforms and collections whose last run finished, so the next one passes straight over
+    them. It is a count of what is already done, not of what is left: the plugin can only know the finished side without
+    asking your server, so no total is shown.
 - **Force Full Sync starts over from scratch.** Under the sync buttons, **Force Full Sync** clears the plugin's record
   of what it has already synced and re-fetches every platform and collection from RomM on the next run — and that run
   also rewrites every shortcut instead of skipping the ones that look correct, so it repairs anything that drifted on
@@ -161,6 +165,10 @@ complete the job.
     dropping back to "Never". The next preview names the full re-sync explicitly: above the change line it reads **"Full
     re-sync — all platforms re-fetched."**, so a big "Games: … updated" count reads as the intended rebuild rather than
     a surprise. The button stays put after you press it — pressing it again simply re-arms the same fresh start.
+  - **"Resume Sync" goes back to "Sync Library".** Force Full Sync discards exactly the record a resume would continue
+    from, so nothing is left to resume: the button reads **Sync Library** again even when your last run was cancelled or
+    interrupted, and the line naming what would be skipped goes with it. Whichever button you press next, the run is a
+    full one — the label now says so rather than promising otherwise.
 
 ## Multiple versions of a game
 

--- a/docs/user-guide/syncing-your-library.md
+++ b/docs/user-guide/syncing-your-library.md
@@ -149,16 +149,21 @@ complete the job.
   "Never". The end-of-run toast and the sync status line make the same distinction: a run stopped by a crash or Steam
   reload reads "Sync interrupted — … so far." rather than blaming a Cancel you never pressed, and the status line
   compares progress against the run's planned total (e.g. "3 of 10 games processed").
-- **The Sync button becomes "Resume Sync".** When a run was cancelled, interrupted, or paused, left games in your
-  library, and left at least one platform or collection synced in full, the **Sync Library** button changes to **Resume
-  Sync**. Pressing it completes the library: the platforms that already synced in full are skipped, and even in the
-  platform that stopped, only the games it hadn't finished are processed — the ones already correct are skipped, so a
-  resume finishes quickly and the counter shows just the remaining work. This is true whether or not you restart Steam
-  in between. Once a run finishes in full, the button goes back to **Sync Library**.
-  - **The line under the button says what a resume would skip** — for example "3 platforms · 1 collection already synced
-    in full". Those are the platforms and collections whose last run finished, so the next one passes straight over
-    them. It is a count of what is already done, not of what is left: the plugin can only know the finished side without
-    asking your server, so no total is shown.
+- **The Sync button becomes "Resume Sync".** When a run was cancelled, interrupted, or paused and left work the next run
+  can skip, the **Sync Library** button changes to **Resume Sync**. Pressing it completes the library: the platforms
+  that already synced in full are skipped, and even in the platform that stopped, only the games it hadn't finished are
+  processed — the ones already correct are skipped, so a resume finishes quickly and the counter shows just the
+  remaining work. This is true whether or not you restart Steam in between. Once a run finishes in full, the button goes
+  back to **Sync Library**.
+  - **A run that stopped early still counts.** Even a run cancelled inside its very first platform had already added
+    games and would skip them next time, so that is a resume too. The button only stays **Sync Library** when nothing
+    survives for the next run to skip — a first run stopped before a single game was added, or a **Force Full Sync**
+    since (see below).
+  - **The line under the button says how much a resume would skip** — for example "1200 games already synced — a resume
+    continues from there." It counts what is already done, not what is left: the plugin can only know the finished side
+    without asking your server, so no total is shown. It is left out in the one case where the plugin knows a resume is
+    possible but cannot put a number on it — a library synced before the plugin started recording per-game progress,
+    where whole platforms are skipped but no individual game is counted.
 - **Force Full Sync starts over from scratch.** Under the sync buttons, **Force Full Sync** clears the plugin's record
   of what it has already synced and re-fetches every platform and collection from RomM on the next run — and that run
   also rewrites every shortcut instead of skipping the ones that look correct, so it repairs anything that drifted on
@@ -170,10 +175,12 @@ complete the job.
     dropping back to "Never". The next preview names the full re-sync explicitly: above the change line it reads **"Full
     re-sync — all platforms re-fetched."**, so a big "Games: … updated" count reads as the intended rebuild rather than
     a surprise. The button stays put after you press it — pressing it again simply re-arms the same fresh start.
-  - **"Resume Sync" goes back to "Sync Library".** Force Full Sync discards exactly the record a resume would continue
-    from, so nothing is left to resume: the button reads **Sync Library** again even when your last run was cancelled or
-    interrupted, and the line naming what would be skipped goes with it. Whichever button you press next, the run is a
-    full one — the label now says so rather than promising otherwise.
+  - **"Resume Sync" goes back to "Sync Library".** Force Full Sync discards exactly the records a resume would continue
+    from — both what it knows about finished platforms and what it knows about each already-correct game — so nothing is
+    left to resume: the button reads **Sync Library** again even when your last run was cancelled or interrupted, and
+    the line naming what would be skipped goes with it. Your games stay in Steam; it is only the plugin's record of what
+    is already correct that goes, which is what makes the next run redo all of it. Whichever button you press next, the
+    run is a full one — the label now says so rather than promising otherwise.
 
 ## Multiple versions of a game
 

--- a/py_modules/adapters/repositories/collection_sync_state.py
+++ b/py_modules/adapters/repositories/collection_sync_state.py
@@ -68,8 +68,8 @@ class SqliteCollectionSyncStateRepository(BaseRepository):
         for row in self._conn.execute(f"SELECT {_COLUMNS} FROM collection_sync_state").fetchall():
             yield self._row_to_state(row)
 
-    def count(self) -> int:
-        return int(self._conn.execute("SELECT COUNT(*) FROM collection_sync_state").fetchone()[0])
+    def has_any(self) -> bool:
+        return self._conn.execute("SELECT 1 FROM collection_sync_state LIMIT 1").fetchone() is not None
 
     def clear(self) -> None:
         self._conn.execute("DELETE FROM collection_sync_state")

--- a/py_modules/adapters/repositories/collection_sync_state.py
+++ b/py_modules/adapters/repositories/collection_sync_state.py
@@ -68,5 +68,8 @@ class SqliteCollectionSyncStateRepository(BaseRepository):
         for row in self._conn.execute(f"SELECT {_COLUMNS} FROM collection_sync_state").fetchall():
             yield self._row_to_state(row)
 
+    def count(self) -> int:
+        return int(self._conn.execute("SELECT COUNT(*) FROM collection_sync_state").fetchone()[0])
+
     def clear(self) -> None:
         self._conn.execute("DELETE FROM collection_sync_state")

--- a/py_modules/adapters/repositories/platform_sync_state.py
+++ b/py_modules/adapters/repositories/platform_sync_state.py
@@ -48,5 +48,8 @@ class SqlitePlatformSyncStateRepository(BaseRepository):
     def delete(self, platform_slug: str) -> None:
         self._conn.execute("DELETE FROM platform_sync_state WHERE platform_slug = ?", (platform_slug,))
 
+    def count(self) -> int:
+        return int(self._conn.execute("SELECT COUNT(*) FROM platform_sync_state").fetchone()[0])
+
     def clear(self) -> None:
         self._conn.execute("DELETE FROM platform_sync_state")

--- a/py_modules/adapters/repositories/platform_sync_state.py
+++ b/py_modules/adapters/repositories/platform_sync_state.py
@@ -48,8 +48,8 @@ class SqlitePlatformSyncStateRepository(BaseRepository):
     def delete(self, platform_slug: str) -> None:
         self._conn.execute("DELETE FROM platform_sync_state WHERE platform_slug = ?", (platform_slug,))
 
-    def count(self) -> int:
-        return int(self._conn.execute("SELECT COUNT(*) FROM platform_sync_state").fetchone()[0])
+    def has_any(self) -> bool:
+        return self._conn.execute("SELECT 1 FROM platform_sync_state LIMIT 1").fetchone() is not None
 
     def clear(self) -> None:
         self._conn.execute("DELETE FROM platform_sync_state")

--- a/py_modules/services/library/reporter.py
+++ b/py_modules/services/library/reporter.py
@@ -932,10 +932,11 @@ class SyncReporter:
                 if rom.shortcut_app_id is None:
                     continue
                 rom_count += 1
-                # Bound AND recorded, never recorded alone. ``classify_sync_roms``
-                # sends an unbound row down the NEW branch before it ever looks at
+                # Bound AND recorded, never recorded alone. ``classify_roms``
+                # (``domain/sync_diff.py``) sends an unbound row down the NEW branch
+                # — ``if not reg or not reg.get("app_id")`` — before it ever reads
                 # the recorded value, so a recorded command with no shortcut is not
-                # skip authority — the next run has to mint the shortcut regardless.
+                # skip authority: the next run has to mint the shortcut regardless.
                 # Requiring the binding is therefore what makes this count fall to
                 # zero after a DangerZone remove-all by construction: unbinding
                 # keeps the row and its recorded command on purpose (ADR-0007), so

--- a/py_modules/services/library/reporter.py
+++ b/py_modules/services/library/reporter.py
@@ -94,8 +94,8 @@ class _SyncStatsReading:
     last_sync: str | None
     last_attempt: dict[str, str] | None
     rom_count: int
-    stamped_platforms: int
-    stamped_collections: int
+    resumable_games: int
+    has_completion_stamp: bool
 
 
 class SyncReporter:
@@ -853,10 +853,12 @@ class SyncReporter:
         collections/platforms as "unchanged" (they exist in Steam; membership
         did not change), which is correct.
 
-        What the preserved history does **not** carry is a resumable run. The
-        panel's "Resume Sync" offer reads the surviving stamps this clear has
-        just taken away, never the history, so the sync button falls back to
-        "Sync Library" here — see :meth:`_read_sync_stats_io` (#1789).
+        What the preserved history does **not** carry is a resumable run. This
+        clear takes away BOTH kinds of skip authority — every completion stamp and
+        every recorded launch command — and the panel's "Resume Sync" offer reads
+        those, never the history, so the sync button falls back to "Sync Library"
+        here. That the two are cleared together is what makes the offer's rule
+        hold; see :meth:`_read_sync_stats_io` (#1789).
         """
         with self._uow_factory() as uow:
             uow.platform_sync_state.clear()
@@ -883,47 +885,71 @@ class SyncReporter:
             "collections": enabled_collection_count,
             "roms": stats.rom_count,
             "total_shortcuts": stats.rom_count,
-            "stamped_platforms": stats.stamped_platforms,
-            "stamped_collections": stats.stamped_collections,
+            "resumable_games": stats.resumable_games,
+            "has_completion_stamp": stats.has_completion_stamp,
         }
 
     def _read_sync_stats_io(self) -> _SyncStatsReading:
-        """Read the run history, the bound-ROM count and the surviving stamps from SQLite.
+        """Read the run history, the bound-ROM count and the surviving skip authority from SQLite.
 
         ``last_sync`` is the ``finished_at`` of the latest completed ``SyncRun``;
         ``last_attempt`` surfaces the newest cancelled/interrupted/paused/errored run when
         it is newer than that (see :meth:`_last_attempt`); the ROM count is the
         bound-shortcut count in ``roms``.
 
-        The two stamp counts are what makes the panel's "Resume Sync" offer
-        honest. A resume resumes FROM a completion stamp, and the run history
-        stops implying one the moment Force Full Sync runs: it clears every stamp
-        while deliberately preserving the history (#1318), so deriving the offer
-        from the history alone kept offering to continue a run whose progress had
-        just been discarded (#1789).
+        The last two are what makes the panel's "Resume Sync" offer honest, and
+        they are two facts rather than one because this plugin keeps **two** kinds
+        of durable progress. A **completion stamp** makes the next run pass over a
+        whole platform or collection at fetch time; a **recorded launch command**
+        makes it pass over one game at apply time. Both survive a stopped run and
+        both are cleared together by Force Full Sync, which is the entire #1789
+        defect: the offer used to be derived from the run history, which Force
+        Full Sync deliberately preserves (#1318), so it outlived the progress it
+        promised to continue.
 
-        Collections are counted alongside platforms deliberately, not by
-        oversight: a collection carries its own completion stamp and is part of a
-        sync's enabled scope exactly as a platform is, so a library synced only
-        through collections holds no platform stamp at all — a platforms-only
-        count would silently withdraw the resume offer from that user.
+        Neither fact subsumes the other, so the offer reads both. A run cancelled
+        inside its very first platform unit has written shortcuts and recorded
+        their launch commands but reached no final chunk, so it holds recorded
+        games and no stamp — and it is a genuine resume, because the next run
+        really does less work. In the other direction, a row predating migration
+        015 carries a NULL recorded value while its platform's stamp survives, so
+        an upgraded install can hold stamps with zero recorded games and still
+        skip those platforms wholesale. Counting only one kind declares one of
+        these two a fresh start when it is not.
 
-        Both counts ride along in the same read UoW as the ``roms`` scan already
-        performed here; each is one ``COUNT(*)`` over a leaf table holding one row
-        per synced unit, so the panel mount pays nothing measurable for them.
+        Everything here rides in the read UoW that already scans ``roms``: the
+        recorded-game count is one more condition inside that same loop (``iter_all``
+        already selects ``applied_launch_options``), and each stamp probe is a
+        ``SELECT 1 … LIMIT 1`` over a leaf table. The panel mount pays nothing
+        measurable for any of it.
         """
         with self._uow_factory() as uow:
             completed = uow.sync_runs.get_latest_completed()
             terminal = uow.sync_runs.get_latest_terminal()
-            rom_count = sum(1 for rom in uow.roms.iter_all() if rom.shortcut_app_id is not None)
-            stamped_platforms = uow.platform_sync_state.count()
-            stamped_collections = uow.collection_sync_state.count()
+            rom_count = 0
+            resumable_games = 0
+            for rom in uow.roms.iter_all():
+                if rom.shortcut_app_id is None:
+                    continue
+                rom_count += 1
+                # Bound AND recorded, never recorded alone. ``classify_sync_roms``
+                # sends an unbound row down the NEW branch before it ever looks at
+                # the recorded value, so a recorded command with no shortcut is not
+                # skip authority — the next run has to mint the shortcut regardless.
+                # Requiring the binding is therefore what makes this count fall to
+                # zero after a DangerZone remove-all by construction: unbinding
+                # keeps the row and its recorded command on purpose (ADR-0007), so
+                # a count over all rows would keep offering a resume of shortcuts
+                # that no longer exist. Do not "simplify" this to every row.
+                if rom.applied_launch_options is not None:
+                    resumable_games += 1
+            has_completion_stamp = uow.platform_sync_state.has_any() or uow.collection_sync_state.has_any()
         return _SyncStatsReading(
             last_sync=completed.finished_at if completed is not None else None,
             last_attempt=self._last_attempt(completed, terminal),
             rom_count=rom_count,
-            stamped_platforms=stamped_platforms,
-            stamped_collections=stamped_collections,
+            resumable_games=resumable_games,
+            has_completion_stamp=has_completion_stamp,
         )
 
     @staticmethod

--- a/py_modules/services/library/reporter.py
+++ b/py_modules/services/library/reporter.py
@@ -87,6 +87,17 @@ class SyncReporterConfig:
     artwork: ArtworkManager
 
 
+@dataclass(frozen=True)
+class _SyncStatsReading:
+    """One read of everything ``get_sync_stats`` takes from SQLite."""
+
+    last_sync: str | None
+    last_attempt: dict[str, str] | None
+    rom_count: int
+    stamped_platforms: int
+    stamped_collections: int
+
+
 class SyncReporter:
     """Post-apply reporter + the ``roms``-derived queries + cache reset."""
 
@@ -841,6 +852,11 @@ class SyncReporter:
         after a reset (#1318). Keeping it means a post-force preview shows
         collections/platforms as "unchanged" (they exist in Steam; membership
         did not change), which is correct.
+
+        What the preserved history does **not** carry is a resumable run. The
+        panel's "Resume Sync" offer reads the surviving stamps this clear has
+        just taken away, never the history, so the sync button falls back to
+        "Sync Library" here — see :meth:`_read_sync_stats_io` (#1789).
         """
         with self._uow_factory() as uow:
             uow.platform_sync_state.clear()
@@ -859,30 +875,56 @@ class SyncReporter:
             )
         else:
             enabled_collection_count = 0
-        last_sync, last_attempt, rom_count = self._read_sync_stats_io()
+        stats = self._read_sync_stats_io()
         return {
-            "last_sync": last_sync,
-            "last_attempt": last_attempt,
+            "last_sync": stats.last_sync,
+            "last_attempt": stats.last_attempt,
             "platforms": enabled_platform_count,
             "collections": enabled_collection_count,
-            "roms": rom_count,
-            "total_shortcuts": rom_count,
+            "roms": stats.rom_count,
+            "total_shortcuts": stats.rom_count,
+            "stamped_platforms": stats.stamped_platforms,
+            "stamped_collections": stats.stamped_collections,
         }
 
-    def _read_sync_stats_io(self) -> tuple[str | None, dict[str, str] | None, int]:
-        """Read ``(last_sync_iso, last_attempt, bound_rom_count)`` from SQLite.
+    def _read_sync_stats_io(self) -> _SyncStatsReading:
+        """Read the run history, the bound-ROM count and the surviving stamps from SQLite.
 
         ``last_sync`` is the ``finished_at`` of the latest completed ``SyncRun``;
         ``last_attempt`` surfaces the newest cancelled/interrupted/paused/errored run when
         it is newer than that (see :meth:`_last_attempt`); the ROM count is the
         bound-shortcut count in ``roms``.
+
+        The two stamp counts are what makes the panel's "Resume Sync" offer
+        honest. A resume resumes FROM a completion stamp, and the run history
+        stops implying one the moment Force Full Sync runs: it clears every stamp
+        while deliberately preserving the history (#1318), so deriving the offer
+        from the history alone kept offering to continue a run whose progress had
+        just been discarded (#1789).
+
+        Collections are counted alongside platforms deliberately, not by
+        oversight: a collection carries its own completion stamp and is part of a
+        sync's enabled scope exactly as a platform is, so a library synced only
+        through collections holds no platform stamp at all — a platforms-only
+        count would silently withdraw the resume offer from that user.
+
+        Both counts ride along in the same read UoW as the ``roms`` scan already
+        performed here; each is one ``COUNT(*)`` over a leaf table holding one row
+        per synced unit, so the panel mount pays nothing measurable for them.
         """
         with self._uow_factory() as uow:
             completed = uow.sync_runs.get_latest_completed()
             terminal = uow.sync_runs.get_latest_terminal()
             rom_count = sum(1 for rom in uow.roms.iter_all() if rom.shortcut_app_id is not None)
-        last_sync = completed.finished_at if completed is not None else None
-        return last_sync, self._last_attempt(completed, terminal), rom_count
+            stamped_platforms = uow.platform_sync_state.count()
+            stamped_collections = uow.collection_sync_state.count()
+        return _SyncStatsReading(
+            last_sync=completed.finished_at if completed is not None else None,
+            last_attempt=self._last_attempt(completed, terminal),
+            rom_count=rom_count,
+            stamped_platforms=stamped_platforms,
+            stamped_collections=stamped_collections,
+        )
 
     @staticmethod
     def _last_attempt(completed: SyncRun | None, terminal: SyncRun | None) -> dict[str, str] | None:

--- a/py_modules/services/protocols/repositories.py
+++ b/py_modules/services/protocols/repositories.py
@@ -364,13 +364,15 @@ class PlatformSyncStateRepository(Protocol):
         """
         ...
 
-    def count(self) -> int:
-        """Return how many platforms currently carry a completion stamp.
+    def has_any(self) -> bool:
+        """Return whether ANY platform currently carries a completion stamp.
 
-        Backs the panel's resume offer: the stamps are what a resume resumes
-        FROM, so a non-zero count is what makes "Resume Sync" honest after an
-        incomplete run — the run history alone does not, since Force Full Sync
-        preserves it while clearing every stamp (#1789). (library/reporter.py)
+        One of the two skip authorities the panel's resume offer reads: a
+        surviving stamp means the next run passes over that whole platform at
+        fetch time, so there is something to resume even when no individual game
+        carries a recorded launch command (a row predating migration 015). The run
+        history cannot answer this — Force Full Sync preserves it while clearing
+        every stamp (#1789). (library/reporter.py)
         """
         ...
 
@@ -419,13 +421,13 @@ class CollectionSyncStateRepository(Protocol):
         """
         ...
 
-    def count(self) -> int:
-        """Return how many collections currently carry a completion stamp.
+    def has_any(self) -> bool:
+        """Return whether ANY collection currently carries a completion stamp.
 
-        The collection sibling of ``PlatformSyncStateRepository.count`` and read
+        The collection sibling of ``PlatformSyncStateRepository.has_any`` and read
         with it: a collection unit is part of a sync's enabled scope exactly as a
-        platform unit is, so its surviving stamp counts towards the panel's
-        resume offer the same way (#1789). (library/reporter.py)
+        platform unit is, so its surviving stamp answers the resume offer the same
+        way (#1789). (library/reporter.py)
         """
         ...
 

--- a/py_modules/services/protocols/repositories.py
+++ b/py_modules/services/protocols/repositories.py
@@ -364,6 +364,16 @@ class PlatformSyncStateRepository(Protocol):
         """
         ...
 
+    def count(self) -> int:
+        """Return how many platforms currently carry a completion stamp.
+
+        Backs the panel's resume offer: the stamps are what a resume resumes
+        FROM, so a non-zero count is what makes "Resume Sync" honest after an
+        incomplete run — the run history alone does not, since Force Full Sync
+        preserves it while clearing every stamp (#1789). (library/reporter.py)
+        """
+        ...
+
     def clear(self) -> None:
         """Drop every stamp so no platform skips next run.
 
@@ -406,6 +416,16 @@ class CollectionSyncStateRepository(Protocol):
         Backs the removal flows' surgical invalidation: they scan the stamps and
         delete the ones whose ``member_rom_ids`` contain a removed ROM.
         (services/shortcut_removal.py)
+        """
+        ...
+
+    def count(self) -> int:
+        """Return how many collections currently carry a completion stamp.
+
+        The collection sibling of ``PlatformSyncStateRepository.count`` and read
+        with it: a collection unit is part of a sync's enabled scope exactly as a
+        platform unit is, so its surviving stamp counts towards the panel's
+        resume offer the same way (#1789). (library/reporter.py)
         """
         ...
 

--- a/scripts/check_read_only_module.py
+++ b/scripts/check_read_only_module.py
@@ -97,7 +97,7 @@ REPOSITORY_ATTRS: frozenset[str] = frozenset(
 READ_PREFIXES: tuple[str, ...] = ("get_", "iter_")
 # Reads whose names carry neither prefix. Exact names, not prefixes, so a
 # hypothetical ``count_and_prune`` would not inherit the exemption.
-READ_METHODS: frozenset[str] = frozenset({"get", "count", "rom_ids_with_pending_device"})
+READ_METHODS: frozenset[str] = frozenset({"get", "count", "has_any", "rom_ids_with_pending_device"})
 
 
 def _is_read(method: str) -> bool:

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -171,8 +171,23 @@ vi.mock("@decky/ui", async () => {
     // Focusable wrappers around read-only rows (info fields, banners, progress) —
     // pass children through a plain div so the wrapped content stays queryable.
     Focusable: passthrough("div"),
-    ButtonItem: ({ children, onClick, disabled }: AnyProps & { onClick?: () => void; disabled?: boolean }) =>
-      ce("button", { onClick, disabled }, children as never),
+    // Mirrors the shared stub in src/test-setup.ts: the description rides in a
+    // SIBLING span, never inside the button, so it stays assertable (a dropped
+    // prop would make every assertion of its ABSENCE vacuously true) without
+    // leaking into the button's own textContent, which is how tests here identify
+    // buttons by label.
+    ButtonItem: ({
+      children,
+      onClick,
+      disabled,
+      description,
+    }: AnyProps & { onClick?: () => void; disabled?: boolean; description?: unknown }) =>
+      ce(
+        "div",
+        null,
+        ce("button", { onClick, disabled }, children as never),
+        description == null ? null : ce("span", { "data-testid": "button-desc" }, description as never),
+      ),
     Field: (p: AnyProps & { label?: unknown; description?: unknown }) =>
       ce(
         "div",
@@ -3236,17 +3251,32 @@ describe("MainPage", () => {
   });
 
   describe("sync button label (resume vs fresh)", () => {
-    // roms > 0 = partial progress actually exists to resume. Every non-completed,
-    // non-errored terminal status resumes: interrupted, cancelled, and the #1383
-    // session-budget pause.
+    /** The stamp counts a resume situation needs: something on disk to continue
+     *  from. Without them the offer is off whatever the run history says (#1789). */
+    function resumeStats(overrides: Partial<SyncStats> = {}): SyncStats {
+      return {
+        ...defaultStats(),
+        roms: 42,
+        last_attempt: { finished_at: "2026-06-01T17:48:00", status: "interrupted" },
+        stamped_platforms: 3,
+        stamped_collections: 0,
+        ...overrides,
+      };
+    }
+
+    function buttonDescriptions(container: HTMLElement): string[] {
+      return Array.from(container.querySelectorAll('[data-testid="button-desc"]')).map((el) => el.textContent);
+    }
+
+    // roms > 0 = shortcuts on disk, a surviving stamp = progress the next run
+    // will skip. Every non-completed, non-errored terminal status resumes:
+    // interrupted, cancelled, and the #1383 session-budget pause.
     it.each(["interrupted", "cancelled", "paused"] as const)(
-      "reads 'Resume Sync' when the newest attempt was %s with bound shortcuts on disk",
+      "reads 'Resume Sync' when the newest attempt was %s with bound shortcuts and a surviving stamp",
       async (status) => {
-        vi.mocked(backend.getSyncStats).mockResolvedValue({
-          ...defaultStats(),
-          roms: 42,
-          last_attempt: { finished_at: "2026-06-01T17:48:00", status },
-        });
+        vi.mocked(backend.getSyncStats).mockResolvedValue(
+          resumeStats({ last_attempt: { finished_at: "2026-06-01T17:48:00", status } }),
+        );
         const { container } = render(<MainPage onNavigate={vi.fn()} />);
         await flushAsync();
         expect(buttonByExactText(container, "Resume Sync")).not.toBeNull();
@@ -3254,15 +3284,56 @@ describe("MainPage", () => {
       },
     );
 
+    it("reads 'Sync Library' when an incomplete attempt has NO surviving stamp (post-Force-Full-Sync)", async () => {
+      // The #1789 regression. Force Full Sync clears every completion stamp but
+      // deliberately preserves the run history (#1318), so the incomplete attempt
+      // and the bound shortcuts both survive while the progress they described is
+      // gone. Whichever button is pressed the next run is a full one, so offering
+      // to resume promises something that can no longer happen.
+      vi.mocked(backend.getSyncStats).mockResolvedValue(resumeStats({ stamped_platforms: 0, stamped_collections: 0 }));
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      expect(buttonByExactText(container, "Sync Library")).not.toBeNull();
+      expect(buttonByExactText(container, "Resume Sync")).toBeNull();
+      expect(buttonDescriptions(container).join(" ")).not.toContain("already synced in full");
+    });
+
+    it("reads 'Resume Sync' on collection stamps alone (no platform ever stamped)", async () => {
+      // A library synced only through collections holds no platform stamp at all;
+      // a platforms-only rule would silently withdraw its resume offer.
+      vi.mocked(backend.getSyncStats).mockResolvedValue(resumeStats({ stamped_platforms: 0, stamped_collections: 2 }));
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      expect(buttonByExactText(container, "Resume Sync")).not.toBeNull();
+      expect(buttonDescriptions(container)).toContain(
+        "2 collections already synced in full — a resume continues with the rest.",
+      );
+    });
+
+    it("names both kinds of stamped unit under the button, each correctly pluralized", async () => {
+      vi.mocked(backend.getSyncStats).mockResolvedValue(resumeStats({ stamped_platforms: 1, stamped_collections: 4 }));
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      expect(buttonDescriptions(container)).toContain(
+        "1 platform · 4 collections already synced in full — a resume continues with the rest.",
+      );
+    });
+
+    it("omits the line entirely when the button reads 'Sync Library'", async () => {
+      // No resume, nothing to describe — a stale count under a fresh-sync button
+      // would name progress the run is not going to skip.
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      expect(buttonByExactText(container, "Sync Library")).not.toBeNull();
+      expect(buttonDescriptions(container).join(" ")).not.toContain("already synced in full");
+    });
+
     it("reads 'Sync Library' when an interrupted attempt left ZERO bound shortcuts (all removed — nothing to resume)", async () => {
       // The regression: after an interrupted run the user removed every shortcut
       // (DangerZone "remove all"), so roms is 0 — the next run is a full fresh
-      // import, and the label must not falsely promise a resume.
-      vi.mocked(backend.getSyncStats).mockResolvedValue({
-        ...defaultStats(),
-        roms: 0,
-        last_attempt: { finished_at: "2026-06-01T17:48:00", status: "interrupted" },
-      });
+      // import, and the label must not falsely promise a resume. The stamps are
+      // left standing so the zero shortcut count is what carries the assertion.
+      vi.mocked(backend.getSyncStats).mockResolvedValue(resumeStats({ roms: 0 }));
       const { container } = render(<MainPage onNavigate={vi.fn()} />);
       await flushAsync();
       expect(buttonByExactText(container, "Sync Library")).not.toBeNull();
@@ -3271,11 +3342,11 @@ describe("MainPage", () => {
 
     it("keeps 'Sync Library' when the newest attempt errored (resume isn't the model)", async () => {
       // An errored run often failed before applying anything (config error, etc.),
-      // so "resume" would mislead — the fresh label stays.
-      vi.mocked(backend.getSyncStats).mockResolvedValue({
-        ...defaultStats(),
-        last_attempt: { finished_at: "2026-06-01T17:48:00", status: "errored" },
-      });
+      // so "resume" would mislead — the fresh label stays. Stamps and shortcuts
+      // are present, so only the status can be what withholds the offer.
+      vi.mocked(backend.getSyncStats).mockResolvedValue(
+        resumeStats({ last_attempt: { finished_at: "2026-06-01T17:48:00", status: "errored" } }),
+      );
       const { container } = render(<MainPage onNavigate={vi.fn()} />);
       await flushAsync();
       expect(buttonByExactText(container, "Sync Library")).not.toBeNull();
@@ -3283,7 +3354,9 @@ describe("MainPage", () => {
     });
 
     it("keeps 'Sync Library' when there is no last attempt (clean state)", async () => {
-      // defaultStats() has no last_attempt → the fresh label.
+      // Stamps survive every completed run, so a fully-synced library carries
+      // plenty of them — the absent last_attempt is what has to withhold the offer.
+      vi.mocked(backend.getSyncStats).mockResolvedValue(resumeStats({ last_attempt: null }));
       const { container } = render(<MainPage onNavigate={vi.fn()} />);
       await flushAsync();
       expect(buttonByExactText(container, "Sync Library")).not.toBeNull();
@@ -3311,16 +3384,31 @@ describe("MainPage", () => {
       expect(buttonByExactText(container, "Force Full Sync")).toBeNull();
     });
 
-    it("keeps 'Resume Sync' and the Force button after a force-clear (history preserved, #1318)", async () => {
-      // Force Full Sync no longer deletes the run history — the backend preserves
-      // it so the Last-sync display stays truthful. Both stats reads (mount +
-      // post-clear) therefore return the SAME resume situation.
-      vi.mocked(backend.getSyncStats).mockResolvedValue({
-        ...defaultStats(),
-        roms: 42,
-        last_sync: null,
-        last_attempt: { finished_at: "2026-06-01T17:48:00", status: "interrupted" },
-      });
+    it("keeps the Force button after a force-clear while the label drops back to 'Sync Library'", async () => {
+      // Two things a force-clear does, deliberately opposite, and they are easy to
+      // merge into one. The run HISTORY is preserved (#1318) so the Last-sync line
+      // and this button both stay put — the button is idempotent, pressing it
+      // again just re-clears already-cleared stamps. The completion STAMPS are
+      // gone, and the resume offer reads those, so the label must NOT survive the
+      // clear: the next run is a full one either way, and continuing to offer a
+      // resume promises progress that has just been discarded (#1789).
+      vi.mocked(backend.getSyncStats)
+        .mockResolvedValueOnce({
+          ...defaultStats(),
+          roms: 42,
+          last_sync: null,
+          last_attempt: { finished_at: "2026-06-01T17:48:00", status: "interrupted" },
+          stamped_platforms: 3,
+          stamped_collections: 1,
+        })
+        .mockResolvedValue({
+          ...defaultStats(),
+          roms: 42,
+          last_sync: null,
+          last_attempt: { finished_at: "2026-06-01T17:48:00", status: "interrupted" },
+          stamped_platforms: 0,
+          stamped_collections: 0,
+        });
       vi.mocked(backend.clearSyncCache).mockResolvedValue({ success: true, message: "Cleared" });
       const { container } = render(<MainPage onNavigate={vi.fn()} />);
       await flushAsync();
@@ -3329,7 +3417,7 @@ describe("MainPage", () => {
       expect(buttonByExactText(container, "Force Full Sync")).not.toBeNull();
 
       // Press Force Full Sync → clearSyncCache succeeds → the stats refresh reads
-      // the SAME preserved history.
+      // the preserved history with every stamp gone.
       await act(async () => {
         fireEvent.click(buttonByExactText(container, "Force Full Sync")!);
         await Promise.resolve();
@@ -3337,10 +3425,8 @@ describe("MainPage", () => {
       });
       await flushAsync();
 
-      // History preserved: the label stays "Resume Sync" and the Force button
-      // stays visible (idempotent — the stamps are already cleared).
-      expect(buttonByExactText(container, "Resume Sync")).not.toBeNull();
-      expect(buttonByExactText(container, "Sync Library")).toBeNull();
+      expect(buttonByExactText(container, "Sync Library")).not.toBeNull();
+      expect(buttonByExactText(container, "Resume Sync")).toBeNull();
       expect(buttonByExactText(container, "Force Full Sync")).not.toBeNull();
     });
   });
@@ -5377,8 +5463,8 @@ describe("MainPage", () => {
     /** Stats that let EVERY start control render, so an assertion that none of
      *  them is on screen is carried by four absences rather than one. Without a
      *  recorded attempt "Force Full Sync" is hidden anyway, and without an
-     *  incomplete one plus bound shortcuts the sync button reads "Sync Library"
-     *  rather than "Resume Sync". */
+     *  incomplete one plus bound shortcuts plus a surviving completion stamp the
+     *  sync button reads "Sync Library" rather than "Resume Sync". */
     function statsWithEveryStartControl(): SyncStats {
       return {
         last_sync: null,
@@ -5387,6 +5473,8 @@ describe("MainPage", () => {
         roms: 12,
         total_shortcuts: 12,
         last_attempt: { finished_at: "2026-06-01T17:48:00", status: "cancelled" },
+        stamped_platforms: 1,
+        stamped_collections: 0,
       };
     }
 

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -1396,16 +1396,16 @@ describe("MainPage", () => {
       rssKb: number | null,
       resumeReady: boolean | null = null,
       counts: { done: number | null; total: number | null } = { done: null, total: null },
-      stampedPlatforms = 3,
+      resumableGames = 30,
     ): Promise<HTMLElement> {
       vi.mocked(backend.getSyncStats).mockResolvedValue({
         ...defaultStats(),
         roms: 42,
-        // A surviving stamp by default, so the paused banner describes the resume
+        // Surviving progress by default, so the paused banner describes the resume
         // situation it was written for. Pass 0 for the post-Force-Full-Sync state,
         // where the run is still paused but the button beside it is not a resume.
-        stamped_platforms: stampedPlatforms,
-        stamped_collections: 0,
+        resumable_games: resumableGames,
+        has_completion_stamp: false,
         last_attempt: lastAttemptStatus
           ? { finished_at: "2026-07-11T17:48:00", status: lastAttemptStatus as "paused" }
           : null,
@@ -1580,7 +1580,7 @@ describe("MainPage", () => {
         vi.mocked(backend.getSyncStats).mockResolvedValue({
           ...defaultStats(),
           roms: 42,
-          stamped_platforms: 3,
+          resumable_games: 30,
           last_attempt: { finished_at: "2026-07-11T17:48:00", status: "paused" },
         });
         // Before the restart: high RSS, resume would re-pause. After (poll tick):
@@ -3270,15 +3270,18 @@ describe("MainPage", () => {
   });
 
   describe("sync button label (resume vs fresh)", () => {
-    /** The stamp counts a resume situation needs: something on disk to continue
-     *  from. Without them the offer is off whatever the run history says (#1789). */
+    /** A resume situation: shortcuts on disk, and games the next run can pass
+     *  over. Recorded launch commands are the ordinary carrier — every stopped
+     *  run has committed chunks — so they, not a completion stamp, are the
+     *  default here. Without either kind the offer is off whatever the run
+     *  history says (#1789). */
     function resumeStats(overrides: Partial<SyncStats> = {}): SyncStats {
       return {
         ...defaultStats(),
         roms: 42,
         last_attempt: { finished_at: "2026-06-01T17:48:00", status: "interrupted" },
-        stamped_platforms: 3,
-        stamped_collections: 0,
+        resumable_games: 30,
+        has_completion_stamp: false,
         ...overrides,
       };
     }
@@ -3287,82 +3290,85 @@ describe("MainPage", () => {
       return Array.from(container.querySelectorAll('[data-testid="button-desc"]')).map((el) => el.textContent);
     }
 
-    // roms > 0 = shortcuts on disk, a surviving stamp = progress the next run
-    // will skip. Every non-completed, non-errored terminal status resumes:
-    // interrupted, cancelled, and the #1383 session-budget pause.
+    async function renderStats(stats: SyncStats): Promise<HTMLElement> {
+      vi.mocked(backend.getSyncStats).mockResolvedValue(stats);
+      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      await flushAsync();
+      return container;
+    }
+
+    // Every non-completed, non-errored terminal status resumes: interrupted,
+    // cancelled, and the #1383 session-budget pause.
     it.each(["interrupted", "cancelled", "paused"] as const)(
-      "reads 'Resume Sync' when the newest attempt was %s with bound shortcuts and a surviving stamp",
+      "reads 'Resume Sync' when the newest attempt was %s and progress survives",
       async (status) => {
-        vi.mocked(backend.getSyncStats).mockResolvedValue(
-          resumeStats({ last_attempt: { finished_at: "2026-06-01T17:48:00", status } }),
-        );
-        const { container } = render(<MainPage onNavigate={vi.fn()} />);
-        await flushAsync();
-        expect(buttonByExactText(container, "Resume Sync")).not.toBeNull();
-        expect(buttonByExactText(container, "Sync Library")).toBeNull();
+        const c = await renderStats(resumeStats({ last_attempt: { finished_at: "2026-06-01T17:48:00", status } }));
+        expect(buttonByExactText(c, "Resume Sync")).not.toBeNull();
+        expect(buttonByExactText(c, "Sync Library")).toBeNull();
       },
     );
 
-    it("reads 'Sync Library' when an incomplete attempt has NO surviving stamp (post-Force-Full-Sync)", async () => {
-      // The #1789 regression. Force Full Sync clears every completion stamp but
-      // deliberately preserves the run history (#1318), so the incomplete attempt
-      // and the bound shortcuts both survive while the progress they described is
-      // gone. Whichever button is pressed the next run is a full one, so offering
-      // to resume promises something that can no longer happen.
-      vi.mocked(backend.getSyncStats).mockResolvedValue(resumeStats({ stamped_platforms: 0, stamped_collections: 0 }));
-      const { container } = render(<MainPage onNavigate={vi.fn()} />);
-      await flushAsync();
-      expect(buttonByExactText(container, "Sync Library")).not.toBeNull();
-      expect(buttonByExactText(container, "Resume Sync")).toBeNull();
-      expect(buttonDescriptions(container).join(" ")).not.toContain("already synced in full");
+    it("reads 'Sync Library' once a force-clear left NEITHER kind of progress", async () => {
+      // The #1789 regression. Force Full Sync deletes the completion stamps and
+      // the recorded launch commands but not the shortcuts, and it deliberately
+      // preserves the run history (#1318) — so the incomplete attempt and the
+      // bound shortcuts both survive while everything the next run could skip is
+      // gone. Whichever button is pressed the next run is a full one.
+      const c = await renderStats(resumeStats({ resumable_games: 0, has_completion_stamp: false }));
+      expect(buttonByExactText(c, "Sync Library")).not.toBeNull();
+      expect(buttonByExactText(c, "Resume Sync")).toBeNull();
+      expect(buttonDescriptions(c).join(" ")).not.toContain("already synced");
     });
 
-    it("reads 'Resume Sync' on collection stamps alone (no platform ever stamped)", async () => {
-      // A library synced only through collections holds no platform stamp at all;
-      // a platforms-only rule would silently withdraw its resume offer.
-      vi.mocked(backend.getSyncStats).mockResolvedValue(resumeStats({ stamped_platforms: 0, stamped_collections: 2 }));
-      const { container } = render(<MainPage onNavigate={vi.fn()} />);
-      await flushAsync();
-      expect(buttonByExactText(container, "Resume Sync")).not.toBeNull();
-      expect(buttonDescriptions(container)).toContain(
-        "2 collections already synced in full — a resume continues with the rest.",
-      );
+    it("reads 'Resume Sync' on recorded games alone — a cancel inside the first platform", async () => {
+      // No unit reached its final chunk, so no stamp exists; the committed chunks
+      // still wrote shortcuts and recorded their launch commands, and the next run
+      // passes over every one of them. Keying the offer on stamps alone called
+      // this a fresh start, which it is not.
+      const c = await renderStats(resumeStats({ resumable_games: 12, has_completion_stamp: false }));
+      expect(buttonByExactText(c, "Resume Sync")).not.toBeNull();
+      expect(buttonDescriptions(c)).toContain("12 games already synced — a resume continues from there.");
     });
 
-    it("names both kinds of stamped unit under the button, each correctly pluralized", async () => {
-      vi.mocked(backend.getSyncStats).mockResolvedValue(resumeStats({ stamped_platforms: 1, stamped_collections: 4 }));
-      const { container } = render(<MainPage onNavigate={vi.fn()} />);
-      await flushAsync();
-      expect(buttonDescriptions(container)).toContain(
-        "1 platform · 4 collections already synced in full — a resume continues with the rest.",
-      );
+    it("reads 'Resume Sync' on a completion stamp alone, and says nothing under it", async () => {
+      // The mirror case: rows predating migration 015 carry no recorded command
+      // while their platform's stamp survives, so an upgraded install can hold
+      // stamps and zero recorded games — those platforms still skip wholesale.
+      // With no number to state, the line is omitted rather than reading "0 games".
+      const c = await renderStats(resumeStats({ resumable_games: 0, has_completion_stamp: true }));
+      expect(buttonByExactText(c, "Resume Sync")).not.toBeNull();
+      expect(buttonDescriptions(c).join(" ")).not.toContain("already synced");
+    });
+
+    it("counts the resume line in games, singular at one", async () => {
+      const c = await renderStats(resumeStats({ resumable_games: 1 }));
+      expect(buttonDescriptions(c)).toContain("1 game already synced — a resume continues from there.");
     });
 
     it("omits the line entirely when the button reads 'Sync Library'", async () => {
-      // No resume, nothing to describe — a stale count under a fresh-sync button
-      // would name progress the run is not going to skip.
-      const { container } = render(<MainPage onNavigate={vi.fn()} />);
-      await flushAsync();
-      expect(buttonByExactText(container, "Sync Library")).not.toBeNull();
-      expect(buttonDescriptions(container).join(" ")).not.toContain("already synced in full");
+      // No resume, nothing to describe — a count under a fresh-sync button would
+      // name progress the run is not going to skip.
+      const c = await renderStats(defaultStats());
+      expect(buttonByExactText(c, "Sync Library")).not.toBeNull();
+      expect(buttonDescriptions(c).join(" ")).not.toContain("already synced");
     });
 
     it("reads 'Sync Library' when an interrupted attempt left ZERO bound shortcuts (all removed — nothing to resume)", async () => {
-      // The regression: after an interrupted run the user removed every shortcut
-      // (DangerZone "remove all"), so roms is 0 — the next run is a full fresh
-      // import, and the label must not falsely promise a resume. The stamps are
-      // left standing so the zero shortcut count is what carries the assertion.
-      vi.mocked(backend.getSyncStats).mockResolvedValue(resumeStats({ roms: 0 }));
-      const { container } = render(<MainPage onNavigate={vi.fn()} />);
-      await flushAsync();
-      expect(buttonByExactText(container, "Sync Library")).not.toBeNull();
-      expect(buttonByExactText(container, "Resume Sync")).toBeNull();
+      // After an interrupted run the user removed every shortcut (DangerZone
+      // "remove all"), so roms is 0 and the next run is a full fresh import. Both
+      // kinds of progress are left standing in the fixture so the zero shortcut
+      // count is what carries the assertion — this is the rule `roms > 0` states
+      // in its own right, and what would still catch the wipe if the destructive
+      // flows ever stopped clearing a platform's stamp alongside the unbind.
+      const c = await renderStats(resumeStats({ roms: 0, resumable_games: 30, has_completion_stamp: true }));
+      expect(buttonByExactText(c, "Sync Library")).not.toBeNull();
+      expect(buttonByExactText(c, "Resume Sync")).toBeNull();
     });
 
     it("keeps 'Sync Library' when the newest attempt errored (resume isn't the model)", async () => {
       // An errored run often failed before applying anything (config error, etc.),
-      // so "resume" would mislead — the fresh label stays. Stamps and shortcuts
-      // are present, so only the status can be what withholds the offer.
+      // so "resume" would mislead — the fresh label stays. Shortcuts and both
+      // kinds of progress are present, so only the status can withhold the offer.
       vi.mocked(backend.getSyncStats).mockResolvedValue(
         resumeStats({ last_attempt: { finished_at: "2026-06-01T17:48:00", status: "errored" } }),
       );
@@ -3373,8 +3379,8 @@ describe("MainPage", () => {
     });
 
     it("keeps 'Sync Library' when there is no last attempt (clean state)", async () => {
-      // Stamps survive every completed run, so a fully-synced library carries
-      // plenty of them — the absent last_attempt is what has to withhold the offer.
+      // A fully-synced library carries recorded launch commands for every game, so
+      // the absent last_attempt is what has to withhold the offer.
       vi.mocked(backend.getSyncStats).mockResolvedValue(resumeStats({ last_attempt: null }));
       const { container } = render(<MainPage onNavigate={vi.fn()} />);
       await flushAsync();
@@ -3407,26 +3413,27 @@ describe("MainPage", () => {
       // Two things a force-clear does, deliberately opposite, and they are easy to
       // merge into one. The run HISTORY is preserved (#1318) so the Last-sync line
       // and this button both stay put — the button is idempotent, pressing it
-      // again just re-clears already-cleared stamps. The completion STAMPS are
-      // gone, and the resume offer reads those, so the label must NOT survive the
-      // clear: the next run is a full one either way, and continuing to offer a
-      // resume promises progress that has just been discarded (#1789).
+      // again just re-clears what is already cleared. The SHORTCUTS survive too.
+      // What goes is both kinds of skip authority, which is what the resume offer
+      // reads, so the label must NOT survive the clear: the next run is a full one
+      // either way, and continuing to offer a resume promises progress that has
+      // just been discarded (#1789).
       vi.mocked(backend.getSyncStats)
         .mockResolvedValueOnce({
           ...defaultStats(),
           roms: 42,
           last_sync: null,
           last_attempt: { finished_at: "2026-06-01T17:48:00", status: "interrupted" },
-          stamped_platforms: 3,
-          stamped_collections: 1,
+          resumable_games: 30,
+          has_completion_stamp: true,
         })
         .mockResolvedValue({
           ...defaultStats(),
           roms: 42,
           last_sync: null,
           last_attempt: { finished_at: "2026-06-01T17:48:00", status: "interrupted" },
-          stamped_platforms: 0,
-          stamped_collections: 0,
+          resumable_games: 0,
+          has_completion_stamp: false,
         });
       vi.mocked(backend.clearSyncCache).mockResolvedValue({ success: true, message: "Cleared" });
       const { container } = render(<MainPage onNavigate={vi.fn()} />);
@@ -3436,7 +3443,7 @@ describe("MainPage", () => {
       expect(buttonByExactText(container, "Force Full Sync")).not.toBeNull();
 
       // Press Force Full Sync → clearSyncCache succeeds → the stats refresh reads
-      // the preserved history with every stamp gone.
+      // the preserved history with both skip authorities gone.
       await act(async () => {
         fireEvent.click(buttonByExactText(container, "Force Full Sync")!);
         await Promise.resolve();
@@ -5482,8 +5489,8 @@ describe("MainPage", () => {
     /** Stats that let EVERY start control render, so an assertion that none of
      *  them is on screen is carried by four absences rather than one. Without a
      *  recorded attempt "Force Full Sync" is hidden anyway, and without an
-     *  incomplete one plus bound shortcuts plus a surviving completion stamp the
-     *  sync button reads "Sync Library" rather than "Resume Sync". */
+     *  incomplete one plus bound shortcuts plus surviving progress the sync button
+     *  reads "Sync Library" rather than "Resume Sync". */
     function statsWithEveryStartControl(): SyncStats {
       return {
         last_sync: null,
@@ -5492,8 +5499,7 @@ describe("MainPage", () => {
         roms: 12,
         total_shortcuts: 12,
         last_attempt: { finished_at: "2026-06-01T17:48:00", status: "cancelled" },
-        stamped_platforms: 1,
-        stamped_collections: 0,
+        resumable_games: 12,
       };
     }
 

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -1396,10 +1396,16 @@ describe("MainPage", () => {
       rssKb: number | null,
       resumeReady: boolean | null = null,
       counts: { done: number | null; total: number | null } = { done: null, total: null },
+      stampedPlatforms = 3,
     ): Promise<HTMLElement> {
       vi.mocked(backend.getSyncStats).mockResolvedValue({
         ...defaultStats(),
         roms: 42,
+        // A surviving stamp by default, so the paused banner describes the resume
+        // situation it was written for. Pass 0 for the post-Force-Full-Sync state,
+        // where the run is still paused but the button beside it is not a resume.
+        stamped_platforms: stampedPlatforms,
+        stamped_collections: 0,
         last_attempt: lastAttemptStatus
           ? { finished_at: "2026-07-11T17:48:00", status: lastAttemptStatus as "paused" }
           : null,
@@ -1433,6 +1439,18 @@ describe("MainPage", () => {
       expect(banner).not.toBeNull();
       expect(banner?.textContent).toContain("Resume Sync");
       expect(banner?.textContent).not.toContain("GB");
+    });
+
+    it("points the paused banner at the plain sync button once a force-clear left nothing to resume", async () => {
+      // The panel-level half of #1789: the banner is handed the button rather than
+      // deciding its name from the paused status, which survives the clear that the
+      // resume does not. Without the wiring the panel says "Sync Library" on the
+      // button and "Resume Sync" in the banner directly above it.
+      const c = await renderIdle("paused", 2_299_000, false, { done: 1200, total: 2001 }, 0);
+      const banner = c.querySelector('[data-testid="budget-paused-banner"]');
+      expect(banner?.textContent).toContain("Steam memory is full (2.3 GB). Restart Steam, then Sync Library.");
+      expect(banner?.textContent).not.toContain("Resume Sync");
+      expect(buttonByExactText(c, "Sync Library")).not.toBeNull();
     });
 
     it("shows the yellow high-heap banner after a completed run with a high live heap", async () => {
@@ -1562,6 +1580,7 @@ describe("MainPage", () => {
         vi.mocked(backend.getSyncStats).mockResolvedValue({
           ...defaultStats(),
           roms: 42,
+          stamped_platforms: 3,
           last_attempt: { finished_at: "2026-07-11T17:48:00", status: "paused" },
         });
         // Before the restart: high RSS, resume would re-pause. After (poll tick):

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -3355,11 +3355,12 @@ describe("MainPage", () => {
 
     it("reads 'Sync Library' when an interrupted attempt left ZERO bound shortcuts (all removed — nothing to resume)", async () => {
       // After an interrupted run the user removed every shortcut (DangerZone
-      // "remove all"), so roms is 0 and the next run is a full fresh import. Both
-      // kinds of progress are left standing in the fixture so the zero shortcut
-      // count is what carries the assertion — this is the rule `roms > 0` states
-      // in its own right, and what would still catch the wipe if the destructive
-      // flows ever stopped clearing a platform's stamp alongside the unbind.
+      // "remove all"), so roms is 0 and the next run is a full fresh import. A
+      // surviving stamp alongside zero shortcuts is a REAL state, not a contrived
+      // fixture: removal invalidates only the platform slugs its removed rows name,
+      // and prune deletes rows without touching platform stamps, so a platform
+      // RomM dropped keeps a stamp no remaining row can point the removal at.
+      // `roms > 0` is the only thing that catches it.
       const c = await renderStats(resumeStats({ roms: 0, resumable_games: 30, has_completion_stamp: true }));
       expect(buttonByExactText(c, "Sync Library")).not.toBeNull();
       expect(buttonByExactText(c, "Resume Sync")).toBeNull();

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -341,25 +341,19 @@ function formatSyncScope(s: SyncPreviewSummary): string {
 }
 
 /**
- * The line under "Resume Sync" — what a resume would SKIP, in the same
- * "N platforms · M collections" shape as the preview's scope line.
+ * The line under "Resume Sync" — how much of a resume there is, counted in the
+ * unit the user recognises: games whose shortcut the next run can pass over.
  *
- * It names what is already done rather than what is left, because only the done
- * side can be proved offline: the stamps are keyed by platform slug and the
- * enabled-platform setting by RomM platform id, with nothing persisted bridging
- * the two, so the remainder would take a server round-trip on every panel mount.
- * Hence no total and no "N of M" — a figure the panel cannot know must not be
- * implied. Collections carry their own completion stamps and are part of a sync's
- * enabled scope exactly as platforms are, so they are counted here for the same
- * reason they count towards the offer itself.
+ * It states what is already done, never what is left, and carries no total: the
+ * remainder needs the server's library, and this line renders on every panel
+ * mount. "already synced" is a claim about these games only — the clause that
+ * follows is what keeps it from reading as a claim that the library is complete.
+ *
+ * Omitted entirely when the count is zero, which a resume on a surviving
+ * completion stamp alone can be. Honest silence beats "0 games".
  */
-function formatResumeScope(stats: SyncStats): string {
-  const parts: string[] = [];
-  const platforms = stats.stamped_platforms ?? 0;
-  const collections = stats.stamped_collections ?? 0;
-  if (platforms > 0) parts.push(pluralize(platforms, "platform"));
-  if (collections > 0) parts.push(pluralize(collections, "collection"));
-  return `${parts.join(" · ")} already synced in full — a resume continues with the rest.`;
+function formatResumeScope(resumableGames: number): string {
+  return `${pluralize(resumableGames, "game")} already synced — a resume continues from there.`;
 }
 
 /**
@@ -1133,35 +1127,42 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   // started — both gate the Sync buttons off.
   const connectionUnavailable = connected === false || connected === "backend_failed";
 
-  // The stamp/chunk sync model makes every re-sync an effective resume: a
-  // cancelled or interrupted run's committed chunks survive on disk, so the next
-  // run's incremental skip picks up where it stopped. ``last_attempt`` is
-  // non-null exactly when the newest terminal run did NOT complete. "errored"
-  // stays "Sync Library": an errored run often fails before applying anything
-  // (e.g. a config error), so "resume" isn't the right mental model. A completed
-  // sync clears last_attempt on the stats refresh, flipping the label back.
+  // ``last_attempt`` is non-null exactly when the newest terminal run did NOT
+  // complete. "errored" stays "Sync Library": an errored run often fails before
+  // applying anything (e.g. a config error), so "resume" isn't the right mental
+  // model. A completed sync clears last_attempt on the stats refresh, flipping the
+  // label back.
   //
-  // But "resume" only holds while partial progress actually exists on disk. If
-  // the user removed all shortcuts after an incomplete run (e.g. DangerZone
-  // "remove all"), there are zero bound shortcuts and the next run is a full
-  // fresh import — nothing to resume — so the button must honestly read "Sync
-  // Library" again. ``stats.roms`` is the bound-shortcut count (registry-derived).
+  // An incomplete attempt alone is not enough, and the half that used to stand in
+  // for "progress survives" was measuring the wrong thing: it asked whether
+  // SHORTCUTS exist, and Force Full Sync does not delete shortcuts — it deletes
+  // the completion stamps and the recorded launch commands. So the offer survived
+  // a clear that had just discarded everything it offered to continue (#1789).
   //
-  // And the offer is derived from the surviving completion stamps, never from
-  // ``last_attempt`` alone: Force Full Sync clears every stamp while deliberately
-  // preserving the run history (#1318), so the history outlives the progress it
-  // would offer to continue and kept the button promising a resume that could no
-  // longer happen (#1789).
+  // What a resume actually rests on is skip authority, of which this plugin keeps
+  // two kinds and clears both together in that one place: a completion stamp
+  // (whole platform or collection skipped at fetch time) or a recorded launch
+  // command (one game skipped at apply time). Either is a real resume — a run
+  // cancelled inside its first platform has written shortcuts and recorded their
+  // commands without reaching a stamp, and the next run genuinely does less work.
   const incompleteAttempt =
     stats?.last_attempt?.status === "interrupted" ||
     stats?.last_attempt?.status === "cancelled" ||
     stats?.last_attempt?.status === "paused";
   // ``incompleteAttempt`` being true narrows ``stats`` non-null (it dereferenced
   // stats.last_attempt), and ``roms`` is a required number — no ``?.``/``??`` needed.
-  const stampedUnits = (stats?.stamped_platforms ?? 0) + (stats?.stamped_collections ?? 0);
-  const canResume = incompleteAttempt && stats.roms > 0 && stampedUnits > 0;
+  const resumableGames = stats?.resumable_games ?? 0;
+  const skipAuthoritySurvives = resumableGames > 0 || (stats?.has_completion_stamp ?? false);
+  // ``roms > 0`` is belt-and-braces TODAY — it is implied by both branches, since
+  // a recorded game is counted only while bound and the destructive flows delete a
+  // platform's stamp in the same write UoW as the unbind. It stays because it
+  // states a rule in its own right: a run that stopped before a single shortcut was
+  // written starts from the beginning and must read "Sync Library". Move the
+  // stamp-clearing out of that transaction and this is what still catches the
+  // wipe; delete it as redundant and nothing does.
+  const canResume = incompleteAttempt && stats.roms > 0 && skipAuthoritySurvives;
   const syncButtonLabel = canResume ? "Resume Sync" : "Sync Library";
-  const resumeScopeText = canResume ? formatResumeScope(stats) : null;
+  const resumeScopeText = canResume && resumableGames > 0 ? formatResumeScope(resumableGames) : null;
 
   if (versionError) {
     return <VersionErrorCard message={versionError} compact />;

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -1411,11 +1411,15 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     syncBody = (
       <>
         {/* Persistent session-budget banner (#1383): blue while the last run was
-            paused (restart Steam, then Resume Sync), or yellow when the live heap
-            is high after a completed run. Only in the idle state, so it clears the
-            moment a resume/new sync starts. */}
+            paused (restart Steam, then press the sync button), or yellow when the
+            live heap is high after a completed run. Only in the idle state, so it
+            clears the moment a resume/new sync starts. It is HANDED the sync
+            button rather than working the name out from the same inputs — the
+            banner named it from a paused ``last_attempt`` alone, which survives a
+            Force Full Sync that the resume itself does not (#1789). */}
         <SessionBudgetBanner
           lastAttemptStatus={stats?.last_attempt?.status}
+          syncButton={{ label: syncButtonLabel, resumes: canResume }}
           rssKb={budgetStatus?.rss_kb ?? null}
           resumeReady={budgetStatus?.resume_ready ?? null}
           restartDisabled={connectionUnavailable}

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -341,6 +341,28 @@ function formatSyncScope(s: SyncPreviewSummary): string {
 }
 
 /**
+ * The line under "Resume Sync" — what a resume would SKIP, in the same
+ * "N platforms · M collections" shape as the preview's scope line.
+ *
+ * It names what is already done rather than what is left, because only the done
+ * side can be proved offline: the stamps are keyed by platform slug and the
+ * enabled-platform setting by RomM platform id, with nothing persisted bridging
+ * the two, so the remainder would take a server round-trip on every panel mount.
+ * Hence no total and no "N of M" — a figure the panel cannot know must not be
+ * implied. Collections carry their own completion stamps and are part of a sync's
+ * enabled scope exactly as platforms are, so they are counted here for the same
+ * reason they count towards the offer itself.
+ */
+function formatResumeScope(stats: SyncStats): string {
+  const parts: string[] = [];
+  const platforms = stats.stamped_platforms ?? 0;
+  const collections = stats.stamped_collections ?? 0;
+  if (platforms > 0) parts.push(pluralize(platforms, "platform"));
+  if (collections > 0) parts.push(pluralize(collections, "collection"));
+  return `${parts.join(" · ")} already synced in full — a resume continues with the rest.`;
+}
+
+/**
  * The Library row's one-line summary — "N games · M platforms · K collections" —
  * each part correctly singular/plural, zero parts omitted. Games is always
  * present (the row renders only when ``roms > 0``).
@@ -1124,14 +1146,22 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   // "remove all"), there are zero bound shortcuts and the next run is a full
   // fresh import — nothing to resume — so the button must honestly read "Sync
   // Library" again. ``stats.roms`` is the bound-shortcut count (registry-derived).
+  //
+  // And the offer is derived from the surviving completion stamps, never from
+  // ``last_attempt`` alone: Force Full Sync clears every stamp while deliberately
+  // preserving the run history (#1318), so the history outlives the progress it
+  // would offer to continue and kept the button promising a resume that could no
+  // longer happen (#1789).
   const incompleteAttempt =
     stats?.last_attempt?.status === "interrupted" ||
     stats?.last_attempt?.status === "cancelled" ||
     stats?.last_attempt?.status === "paused";
   // ``incompleteAttempt`` being true narrows ``stats`` non-null (it dereferenced
   // stats.last_attempt), and ``roms`` is a required number — no ``?.``/``??`` needed.
-  const canResume = incompleteAttempt && stats.roms > 0;
+  const stampedUnits = (stats?.stamped_platforms ?? 0) + (stats?.stamped_collections ?? 0);
+  const canResume = incompleteAttempt && stats.roms > 0 && stampedUnits > 0;
   const syncButtonLabel = canResume ? "Resume Sync" : "Sync Library";
+  const resumeScopeText = canResume ? formatResumeScope(stats) : null;
 
   if (versionError) {
     return <VersionErrorCard message={versionError} compact />;
@@ -1400,6 +1430,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
               detach(handleSync());
             }}
             disabled={connectionUnavailable}
+            description={resumeScopeText ?? undefined}
           >
             {syncButtonLabel}
           </ButtonItem>

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -1153,13 +1153,18 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   // stats.last_attempt), and ``roms`` is a required number — no ``?.``/``??`` needed.
   const resumableGames = stats?.resumable_games ?? 0;
   const skipAuthoritySurvives = resumableGames > 0 || (stats?.has_completion_stamp ?? false);
-  // ``roms > 0`` is belt-and-braces TODAY — it is implied by both branches, since
-  // a recorded game is counted only while bound and the destructive flows delete a
-  // platform's stamp in the same write UoW as the unbind. It stays because it
-  // states a rule in its own right: a run that stopped before a single shortcut was
-  // written starts from the beginning and must read "Sync Library". Move the
-  // stamp-clearing out of that transaction and this is what still catches the
-  // wipe; delete it as redundant and nothing does.
+  // ``roms > 0`` is LOAD-BEARING, not a belt-and-braces restatement of the two
+  // branches. ``has_completion_stamp`` is a global "any stamp anywhere", while the
+  // removal path is surgical: it deletes only the platform slugs its removed rows
+  // name, and only the collection stamps whose member set intersects those rows. A
+  // stamp naming nothing the ``roms`` table still holds therefore outlives a
+  // remove-all. Prune is the reachable path — it deletes ``roms`` rows and never
+  // touches ``platform_sync_state`` (services/prune/registry.py ``delete_rows``),
+  // so a platform whose games RomM dropped keeps its stamp with no rows left to
+  // name it; the next remove-all cannot see that slug to invalidate it. Without
+  // this conjunct that state offers "Resume Sync" over zero shortcuts. It is also
+  // the rule in its own right: a run that stopped before a single shortcut was
+  // written starts from the beginning and must read "Sync Library".
   const canResume = incompleteAttempt && stats.roms > 0 && skipAuthoritySurvives;
   const syncButtonLabel = canResume ? "Resume Sync" : "Sync Library";
   const resumeScopeText = canResume && resumableGames > 0 ? formatResumeScope(resumableGames) : null;

--- a/src/components/SessionBudgetBanner.test.tsx
+++ b/src/components/SessionBudgetBanner.test.tsx
@@ -10,6 +10,14 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, fireEvent } from "@testing-library/react";
 import { toaster } from "@decky/api";
 import { SessionBudgetBanner, formatGb, formatSignedGb, memoryLevelColor, HIGH_HEAP_KB } from "./SessionBudgetBanner";
+import type { SyncButton } from "./SessionBudgetBanner";
+
+/** The two sync buttons the panel can be offering. The banner is told which one it
+ *  is pointing at; it may never work that out for itself, so every render below
+ *  states it. Tests not about the instruction line take the resume situation, which
+ *  is the one the paused banner was written for. */
+const RESUME_BUTTON: SyncButton = { label: "Resume Sync", resumes: true };
+const FRESH_BUTTON: SyncButton = { label: "Sync Library", resumes: false };
 
 function buttonByText(container: HTMLElement, text: string): HTMLButtonElement | null {
   return (Array.from(container.querySelectorAll("button")).find((b) => b.textContent === text) ??
@@ -48,7 +56,9 @@ describe("memoryLevelColor", () => {
 
 describe("SessionBudgetBanner — paused (blue)", () => {
   it("shows the blue paused banner with the live number when last run is paused", () => {
-    const { queryByTestId } = render(<SessionBudgetBanner lastAttemptStatus="paused" rssKb={2199000} />);
+    const { queryByTestId } = render(
+      <SessionBudgetBanner syncButton={RESUME_BUTTON} lastAttemptStatus="paused" rssKb={2199000} />,
+    );
     const banner = queryByTestId("budget-paused-banner");
     expect(banner).not.toBeNull();
     expect(banner!.textContent).toContain("Steam memory is full (2.2 GB). Restart Steam, then Resume Sync.");
@@ -63,7 +73,9 @@ describe("SessionBudgetBanner — paused (blue)", () => {
   });
 
   it("drops the number but keeps the guidance when rssKb is null", () => {
-    const { queryByTestId } = render(<SessionBudgetBanner lastAttemptStatus="paused" rssKb={null} />);
+    const { queryByTestId } = render(
+      <SessionBudgetBanner syncButton={RESUME_BUTTON} lastAttemptStatus="paused" rssKb={null} />,
+    );
     const banner = queryByTestId("budget-paused-banner");
     expect(banner).not.toBeNull();
     expect(banner!.textContent).toContain("Steam memory is full. Restart Steam, then Resume Sync.");
@@ -71,7 +83,9 @@ describe("SessionBudgetBanner — paused (blue)", () => {
   });
 
   it("takes precedence over the high-heap banner even at a high heap", () => {
-    const { queryByTestId } = render(<SessionBudgetBanner lastAttemptStatus="paused" rssKb={HIGH_HEAP_KB + 500000} />);
+    const { queryByTestId } = render(
+      <SessionBudgetBanner syncButton={RESUME_BUTTON} lastAttemptStatus="paused" rssKb={HIGH_HEAP_KB + 500000} />,
+    );
     expect(queryByTestId("budget-paused-banner")).not.toBeNull();
     expect(queryByTestId("budget-high-heap-banner")).toBeNull();
   });
@@ -80,7 +94,13 @@ describe("SessionBudgetBanner — paused (blue)", () => {
 describe("SessionBudgetBanner — run progress ('X of Y games done')", () => {
   it("reports how far the paused run got when both counts are known", () => {
     const { queryByTestId } = render(
-      <SessionBudgetBanner lastAttemptStatus="paused" rssKb={2300000} runDoneItems={1200} runTotalItems={2001} />,
+      <SessionBudgetBanner
+        syncButton={RESUME_BUTTON}
+        lastAttemptStatus="paused"
+        rssKb={2300000}
+        runDoneItems={1200}
+        runTotalItems={2001}
+      />,
     );
     expect(queryByTestId("budget-paused-banner")!.textContent).toContain(
       "Steam memory is full (2.3 GB). 1200 of 2001 games done. Restart Steam, then Resume Sync.",
@@ -90,6 +110,7 @@ describe("SessionBudgetBanner — run progress ('X of Y games done')", () => {
   it("reports progress on the resume-ready branch too", () => {
     const { queryByTestId } = render(
       <SessionBudgetBanner
+        syncButton={RESUME_BUTTON}
         lastAttemptStatus="paused"
         rssKb={440000}
         resumeReady={true}
@@ -104,7 +125,13 @@ describe("SessionBudgetBanner — run progress ('X of Y games done')", () => {
 
   it("omits the sentence entirely when the counts are unknown (a backend reload wiped them)", () => {
     const { queryByTestId } = render(
-      <SessionBudgetBanner lastAttemptStatus="paused" rssKb={2300000} runDoneItems={null} runTotalItems={null} />,
+      <SessionBudgetBanner
+        syncButton={RESUME_BUTTON}
+        lastAttemptStatus="paused"
+        rssKb={2300000}
+        runDoneItems={null}
+        runTotalItems={null}
+      />,
     );
     const text = queryByTestId("budget-paused-banner")!.textContent;
     expect(text).toContain("Steam memory is full (2.3 GB). Restart Steam, then Resume Sync.");
@@ -113,21 +140,39 @@ describe("SessionBudgetBanner — run progress ('X of Y games done')", () => {
 
   it("omits the sentence when only one of the two counts is known (never a placeholder)", () => {
     const { queryByTestId } = render(
-      <SessionBudgetBanner lastAttemptStatus="paused" rssKb={2300000} runDoneItems={1200} runTotalItems={null} />,
+      <SessionBudgetBanner
+        syncButton={RESUME_BUTTON}
+        lastAttemptStatus="paused"
+        rssKb={2300000}
+        runDoneItems={1200}
+        runTotalItems={null}
+      />,
     );
     expect(queryByTestId("budget-paused-banner")!.textContent).not.toContain("1200");
   });
 
   it("omits the sentence when the total is zero (never '0 of 0 games done')", () => {
     const { queryByTestId } = render(
-      <SessionBudgetBanner lastAttemptStatus="paused" rssKb={2300000} runDoneItems={0} runTotalItems={0} />,
+      <SessionBudgetBanner
+        syncButton={RESUME_BUTTON}
+        lastAttemptStatus="paused"
+        rssKb={2300000}
+        runDoneItems={0}
+        runTotalItems={0}
+      />,
     );
     expect(queryByTestId("budget-paused-banner")!.textContent).not.toContain("games done");
   });
 
   it("renders a zero done count against a real total (a run that paused before its first chunk)", () => {
     const { queryByTestId } = render(
-      <SessionBudgetBanner lastAttemptStatus="paused" rssKb={2300000} runDoneItems={0} runTotalItems={2001} />,
+      <SessionBudgetBanner
+        syncButton={RESUME_BUTTON}
+        lastAttemptStatus="paused"
+        rssKb={2300000}
+        runDoneItems={0}
+        runTotalItems={2001}
+      />,
     );
     expect(queryByTestId("budget-paused-banner")!.textContent).toContain("0 of 2001 games done.");
   });
@@ -140,7 +185,7 @@ describe("SessionBudgetBanner — paused, resume ready (#38)", () => {
 
   it("flips to 'memory is free' and hides the restart button when resumeReady is true", () => {
     const { queryByTestId, container } = render(
-      <SessionBudgetBanner lastAttemptStatus="paused" rssKb={500000} resumeReady={true} />,
+      <SessionBudgetBanner syncButton={RESUME_BUTTON} lastAttemptStatus="paused" rssKb={500000} resumeReady={true} />,
     );
     const banner = queryByTestId("budget-paused-banner");
     expect(banner).not.toBeNull();
@@ -152,7 +197,7 @@ describe("SessionBudgetBanner — paused, resume ready (#38)", () => {
 
   it("keeps the restart guidance + button when resumeReady is false (still high)", () => {
     const { queryByTestId, container } = render(
-      <SessionBudgetBanner lastAttemptStatus="paused" rssKb={2199000} resumeReady={false} />,
+      <SessionBudgetBanner syncButton={RESUME_BUTTON} lastAttemptStatus="paused" rssKb={2199000} resumeReady={false} />,
     );
     const banner = queryByTestId("budget-paused-banner");
     expect(banner!.textContent).toContain("Steam memory is full (2.2 GB). Restart Steam, then Resume Sync.");
@@ -162,16 +207,92 @@ describe("SessionBudgetBanner — paused, resume ready (#38)", () => {
 
   it("keeps the restart guidance + button when resumeReady is null (undecidable → conservative)", () => {
     const { queryByTestId, container } = render(
-      <SessionBudgetBanner lastAttemptStatus="paused" rssKb={2199000} resumeReady={null} />,
+      <SessionBudgetBanner syncButton={RESUME_BUTTON} lastAttemptStatus="paused" rssKb={2199000} resumeReady={null} />,
     );
     expect(queryByTestId("budget-paused-banner")!.textContent).toContain("Restart Steam, then Resume Sync.");
     expect(restartButton(container)).not.toBeNull();
   });
 });
 
+describe("SessionBudgetBanner — names the button it is told about (#1789)", () => {
+  // A paused run stays paused after a Force Full Sync — the clear takes the
+  // completion stamps, not the run's status — so this banner keeps rendering while
+  // the button beside it has dropped back to "Sync Library". Naming the button from
+  // the paused status alone therefore sent the user to press something that was no
+  // longer on screen.
+  /** The paused banner's body, scoped to this render — two banners in one test
+   *  would both sit under document.body and make a global query ambiguous. */
+  function pausedBody(syncButton: SyncButton, resumeReady?: boolean): string {
+    const { container } = render(
+      <SessionBudgetBanner
+        syncButton={syncButton}
+        lastAttemptStatus="paused"
+        rssKb={resumeReady === true ? 440000 : 2300000}
+        resumeReady={resumeReady ?? null}
+        runDoneItems={1200}
+        runTotalItems={2001}
+      />,
+    );
+    return container.querySelector('[data-testid="budget-paused-banner"]')!.textContent;
+  }
+
+  it("names the resume button on the restart branch while a resume is on offer", () => {
+    expect(pausedBody(RESUME_BUTTON)).toContain(
+      "Steam memory is full (2.3 GB). 1200 of 2001 games done. Restart Steam, then Resume Sync.",
+    );
+  });
+
+  it("names the resume button on the memory-freed branch while a resume is on offer", () => {
+    expect(pausedBody(RESUME_BUTTON, true)).toContain(
+      "Steam memory is free again (0.4 GB). 1200 of 2001 games done. Press Resume Sync to continue.",
+    );
+  });
+
+  it("names the plain sync button on the restart branch once nothing can be resumed", () => {
+    const text = pausedBody(FRESH_BUTTON);
+    expect(text).toContain("Steam memory is full (2.3 GB). Restart Steam, then Sync Library.");
+    expect(text).not.toContain("Resume Sync");
+  });
+
+  it("names the plain sync button on the memory-freed branch once nothing can be resumed", () => {
+    const text = pausedBody(FRESH_BUTTON, true);
+    expect(text).toContain("Steam memory is free again (0.4 GB). Press Sync Library to start over.");
+    expect(text).not.toContain("Resume Sync");
+  });
+
+  it("drops the progress sentence once nothing can be resumed", () => {
+    // "1200 of 2001 games done" promises the next run will not redo those 1200.
+    // With the stamps cleared it redoes all of them, so the sentence would be the
+    // same false head start the button label no longer offers.
+    const { queryByTestId } = render(
+      <SessionBudgetBanner
+        syncButton={FRESH_BUTTON}
+        lastAttemptStatus="paused"
+        rssKb={2300000}
+        runDoneItems={1200}
+        runTotalItems={2001}
+      />,
+    );
+    const text = queryByTestId("budget-paused-banner")!.textContent;
+    expect(text).not.toContain("games done");
+    expect(text).not.toContain("1200");
+  });
+
+  it("still offers the restart button when nothing can be resumed but memory is full", () => {
+    // The memory problem is real either way — a full re-sync needs the headroom
+    // just as a resume does — so the restart guidance must not go with the resume.
+    const { container } = render(
+      <SessionBudgetBanner syncButton={FRESH_BUTTON} lastAttemptStatus="paused" rssKb={2300000} />,
+    );
+    expect(buttonByText(container, "Restart Steam now")).not.toBeNull();
+  });
+});
+
 describe("SessionBudgetBanner — high heap (yellow)", () => {
   it("shows the yellow banner when the live heap is above the threshold after a non-paused run", () => {
-    const { queryByTestId } = render(<SessionBudgetBanner lastAttemptStatus="completed" rssKb={1900000} />);
+    const { queryByTestId } = render(
+      <SessionBudgetBanner syncButton={RESUME_BUTTON} lastAttemptStatus="completed" rssKb={1900000} />,
+    );
     const banner = queryByTestId("budget-high-heap-banner");
     expect(banner).not.toBeNull();
     expect(banner!.textContent).toContain(
@@ -182,13 +303,17 @@ describe("SessionBudgetBanner — high heap (yellow)", () => {
   });
 
   it("shows nothing when heap is at or below the threshold", () => {
-    const { queryByTestId } = render(<SessionBudgetBanner lastAttemptStatus="completed" rssKb={HIGH_HEAP_KB} />);
+    const { queryByTestId } = render(
+      <SessionBudgetBanner syncButton={RESUME_BUTTON} lastAttemptStatus="completed" rssKb={HIGH_HEAP_KB} />,
+    );
     expect(queryByTestId("budget-high-heap-banner")).toBeNull();
     expect(queryByTestId("budget-paused-banner")).toBeNull();
   });
 
   it("shows nothing when the reading is unavailable and the run was not paused", () => {
-    const { queryByTestId } = render(<SessionBudgetBanner lastAttemptStatus="cancelled" rssKb={null} />);
+    const { queryByTestId } = render(
+      <SessionBudgetBanner syncButton={RESUME_BUTTON} lastAttemptStatus="cancelled" rssKb={null} />,
+    );
     expect(queryByTestId("budget-high-heap-banner")).toBeNull();
     expect(queryByTestId("budget-paused-banner")).toBeNull();
   });
@@ -203,7 +328,9 @@ describe("SessionBudgetBanner — Restart Steam now button (#35)", () => {
   });
 
   it("renders the restart button on the paused banner and restarts Steam on click", () => {
-    const { container } = render(<SessionBudgetBanner lastAttemptStatus="paused" rssKb={2199000} />);
+    const { container } = render(
+      <SessionBudgetBanner syncButton={RESUME_BUTTON} lastAttemptStatus="paused" rssKb={2199000} />,
+    );
     const btn = buttonByText(container, "Restart Steam now");
     expect(btn).not.toBeNull();
     fireEvent.click(btn!);
@@ -211,7 +338,9 @@ describe("SessionBudgetBanner — Restart Steam now button (#35)", () => {
   });
 
   it("renders the restart button on the high-heap banner too", () => {
-    const { container } = render(<SessionBudgetBanner lastAttemptStatus="completed" rssKb={1900000} />);
+    const { container } = render(
+      <SessionBudgetBanner syncButton={RESUME_BUTTON} lastAttemptStatus="completed" rssKb={1900000} />,
+    );
     const btn = buttonByText(container, "Restart Steam now");
     expect(btn).not.toBeNull();
     fireEvent.click(btn!);
@@ -219,12 +348,16 @@ describe("SessionBudgetBanner — Restart Steam now button (#35)", () => {
   });
 
   it("disables the button when restartDisabled is true", () => {
-    const { container } = render(<SessionBudgetBanner lastAttemptStatus="paused" rssKb={2199000} restartDisabled />);
+    const { container } = render(
+      <SessionBudgetBanner syncButton={RESUME_BUTTON} lastAttemptStatus="paused" rssKb={2199000} restartDisabled />,
+    );
     expect(buttonByText(container, "Restart Steam now")!.disabled).toBe(true);
   });
 
   it("carries NO description on the enabled button (the banner body already says why)", () => {
-    const { queryByTestId } = render(<SessionBudgetBanner lastAttemptStatus="paused" rssKb={2199000} />);
+    const { queryByTestId } = render(
+      <SessionBudgetBanner syncButton={RESUME_BUTTON} lastAttemptStatus="paused" rssKb={2199000} />,
+    );
     // The ButtonItem mock renders a description into "button-desc" when one is
     // passed, so its absence is a real assertion, not a dropped prop.
     expect(queryByTestId("button-desc")).toBeNull();
@@ -232,7 +365,9 @@ describe("SessionBudgetBanner — Restart Steam now button (#35)", () => {
 
   it("disables the button while a game is running, and says why (the one kept description)", () => {
     vi.stubGlobal("SteamUIStore", { RunningApps: [{ appid: 123, display_name: "Game" }] });
-    const { container, queryByTestId } = render(<SessionBudgetBanner lastAttemptStatus="paused" rssKb={2199000} />);
+    const { container, queryByTestId } = render(
+      <SessionBudgetBanner syncButton={RESUME_BUTTON} lastAttemptStatus="paused" rssKb={2199000} />,
+    );
     expect(buttonByText(container, "Restart Steam now")!.disabled).toBe(true);
     expect(queryByTestId("button-desc")!.textContent).toBe(
       "Close your running game first — restarting Steam would close it.",
@@ -241,7 +376,9 @@ describe("SessionBudgetBanner — Restart Steam now button (#35)", () => {
 
   it("hard-guards the click so a game that started after render can't be killed", () => {
     // Rendered with no game → button enabled.
-    const { container } = render(<SessionBudgetBanner lastAttemptStatus="paused" rssKb={2199000} />);
+    const { container } = render(
+      <SessionBudgetBanner syncButton={RESUME_BUTTON} lastAttemptStatus="paused" rssKb={2199000} />,
+    );
     const btn = buttonByText(container, "Restart Steam now")!;
     expect(btn.disabled).toBe(false);
     // A game starts before the click lands — the click-time guard must win.
@@ -254,7 +391,9 @@ describe("SessionBudgetBanner — Restart Steam now button (#35)", () => {
   });
 
   it("shows no restart button when no banner is shown", () => {
-    const { container } = render(<SessionBudgetBanner lastAttemptStatus="completed" rssKb={440000} />);
+    const { container } = render(
+      <SessionBudgetBanner syncButton={RESUME_BUTTON} lastAttemptStatus="completed" rssKb={440000} />,
+    );
     expect(buttonByText(container, "Restart Steam now")).toBeNull();
   });
 });

--- a/src/components/SessionBudgetBanner.tsx
+++ b/src/components/SessionBudgetBanner.tsx
@@ -82,16 +82,42 @@ function bannerCard(accent: string, background: string, testId: string, title: s
   );
 }
 
+/**
+ * The panel's sync button as the rest of the panel is TOLD it, never as anything
+ * re-derives it. One value carries both halves because they are one fact: a
+ * consumer holding only the label would have to read the resume question back out
+ * of the text, and a consumer holding only the flag would have to spell the name a
+ * second time. That second spelling is exactly how the banner came to say "then
+ * Resume Sync" while the button said "Sync Library" (#1789) — it decided the name
+ * from ``last_attempt`` alone, which stopped implying a resume the moment Force
+ * Full Sync cleared the completion stamps.
+ */
+export interface SyncButton {
+  /** Exactly the text on the panel's sync button — quote it, never reconstruct it. */
+  label: string;
+  /** Whether pressing it continues an incomplete run or starts a full one. */
+  resumes: boolean;
+}
+
 interface SessionBudgetBannerProps {
   /** ``stats.last_attempt?.status`` — a ``"paused"`` last run shows the blue resume banner. */
   lastAttemptStatus?: string | undefined;
+  /**
+   * The sync button this banner points the user at. Required, and deliberately not
+   * defaulted: a banner that guessed would be free to guess wrong, which is the
+   * defect it exists to prevent. Pausedness and resumability are different facts —
+   * a paused run stays paused after a Force Full Sync, it just has nothing left to
+   * resume from — so this does not replace {@link lastAttemptStatus}.
+   */
+  syncButton: SyncButton;
   /** Live renderer RSS in KB from ``get_session_budget_status``; ``null`` when unreadable. */
   rssKb: number | null;
   /**
    * ``resume_ready`` from ``get_session_budget_status`` — ``true`` once the live
    * reading is low enough that resuming a paused run would proceed (e.g. after a
-   * Steam restart). Flips the paused banner to "memory is free, press Resume Sync"
-   * and hides the restart button. ``false``/``null`` keeps the restart guidance.
+   * Steam restart). Flips the paused banner from "restart Steam first" to "memory
+   * is free, press the sync button" and hides the restart button.
+   * ``false``/``null`` keeps the restart guidance.
    */
   resumeReady?: boolean | null | undefined;
   /**
@@ -113,9 +139,9 @@ interface SessionBudgetBannerProps {
 
 /**
  * Persistent QAM banner for the session-budget UX (#1383). Renders a BLUE/info
- * banner while the last run is ``paused`` (restart Steam, then Resume Sync), or a
- * YELLOW/warning banner when the live renderer heap is high after a completed
- * run. A paused run takes precedence (it is high-heap anyway). Returns nothing
+ * banner while the last run is ``paused`` — restart Steam, then press whatever the
+ * sync button currently says ({@link SyncButton}) — or a YELLOW/warning banner
+ * when the live renderer heap is high after a completed run. A paused run takes precedence (it is high-heap anyway). Returns nothing
  * when neither applies. When ``rssKb`` is ``null`` (measurement unavailable) the
  * live number is dropped but the guidance text stays. Both banners offer a
  * **Restart Steam now** button — a deterministic full client restart that resets
@@ -123,6 +149,7 @@ interface SessionBudgetBannerProps {
  */
 export const SessionBudgetBanner: FC<SessionBudgetBannerProps> = ({
   lastAttemptStatus,
+  syncButton,
   rssKb,
   resumeReady,
   restartDisabled,
@@ -143,13 +170,24 @@ export const SessionBudgetBanner: FC<SessionBudgetBannerProps> = ({
   // reload wipes them (in-memory, by design). Then, and whenever the total is
   // unknown or zero, the sentence is dropped entirely rather than rendered with
   // placeholders or zeros.
+  //
+  // It is also dropped when nothing can be resumed. "1200 of 2001 games done" is a
+  // statement about work the NEXT run will not repeat, and once the completion
+  // stamps are gone the next run repeats all of it — so after a Force Full Sync the
+  // sentence would claim exactly the false head start the button no longer offers.
   const progressSentence =
-    runDoneItems != null && runTotalItems != null && runTotalItems > 0
+    syncButton.resumes && runDoneItems != null && runTotalItems != null && runTotalItems > 0
       ? ` ${runDoneItems} of ${runTotalItems} games done.`
       : "";
+  // The instruction names the button by quoting what the panel put on it. Both
+  // branches must name SOMETHING pressable: the memory reading is the banner's
+  // subject, but the action is why the user is reading it.
+  const pressInstruction = syncButton.resumes
+    ? `Press ${syncButton.label} to continue.`
+    : `Press ${syncButton.label} to start over.`;
   const pausedBody = memoryFreedForResume
-    ? `Steam memory is free again${liveReadingSuffix}.${progressSentence} Press Resume Sync to continue.`
-    : `Steam memory is full${liveReadingSuffix}.${progressSentence} Restart Steam, then Resume Sync.`;
+    ? `Steam memory is free again${liveReadingSuffix}.${progressSentence} ${pressInstruction}`
+    : `Steam memory is full${liveReadingSuffix}.${progressSentence} Restart Steam, then ${syncButton.label}.`;
 
   const card = paused
     ? bannerCard("#3d9df6", "rgba(61, 157, 246, 0.15)", "budget-paused-banner", "Sync paused", pausedBody)

--- a/src/components/SessionBudgetBanner.tsx
+++ b/src/components/SessionBudgetBanner.tsx
@@ -141,8 +141,9 @@ interface SessionBudgetBannerProps {
  * Persistent QAM banner for the session-budget UX (#1383). Renders a BLUE/info
  * banner while the last run is ``paused`` — restart Steam, then press whatever the
  * sync button currently says ({@link SyncButton}) — or a YELLOW/warning banner
- * when the live renderer heap is high after a completed run. A paused run takes precedence (it is high-heap anyway). Returns nothing
- * when neither applies. When ``rssKb`` is ``null`` (measurement unavailable) the
+ * when the live renderer heap is high after a completed run. A paused run takes
+ * precedence (it is high-heap anyway). Returns nothing when neither applies.
+ * When ``rssKb`` is ``null`` (measurement unavailable) the
  * live number is dropped but the guidance text stays. Both banners offer a
  * **Restart Steam now** button — a deterministic full client restart that resets
  * the renderer's per-session heap budget — disabled while a game is running.

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -189,27 +189,31 @@ export interface SyncStats {
   roms: number;
   total_shortcuts: number;
   /**
-   * Platforms that currently carry a completion stamp — the units a resume would
-   * skip because their last apply ran to completion. This, not ``last_attempt``,
-   * is what makes a resume a resume: Force Full Sync clears every stamp while
-   * deliberately preserving the run history (#1318), so an offer derived from the
-   * history alone outlived the progress it offered to continue (#1789).
+   * Bound ROMs carrying a recorded launch command — the games the next run can
+   * pass over at apply time, and the number the resume line states.
    *
-   * It is a count of what is DONE, never of what is left: the enabled-platform
-   * set is keyed by RomM platform id and the stamps by slug, with no local bridge
-   * between them, so the remainder cannot be named without asking the server.
-   * Absent from an older backend, which reads as "no stamps" and so as no resume
-   * — the safe direction, since the label then understates rather than promises.
+   * Bound AND recorded, never recorded alone: an unbound row is classified NEW
+   * before its recorded value is read, so a recorded command with no shortcut is
+   * not skip authority. That is what makes this fall to zero after a
+   * remove-all, where the rows (and their recorded commands) deliberately
+   * survive.
+   *
+   * Absent from an older backend, which reads as no recorded games — the safe
+   * direction, since the offer then understates rather than promises.
    */
-  stamped_platforms?: number;
+  resumable_games?: number;
   /**
-   * Collections that currently carry a completion stamp. Counted alongside
-   * ``stamped_platforms`` by decision, not by accident: a collection is part of a
-   * sync's enabled scope exactly as a platform is and carries its own stamp, so a
-   * library synced only through collections holds no platform stamp at all and a
-   * platforms-only rule would silently withdraw its resume offer.
+   * Whether ANY platform or collection still carries a completion stamp — the
+   * other kind of durable progress, which makes the next run pass over a whole
+   * unit at fetch time.
+   *
+   * A separate fact rather than an optimisation of {@link resumable_games},
+   * because neither implies the other. A run cancelled inside its first platform
+   * unit has recorded games and no stamp; a row predating migration 015 carries a
+   * NULL recorded value while its platform's stamp survives, so an upgraded
+   * install can hold stamps and no recorded games. Both are genuine resumes.
    */
-  stamped_collections?: number;
+  has_completion_stamp?: boolean;
 }
 
 export interface RegistryPlatform {

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -188,6 +188,28 @@ export interface SyncStats {
   collections?: number;
   roms: number;
   total_shortcuts: number;
+  /**
+   * Platforms that currently carry a completion stamp — the units a resume would
+   * skip because their last apply ran to completion. This, not ``last_attempt``,
+   * is what makes a resume a resume: Force Full Sync clears every stamp while
+   * deliberately preserving the run history (#1318), so an offer derived from the
+   * history alone outlived the progress it offered to continue (#1789).
+   *
+   * It is a count of what is DONE, never of what is left: the enabled-platform
+   * set is keyed by RomM platform id and the stamps by slug, with no local bridge
+   * between them, so the remainder cannot be named without asking the server.
+   * Absent from an older backend, which reads as "no stamps" and so as no resume
+   * — the safe direction, since the label then understates rather than promises.
+   */
+  stamped_platforms?: number;
+  /**
+   * Collections that currently carry a completion stamp. Counted alongside
+   * ``stamped_platforms`` by decision, not by accident: a collection is part of a
+   * sync's enabled scope exactly as a platform is and carries its own stamp, so a
+   * library synced only through collections holds no platform stamp at all and a
+   * platforms-only rule would silently withdraw its resume offer.
+   */
+  stamped_collections?: number;
 }
 
 export interface RegistryPlatform {

--- a/tests/adapters/repositories/test_collection_sync_state.py
+++ b/tests/adapters/repositories/test_collection_sync_state.py
@@ -108,6 +108,34 @@ class TestIterAll:
         assert list(uow.collection_sync_state.iter_all()) == []
 
 
+class TestCount:
+    def test_count_is_zero_when_no_stamps(self, uow: SqliteUnitOfWork):
+        assert uow.collection_sync_state.count() == 0
+
+    def test_count_reports_one_per_stamped_collection(self, uow: SqliteUnitOfWork):
+        uow.collection_sync_state.save(_stamp("7", kind="standard"))
+        uow.collection_sync_state.save(_stamp("9", kind="smart"))
+
+        assert uow.collection_sync_state.count() == 2
+
+    def test_same_id_under_two_kinds_counts_twice(self, uow: SqliteUnitOfWork):
+        """Identity is the composite ``(collection_id, collection_kind)`` — two rows, two stamps."""
+        uow.collection_sync_state.save(_stamp("7", kind="standard"))
+        uow.collection_sync_state.save(_stamp("7", kind="smart"))
+
+        assert uow.collection_sync_state.count() == 2
+
+    def test_count_follows_delete_and_clear(self, uow: SqliteUnitOfWork):
+        uow.collection_sync_state.save(_stamp("7", kind="standard"))
+        uow.collection_sync_state.save(_stamp("9", kind="smart"))
+
+        uow.collection_sync_state.delete("7", "standard")
+        assert uow.collection_sync_state.count() == 1
+
+        uow.collection_sync_state.clear()
+        assert uow.collection_sync_state.count() == 0
+
+
 class TestClear:
     def test_clear_removes_every_stamp(self, uow: SqliteUnitOfWork):
         uow.collection_sync_state.save(_stamp("7", kind="standard"))

--- a/tests/adapters/repositories/test_collection_sync_state.py
+++ b/tests/adapters/repositories/test_collection_sync_state.py
@@ -108,32 +108,30 @@ class TestIterAll:
         assert list(uow.collection_sync_state.iter_all()) == []
 
 
-class TestCount:
-    def test_count_is_zero_when_no_stamps(self, uow: SqliteUnitOfWork):
-        assert uow.collection_sync_state.count() == 0
+class TestHasAny:
+    def test_false_when_no_stamps(self, uow: SqliteUnitOfWork):
+        assert uow.collection_sync_state.has_any() is False
 
-    def test_count_reports_one_per_stamped_collection(self, uow: SqliteUnitOfWork):
-        uow.collection_sync_state.save(_stamp("7", kind="standard"))
-        uow.collection_sync_state.save(_stamp("9", kind="smart"))
-
-        assert uow.collection_sync_state.count() == 2
-
-    def test_same_id_under_two_kinds_counts_twice(self, uow: SqliteUnitOfWork):
-        """Identity is the composite ``(collection_id, collection_kind)`` — two rows, two stamps."""
-        uow.collection_sync_state.save(_stamp("7", kind="standard"))
+    def test_true_once_any_collection_is_stamped(self, uow: SqliteUnitOfWork):
         uow.collection_sync_state.save(_stamp("7", kind="smart"))
 
-        assert uow.collection_sync_state.count() == 2
+        assert uow.collection_sync_state.has_any() is True
 
-    def test_count_follows_delete_and_clear(self, uow: SqliteUnitOfWork):
+    def test_follows_delete_down_to_the_last_stamp(self, uow: SqliteUnitOfWork):
         uow.collection_sync_state.save(_stamp("7", kind="standard"))
         uow.collection_sync_state.save(_stamp("9", kind="smart"))
 
         uow.collection_sync_state.delete("7", "standard")
-        assert uow.collection_sync_state.count() == 1
+        assert uow.collection_sync_state.has_any() is True
 
+        uow.collection_sync_state.delete("9", "smart")
+        assert uow.collection_sync_state.has_any() is False
+
+    def test_false_after_clear(self, uow: SqliteUnitOfWork):
+        uow.collection_sync_state.save(_stamp("7", kind="standard"))
         uow.collection_sync_state.clear()
-        assert uow.collection_sync_state.count() == 0
+
+        assert uow.collection_sync_state.has_any() is False
 
 
 class TestClear:

--- a/tests/adapters/repositories/test_platform_sync_state.py
+++ b/tests/adapters/repositories/test_platform_sync_state.py
@@ -68,6 +68,34 @@ class TestDelete:
         assert uow.platform_sync_state.get("nope") is None
 
 
+class TestCount:
+    def test_count_is_zero_when_no_stamps(self, uow: SqliteUnitOfWork):
+        assert uow.platform_sync_state.count() == 0
+
+    def test_count_reports_one_per_stamped_platform(self, uow: SqliteUnitOfWork):
+        uow.platform_sync_state.save(_stamp("n64"))
+        uow.platform_sync_state.save(_stamp("snes"))
+
+        assert uow.platform_sync_state.count() == 2
+
+    def test_re_stamping_the_same_slug_does_not_double_count(self, uow: SqliteUnitOfWork):
+        """The upsert replaces the row, so a platform re-synced twice is still one stamp."""
+        uow.platform_sync_state.save(_stamp("n64"))
+        uow.platform_sync_state.save(_stamp("n64"))
+
+        assert uow.platform_sync_state.count() == 1
+
+    def test_count_follows_delete_and_clear(self, uow: SqliteUnitOfWork):
+        uow.platform_sync_state.save(_stamp("n64"))
+        uow.platform_sync_state.save(_stamp("snes"))
+
+        uow.platform_sync_state.delete("n64")
+        assert uow.platform_sync_state.count() == 1
+
+        uow.platform_sync_state.clear()
+        assert uow.platform_sync_state.count() == 0
+
+
 class TestClear:
     def test_clear_removes_every_stamp(self, uow: SqliteUnitOfWork):
         uow.platform_sync_state.save(_stamp("n64"))

--- a/tests/adapters/repositories/test_platform_sync_state.py
+++ b/tests/adapters/repositories/test_platform_sync_state.py
@@ -68,32 +68,30 @@ class TestDelete:
         assert uow.platform_sync_state.get("nope") is None
 
 
-class TestCount:
-    def test_count_is_zero_when_no_stamps(self, uow: SqliteUnitOfWork):
-        assert uow.platform_sync_state.count() == 0
+class TestHasAny:
+    def test_false_when_no_stamps(self, uow: SqliteUnitOfWork):
+        assert uow.platform_sync_state.has_any() is False
 
-    def test_count_reports_one_per_stamped_platform(self, uow: SqliteUnitOfWork):
-        uow.platform_sync_state.save(_stamp("n64"))
-        uow.platform_sync_state.save(_stamp("snes"))
-
-        assert uow.platform_sync_state.count() == 2
-
-    def test_re_stamping_the_same_slug_does_not_double_count(self, uow: SqliteUnitOfWork):
-        """The upsert replaces the row, so a platform re-synced twice is still one stamp."""
-        uow.platform_sync_state.save(_stamp("n64"))
+    def test_true_once_any_platform_is_stamped(self, uow: SqliteUnitOfWork):
         uow.platform_sync_state.save(_stamp("n64"))
 
-        assert uow.platform_sync_state.count() == 1
+        assert uow.platform_sync_state.has_any() is True
 
-    def test_count_follows_delete_and_clear(self, uow: SqliteUnitOfWork):
+    def test_follows_delete_down_to_the_last_stamp(self, uow: SqliteUnitOfWork):
         uow.platform_sync_state.save(_stamp("n64"))
         uow.platform_sync_state.save(_stamp("snes"))
 
         uow.platform_sync_state.delete("n64")
-        assert uow.platform_sync_state.count() == 1
+        assert uow.platform_sync_state.has_any() is True
 
+        uow.platform_sync_state.delete("snes")
+        assert uow.platform_sync_state.has_any() is False
+
+    def test_false_after_clear(self, uow: SqliteUnitOfWork):
+        uow.platform_sync_state.save(_stamp("n64"))
         uow.platform_sync_state.clear()
-        assert uow.platform_sync_state.count() == 0
+
+        assert uow.platform_sync_state.has_any() is False
 
 
 class TestClear:

--- a/tests/contract/test_sync_read.py
+++ b/tests/contract/test_sync_read.py
@@ -155,16 +155,12 @@ async def test_clear_sync_cache_takes_both_skip_authorities(harness):
     the button keeps offering to continue a run whose progress has just been
     discarded (#1789).
     """
-    from domain.platform_sync_state import PlatformSyncState
-
     seed_rom(harness, 11, platform_slug="snes")
+    seed_platform_stamp(harness, "snes", rom_count=3)
     with harness.uow_factory() as uow:
         rom = uow.roms.get(11)
         rom.record_applied_launch_options("flatpak run app 'game.zip'")
         uow.roms.set_applied_launch_options(11, rom.applied_launch_options)
-        uow.platform_sync_state.save(
-            PlatformSyncState.stamp(platform_slug="snes", at="2025-06-01T17:10:00", rom_count=3)
-        )
 
     before = await harness.plugin.get_sync_stats()
     assert before["resumable_games"] == 1

--- a/tests/contract/test_sync_read.py
+++ b/tests/contract/test_sync_read.py
@@ -72,13 +72,14 @@ async def test_get_sync_stats_shape(harness):
         "collections",
         "roms",
         "total_shortcuts",
-        "stamped_platforms",
-        "stamped_collections",
+        "resumable_games",
+        "has_completion_stamp",
     }
     assert result["last_sync"] is None
     assert result["last_attempt"] is None
-    for key in ("platforms", "collections", "roms", "total_shortcuts", "stamped_platforms", "stamped_collections"):
+    for key in ("platforms", "collections", "roms", "total_shortcuts", "resumable_games"):
         assert isinstance(result[key], int)
+    assert result["has_completion_stamp"] is False
 
 
 async def test_get_sync_stats_surfaces_cancelled_attempt(harness):
@@ -144,41 +145,38 @@ async def test_clear_sync_cache_preserves_last_sync(harness):
     assert stats["last_attempt"] == {"finished_at": "2025-06-01T18:05:00", "status": "cancelled"}
 
 
-async def test_clear_sync_cache_zeroes_the_stamp_counts(harness):
-    """The counterpart to the history the clear preserves: the stamps it takes.
+async def test_clear_sync_cache_takes_both_skip_authorities(harness):
+    """The counterpart to the history the clear preserves: the skip authority it takes.
 
-    The panel's "Resume Sync" offer reads these two counts, so over the real
-    SQLite stack the clear has to move them from a genuine resume situation to
-    zero — otherwise the button keeps offering to continue a run whose progress
-    has just been discarded (#1789).
+    The panel's "Resume Sync" offer reads both kinds of durable progress — the
+    per-unit completion stamps and the per-ROM recorded launch commands — so over
+    the real SQLite stack the clear has to move both from a genuine resume
+    situation to nothing, while leaving the shortcuts themselves alone. Otherwise
+    the button keeps offering to continue a run whose progress has just been
+    discarded (#1789).
     """
-    from domain.collection_sync_state import CollectionSyncState
     from domain.platform_sync_state import PlatformSyncState
 
+    seed_rom(harness, 11, platform_slug="snes")
     with harness.uow_factory() as uow:
+        rom = uow.roms.get(11)
+        rom.record_applied_launch_options("flatpak run app 'game.zip'")
+        uow.roms.set_applied_launch_options(11, rom.applied_launch_options)
         uow.platform_sync_state.save(
             PlatformSyncState.stamp(platform_slug="snes", at="2025-06-01T17:10:00", rom_count=3)
         )
-        uow.collection_sync_state.save(
-            CollectionSyncState.stamp(
-                collection_id="7",
-                collection_kind="standard",
-                updated_at="2025-06-01T17:00:00",
-                completed_at="2025-06-01T17:10:00",
-                rom_count=1,
-                member_rom_ids=(11,),
-            )
-        )
 
     before = await harness.plugin.get_sync_stats()
-    assert before["stamped_platforms"] == 1
-    assert before["stamped_collections"] == 1
+    assert before["resumable_games"] == 1
+    assert before["has_completion_stamp"] is True
 
     await harness.plugin.clear_sync_cache()
 
     after = await harness.plugin.get_sync_stats()
-    assert after["stamped_platforms"] == 0
-    assert after["stamped_collections"] == 0
+    assert after["resumable_games"] == 0
+    assert after["has_completion_stamp"] is False
+    # The shortcut survives the clear — only what the next run could skip is gone.
+    assert after["roms"] == 1
 
 
 # ── get_platforms ────────────────────────────────────────────────────────

--- a/tests/contract/test_sync_read.py
+++ b/tests/contract/test_sync_read.py
@@ -65,10 +65,19 @@ async def test_sync_heartbeat_shape(harness):
 async def test_get_sync_stats_shape(harness):
     """Stats dict: every count key present and an int; last_sync + last_attempt None when never synced."""
     result = await harness.plugin.get_sync_stats()
-    assert set(result.keys()) == {"last_sync", "last_attempt", "platforms", "collections", "roms", "total_shortcuts"}
+    assert set(result.keys()) == {
+        "last_sync",
+        "last_attempt",
+        "platforms",
+        "collections",
+        "roms",
+        "total_shortcuts",
+        "stamped_platforms",
+        "stamped_collections",
+    }
     assert result["last_sync"] is None
     assert result["last_attempt"] is None
-    for key in ("platforms", "collections", "roms", "total_shortcuts"):
+    for key in ("platforms", "collections", "roms", "total_shortcuts", "stamped_platforms", "stamped_collections"):
         assert isinstance(result[key], int)
 
 
@@ -133,6 +142,43 @@ async def test_clear_sync_cache_preserves_last_sync(harness):
     stats = await harness.plugin.get_sync_stats()
     assert stats["last_sync"] == "2025-06-01T17:10:00"
     assert stats["last_attempt"] == {"finished_at": "2025-06-01T18:05:00", "status": "cancelled"}
+
+
+async def test_clear_sync_cache_zeroes_the_stamp_counts(harness):
+    """The counterpart to the history the clear preserves: the stamps it takes.
+
+    The panel's "Resume Sync" offer reads these two counts, so over the real
+    SQLite stack the clear has to move them from a genuine resume situation to
+    zero — otherwise the button keeps offering to continue a run whose progress
+    has just been discarded (#1789).
+    """
+    from domain.collection_sync_state import CollectionSyncState
+    from domain.platform_sync_state import PlatformSyncState
+
+    with harness.uow_factory() as uow:
+        uow.platform_sync_state.save(
+            PlatformSyncState.stamp(platform_slug="snes", at="2025-06-01T17:10:00", rom_count=3)
+        )
+        uow.collection_sync_state.save(
+            CollectionSyncState.stamp(
+                collection_id="7",
+                collection_kind="standard",
+                updated_at="2025-06-01T17:00:00",
+                completed_at="2025-06-01T17:10:00",
+                rom_count=1,
+                member_rom_ids=(11,),
+            )
+        )
+
+    before = await harness.plugin.get_sync_stats()
+    assert before["stamped_platforms"] == 1
+    assert before["stamped_collections"] == 1
+
+    await harness.plugin.clear_sync_cache()
+
+    after = await harness.plugin.get_sync_stats()
+    assert after["stamped_platforms"] == 0
+    assert after["stamped_collections"] == 0
 
 
 # ── get_platforms ────────────────────────────────────────────────────────

--- a/tests/fakes/fake_collection_sync_state_repository.py
+++ b/tests/fakes/fake_collection_sync_state_repository.py
@@ -31,6 +31,9 @@ class FakeCollectionSyncStateRepository:
     def iter_all(self) -> Iterator[CollectionSyncState]:
         return iter([copy.deepcopy(state) for state in self._stamps.values()])
 
+    def count(self) -> int:
+        return len(self._stamps)
+
     def clear(self) -> None:
         self._stamps = {}
 

--- a/tests/fakes/fake_collection_sync_state_repository.py
+++ b/tests/fakes/fake_collection_sync_state_repository.py
@@ -31,8 +31,8 @@ class FakeCollectionSyncStateRepository:
     def iter_all(self) -> Iterator[CollectionSyncState]:
         return iter([copy.deepcopy(state) for state in self._stamps.values()])
 
-    def count(self) -> int:
-        return len(self._stamps)
+    def has_any(self) -> bool:
+        return bool(self._stamps)
 
     def clear(self) -> None:
         self._stamps = {}

--- a/tests/fakes/fake_platform_sync_state_repository.py
+++ b/tests/fakes/fake_platform_sync_state_repository.py
@@ -26,6 +26,9 @@ class FakePlatformSyncStateRepository:
     def delete(self, platform_slug: str) -> None:
         self._stamps.pop(platform_slug, None)
 
+    def count(self) -> int:
+        return len(self._stamps)
+
     def clear(self) -> None:
         self._stamps = {}
 

--- a/tests/fakes/fake_platform_sync_state_repository.py
+++ b/tests/fakes/fake_platform_sync_state_repository.py
@@ -26,8 +26,8 @@ class FakePlatformSyncStateRepository:
     def delete(self, platform_slug: str) -> None:
         self._stamps.pop(platform_slug, None)
 
-    def count(self) -> int:
-        return len(self._stamps)
+    def has_any(self) -> bool:
+        return bool(self._stamps)
 
     def clear(self) -> None:
         self._stamps = {}

--- a/tests/fakes/test_fake_repositories.py
+++ b/tests/fakes/test_fake_repositories.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from domain.bios_file import BiosFile
+from domain.collection_sync_state import CollectionSyncState
 from domain.firmware_cache import FirmwareCacheEntry
 from domain.platform_sync_state import PlatformSyncState
 from domain.playtime import Playtime
@@ -22,6 +23,7 @@ from domain.rom_metadata import RomMetadata
 from domain.rom_save_sync_state import FileSyncState, RomSaveSyncState
 from domain.sync_run import SyncRun
 from fakes.fake_bios_file_repository import FakeBiosFileRepository
+from fakes.fake_collection_sync_state_repository import FakeCollectionSyncStateRepository
 from fakes.fake_firmware_cache_repository import FakeFirmwareCacheRepository
 from fakes.fake_kv_config_repository import FakeKvConfigRepository
 from fakes.fake_platform_sync_state_repository import FakePlatformSyncStateRepository
@@ -386,6 +388,38 @@ class TestFakePlatformSyncStateRepository:
         repo.delete("n64")
         assert repo.has_any() is False
         repo.save(PlatformSyncState.stamp(platform_slug="snes", at="2026-01-01T00:00:00+00:00", rom_count=200))
+        repo.clear()
+        assert repo.has_any() is False
+
+
+def _collection_stamp(collection_id: str, kind: str, *, members: tuple[int, ...] = (1,)) -> CollectionSyncState:
+    return CollectionSyncState.stamp(
+        collection_id=collection_id,
+        collection_kind=kind,
+        updated_at="2026-01-01T00:00:00+00:00",
+        completed_at="2026-01-01T00:05:00+00:00",
+        rom_count=len(members),
+        member_rom_ids=members,
+    )
+
+
+class TestFakeCollectionSyncStateRepository:
+    def test_has_any_tracks_the_stored_stamps_not_the_saves(self):
+        """The twin of the platform fake's probe — identity is ``(id, kind)``, so the
+        same id under two kinds is two stamps and the last delete empties it."""
+        repo = FakeCollectionSyncStateRepository()
+        assert repo.has_any() is False
+        repo.save(_collection_stamp("7", "standard"))
+        repo.save(_collection_stamp("7", "smart"))
+        assert repo.has_any() is True
+        repo.delete("7", "standard")
+        assert repo.has_any() is True
+        repo.delete("7", "smart")
+        assert repo.has_any() is False
+
+    def test_clear_empties_it(self):
+        repo = FakeCollectionSyncStateRepository()
+        repo.save(_collection_stamp("7", "standard"))
         repo.clear()
         assert repo.has_any() is False
 

--- a/tests/fakes/test_fake_repositories.py
+++ b/tests/fakes/test_fake_repositories.py
@@ -376,16 +376,18 @@ class TestFakePlatformSyncStateRepository:
         assert repo.get("snes") is not None
         repo.delete("nope")  # absent slug is a no-op
 
-    def test_count_matches_the_stamped_slugs_not_the_saves(self):
-        """Keyed by slug like the SQLite table, so a re-stamp replaces rather than adds."""
+    def test_has_any_tracks_the_stored_stamps_not_the_saves(self):
+        """Keyed by slug like the SQLite table, so deleting the last slug empties it."""
         repo = FakePlatformSyncStateRepository()
-        assert repo.count() == 0
+        assert repo.has_any() is False
         repo.save(PlatformSyncState.stamp(platform_slug="n64", at="2026-01-01T00:00:00+00:00", rom_count=100))
         repo.save(PlatformSyncState.stamp(platform_slug="n64", at="2026-02-01T00:00:00+00:00", rom_count=105))
+        assert repo.has_any() is True
+        repo.delete("n64")
+        assert repo.has_any() is False
         repo.save(PlatformSyncState.stamp(platform_slug="snes", at="2026-01-01T00:00:00+00:00", rom_count=200))
-        assert repo.count() == 2
         repo.clear()
-        assert repo.count() == 0
+        assert repo.has_any() is False
 
 
 class TestFakeKvConfigRepository:

--- a/tests/fakes/test_fake_repositories.py
+++ b/tests/fakes/test_fake_repositories.py
@@ -376,6 +376,17 @@ class TestFakePlatformSyncStateRepository:
         assert repo.get("snes") is not None
         repo.delete("nope")  # absent slug is a no-op
 
+    def test_count_matches_the_stamped_slugs_not_the_saves(self):
+        """Keyed by slug like the SQLite table, so a re-stamp replaces rather than adds."""
+        repo = FakePlatformSyncStateRepository()
+        assert repo.count() == 0
+        repo.save(PlatformSyncState.stamp(platform_slug="n64", at="2026-01-01T00:00:00+00:00", rom_count=100))
+        repo.save(PlatformSyncState.stamp(platform_slug="n64", at="2026-02-01T00:00:00+00:00", rom_count=105))
+        repo.save(PlatformSyncState.stamp(platform_slug="snes", at="2026-01-01T00:00:00+00:00", rom_count=200))
+        assert repo.count() == 2
+        repo.clear()
+        assert repo.count() == 0
+
 
 class TestFakeKvConfigRepository:
     def test_set_get_delete(self):

--- a/tests/scripts/test_check_read_only_module.py
+++ b/tests/scripts/test_check_read_only_module.py
@@ -47,6 +47,7 @@ _EXPECTED_READS = frozenset(
         "get_latest_completed",
         "get_latest_terminal",
         "get_running",
+        "has_any",
         "iter_all",
         "iter_by_group_key",
         "iter_by_platform",

--- a/tests/services/library/test_reporter.py
+++ b/tests/services/library/test_reporter.py
@@ -1361,6 +1361,114 @@ class TestClearSyncCache:
             assert uow.collection_sync_state.get("9", "smart") is None
 
 
+def _stamp_platform(uow, slug: str) -> None:
+    from domain.platform_sync_state import PlatformSyncState
+
+    with uow:
+        uow.platform_sync_state.save(
+            PlatformSyncState.stamp(platform_slug=slug, at="2025-01-01T00:00:00", rom_count=10)
+        )
+
+
+def _stamp_collection(uow, collection_id: str, kind: str = "standard") -> None:
+    from domain.collection_sync_state import CollectionSyncState
+
+    with uow:
+        uow.collection_sync_state.save(
+            CollectionSyncState.stamp(
+                collection_id=collection_id,
+                collection_kind=kind,
+                updated_at="2025-01-01T00:00:00",
+                completed_at="2025-01-01T00:05:00",
+                rom_count=1,
+                member_rom_ids=(1,),
+            )
+        )
+
+
+class TestGetSyncStatsStampCounts:
+    """``stamped_platforms`` / ``stamped_collections`` — the surviving completion
+    stamps the panel derives its "Resume Sync" offer from (#1789).
+
+    The run history cannot carry that offer: Force Full Sync clears every stamp
+    while deliberately preserving the history (#1318), so a history-derived offer
+    outlives the progress it promises to continue."""
+
+    @pytest.mark.asyncio
+    async def test_reports_zero_on_a_pristine_install(self, plugin):
+        stats = await plugin.get_sync_stats()
+        assert stats["stamped_platforms"] == 0
+        assert stats["stamped_collections"] == 0
+
+    @pytest.mark.asyncio
+    async def test_counts_each_kind_of_stamp_separately(self, plugin):
+        uow = plugin._uow
+        _stamp_platform(uow, "n64")
+        _stamp_platform(uow, "snes")
+        _stamp_collection(uow, "7")
+
+        stats = await plugin.get_sync_stats()
+        assert stats["stamped_platforms"] == 2
+        assert stats["stamped_collections"] == 1
+
+    @pytest.mark.asyncio
+    async def test_counts_collections_of_every_stampable_kind(self, plugin):
+        """A standard and a smart collection are both stampable and both count.
+
+        Collections carry their own completion stamps and are part of a sync's
+        enabled scope exactly as platforms are, so a library synced only through
+        collections still has something to resume from.
+        """
+        uow = plugin._uow
+        _stamp_collection(uow, "7", "standard")
+        _stamp_collection(uow, "9", "smart")
+
+        stats = await plugin.get_sync_stats()
+        assert stats["stamped_platforms"] == 0
+        assert stats["stamped_collections"] == 2
+
+    @pytest.mark.asyncio
+    async def test_a_platform_whose_stamp_was_dropped_stops_counting(self, plugin):
+        """The stamps are counted live, not cached — an apply-start clear shows up at once."""
+        uow = plugin._uow
+        _stamp_platform(uow, "n64")
+        _stamp_platform(uow, "snes")
+        with uow:
+            uow.platform_sync_state.delete("n64")
+
+        stats = await plugin.get_sync_stats()
+        assert stats["stamped_platforms"] == 1
+
+    @pytest.mark.asyncio
+    async def test_force_full_sync_zeroes_both_counts_while_the_attempt_survives(self, plugin):
+        """The #1789 case end to end: the clear takes the stamps and leaves the history.
+
+        Before the clear the panel holds an incomplete attempt AND surviving
+        stamps — a genuine resume. Afterwards the attempt is still there (it feeds
+        the "Last sync" display, #1318) but both counts are zero, which is what
+        drops the button back to "Sync Library".
+        """
+        from domain.sync_run import SyncRun
+
+        uow = plugin._uow
+        interrupted = SyncRun.start(id="run-i", at="2025-01-01T00:00:00", platforms_planned=1, roms_planned=1)
+        interrupted.mark_interrupted("2025-01-01T00:05:00", reason="external death")
+        with uow:
+            uow.sync_runs.save(interrupted)
+        _stamp_platform(uow, "n64")
+        _stamp_collection(uow, "7")
+
+        before = await plugin.get_sync_stats()
+        assert (before["stamped_platforms"], before["stamped_collections"]) == (1, 1)
+
+        plugin._sync_service.clear_sync_cache()
+
+        after = await plugin.get_sync_stats()
+        assert after["stamped_platforms"] == 0
+        assert after["stamped_collections"] == 0
+        assert after["last_attempt"] == {"finished_at": "2025-01-01T00:05:00", "status": "interrupted"}
+
+
 class TestFinalizePerUnitRun:
     """SyncReporter.finalize_per_unit_run (stale unbind + sync_collections) and the
     separate emit_sync_complete (terminal sync_complete + progress frame, emitted

--- a/tests/services/library/test_reporter.py
+++ b/tests/services/library/test_reporter.py
@@ -1451,9 +1451,9 @@ class TestGetSyncStatsResumeInputs:
 
         ``Rom.unbind_shortcut`` clears only ``shortcut_app_id`` (ADR-0007), so the
         recorded command survives a DangerZone remove-all. It is not skip authority
-        there: ``classify_sync_roms`` sends an unbound row down the NEW branch
-        before it reads the recorded value, because the next run has to mint the
-        shortcut regardless. A count over every row would keep offering to resume
+        there: ``classify_roms`` (``domain/sync_diff.py``) sends an unbound row down
+        the NEW branch before it reads the recorded value, because the next run has
+        to mint the shortcut regardless. A count over every row would keep offering to resume
         shortcuts that no longer exist.
         """
         uow = plugin._uow

--- a/tests/services/library/test_reporter.py
+++ b/tests/services/library/test_reporter.py
@@ -1386,67 +1386,149 @@ def _stamp_collection(uow, collection_id: str, kind: str = "standard") -> None:
         )
 
 
-class TestGetSyncStatsStampCounts:
-    """``stamped_platforms`` / ``stamped_collections`` — the surviving completion
-    stamps the panel derives its "Resume Sync" offer from (#1789).
+def _record_launch_options(uow, rom_id: int, launch_options: str = "flatpak run app 'game.zip'") -> None:
+    """Record the launch command a sync ack-commit would have written for this ROM."""
+    with uow:
+        rom = uow.roms.get(rom_id)
+        rom.record_applied_launch_options(launch_options)
+        uow.roms.set_applied_launch_options(rom_id, rom.applied_launch_options)
 
-    The run history cannot carry that offer: Force Full Sync clears every stamp
-    while deliberately preserving the history (#1318), so a history-derived offer
-    outlives the progress it promises to continue."""
+
+class TestGetSyncStatsResumeInputs:
+    """``resumable_games`` / ``has_completion_stamp`` — the two kinds of durable
+    progress the panel's "Resume Sync" offer reads (#1789).
+
+    A completion stamp makes the next run pass over a whole platform or collection
+    at fetch time; a recorded launch command makes it pass over one game at apply
+    time. Both survive a stopped run and both are cleared together by Force Full
+    Sync — which is why the run history, deliberately preserved by that clear
+    (#1318), cannot carry the offer."""
 
     @pytest.mark.asyncio
-    async def test_reports_zero_on_a_pristine_install(self, plugin):
+    async def test_pristine_install_has_neither(self, plugin):
         stats = await plugin.get_sync_stats()
-        assert stats["stamped_platforms"] == 0
-        assert stats["stamped_collections"] == 0
+        assert stats["resumable_games"] == 0
+        assert stats["has_completion_stamp"] is False
 
     @pytest.mark.asyncio
-    async def test_counts_each_kind_of_stamp_separately(self, plugin):
+    async def test_counts_bound_roms_carrying_a_recorded_launch_command(self, plugin):
         uow = plugin._uow
-        _stamp_platform(uow, "n64")
-        _stamp_platform(uow, "snes")
-        _stamp_collection(uow, "7")
+        _seed_rom(uow, 10, app_id=1001, platform_slug="n64")
+        _seed_rom(uow, 20, app_id=1002, platform_slug="n64")
+        _record_launch_options(uow, 10)
+        _record_launch_options(uow, 20)
 
         stats = await plugin.get_sync_stats()
-        assert stats["stamped_platforms"] == 2
-        assert stats["stamped_collections"] == 1
+        assert stats["resumable_games"] == 2
 
     @pytest.mark.asyncio
-    async def test_counts_collections_of_every_stampable_kind(self, plugin):
-        """A standard and a smart collection are both stampable and both count.
+    async def test_a_bound_rom_with_no_recorded_command_is_not_resumable(self, plugin):
+        """A NULL recorded value never matches a target, so that row is always re-applied."""
+        uow = plugin._uow
+        _seed_rom(uow, 10, app_id=1001, platform_slug="n64")
 
-        Collections carry their own completion stamps and are part of a sync's
-        enabled scope exactly as platforms are, so a library synced only through
-        collections still has something to resume from.
+        stats = await plugin.get_sync_stats()
+        assert stats["roms"] == 1
+        assert stats["resumable_games"] == 0
+
+    @pytest.mark.asyncio
+    async def test_the_uninstalled_placeholder_still_counts(self, plugin):
+        """An empty string is a recorded value (the uninstall placeholder, #1146), not a missing one.
+
+        The shortcut it describes carries an empty launch command and is correct as
+        it stands, so the next run skips it exactly as it skips a full command.
         """
         uow = plugin._uow
-        _stamp_collection(uow, "7", "standard")
-        _stamp_collection(uow, "9", "smart")
+        _seed_rom(uow, 10, app_id=1001, platform_slug="n64")
+        _record_launch_options(uow, 10, "")
 
         stats = await plugin.get_sync_stats()
-        assert stats["stamped_platforms"] == 0
-        assert stats["stamped_collections"] == 2
+        assert stats["resumable_games"] == 1
 
     @pytest.mark.asyncio
-    async def test_a_platform_whose_stamp_was_dropped_stops_counting(self, plugin):
-        """The stamps are counted live, not cached — an apply-start clear shows up at once."""
+    async def test_an_unbound_rom_is_not_resumable_however_it_was_recorded(self, plugin):
+        """Removing every shortcut must drop the offer, and unbinding KEEPS the row.
+
+        ``Rom.unbind_shortcut`` clears only ``shortcut_app_id`` (ADR-0007), so the
+        recorded command survives a DangerZone remove-all. It is not skip authority
+        there: ``classify_sync_roms`` sends an unbound row down the NEW branch
+        before it reads the recorded value, because the next run has to mint the
+        shortcut regardless. A count over every row would keep offering to resume
+        shortcuts that no longer exist.
+        """
+        uow = plugin._uow
+        _seed_rom(uow, 10, app_id=1001, platform_slug="n64")
+        _record_launch_options(uow, 10)
+        assert (await plugin.get_sync_stats())["resumable_games"] == 1
+
+        await plugin.report_removal_results([10], None)
+
+        stats = await plugin.get_sync_stats()
+        assert stats["roms"] == 0
+        assert stats["resumable_games"] == 0
+        with uow:
+            assert uow.roms.get(10).applied_launch_options is not None
+
+    @pytest.mark.asyncio
+    async def test_a_cancel_inside_the_first_platform_is_still_a_resume(self, plugin):
+        """The case the stamp-only rule got wrong.
+
+        A run cancelled before any unit reached its final chunk leaves no stamp,
+        but its committed chunks wrote shortcuts and recorded their launch
+        commands. The next run genuinely does less work, so this is a resume.
+        """
+        uow = plugin._uow
+        _seed_rom(uow, 10, app_id=1001, platform_slug="n64")
+        _record_launch_options(uow, 10)
+
+        stats = await plugin.get_sync_stats()
+        assert stats["resumable_games"] == 1
+        assert stats["has_completion_stamp"] is False
+
+    @pytest.mark.asyncio
+    async def test_a_platform_stamp_alone_is_still_a_resume(self, plugin):
+        """The mirror case: stamps with no recorded game.
+
+        A row predating migration 015 carries a NULL recorded value while its
+        platform's stamp survives, so an upgraded install can hold stamps and no
+        recorded games — and those platforms still skip wholesale at fetch time.
+        """
+        uow = plugin._uow
+        _seed_rom(uow, 10, app_id=1001, platform_slug="n64")
+        _stamp_platform(uow, "n64")
+
+        stats = await plugin.get_sync_stats()
+        assert stats["resumable_games"] == 0
+        assert stats["has_completion_stamp"] is True
+
+    @pytest.mark.asyncio
+    async def test_a_collection_stamp_alone_answers_the_same_way(self, plugin):
+        """A library synced only through collections holds no platform stamp at all."""
+        uow = plugin._uow
+        _stamp_collection(uow, "7", "smart")
+
+        stats = await plugin.get_sync_stats()
+        assert stats["has_completion_stamp"] is True
+
+    @pytest.mark.asyncio
+    async def test_the_stamp_flag_follows_a_dropped_stamp(self, plugin):
+        """Read live, not cached — an apply-start clear shows up at once."""
         uow = plugin._uow
         _stamp_platform(uow, "n64")
-        _stamp_platform(uow, "snes")
+        assert (await plugin.get_sync_stats())["has_completion_stamp"] is True
         with uow:
             uow.platform_sync_state.delete("n64")
 
-        stats = await plugin.get_sync_stats()
-        assert stats["stamped_platforms"] == 1
+        assert (await plugin.get_sync_stats())["has_completion_stamp"] is False
 
     @pytest.mark.asyncio
-    async def test_force_full_sync_zeroes_both_counts_while_the_attempt_survives(self, plugin):
-        """The #1789 case end to end: the clear takes the stamps and leaves the history.
+    async def test_force_full_sync_takes_both_while_the_attempt_survives(self, plugin):
+        """The #1789 case end to end: the clear takes both skip authorities, not the history.
 
-        Before the clear the panel holds an incomplete attempt AND surviving
-        stamps — a genuine resume. Afterwards the attempt is still there (it feeds
-        the "Last sync" display, #1318) but both counts are zero, which is what
-        drops the button back to "Sync Library".
+        Before the clear the panel holds an incomplete attempt, recorded games AND
+        a stamp — a genuine resume. Afterwards the attempt is still there (it feeds
+        the "Last sync" display, #1318) while both authorities are gone, which is
+        what drops the button back to "Sync Library".
         """
         from domain.sync_run import SyncRun
 
@@ -1455,17 +1537,22 @@ class TestGetSyncStatsStampCounts:
         interrupted.mark_interrupted("2025-01-01T00:05:00", reason="external death")
         with uow:
             uow.sync_runs.save(interrupted)
+        _seed_rom(uow, 10, app_id=1001, platform_slug="n64")
+        _record_launch_options(uow, 10)
         _stamp_platform(uow, "n64")
         _stamp_collection(uow, "7")
 
         before = await plugin.get_sync_stats()
-        assert (before["stamped_platforms"], before["stamped_collections"]) == (1, 1)
+        assert before["resumable_games"] == 1
+        assert before["has_completion_stamp"] is True
 
         plugin._sync_service.clear_sync_cache()
 
         after = await plugin.get_sync_stats()
-        assert after["stamped_platforms"] == 0
-        assert after["stamped_collections"] == 0
+        assert after["resumable_games"] == 0
+        assert after["has_completion_stamp"] is False
+        # The shortcuts themselves are untouched — only the skip authority went.
+        assert after["roms"] == 1
         assert after["last_attempt"] == {"finished_at": "2025-01-01T00:05:00", "status": "interrupted"}
 
 


### PR DESCRIPTION
The main page's sync button read **Resume Sync** whenever the newest attempt ended cancelled, interrupted or paused and shortcuts existed. Force Full Sync deliberately keeps the run history — it feeds the "Last sync" display, and deleting it once blanked that to "Never" — so the offer outlived the progress it referred to and promised something no button could do: after a force-clear the next run redoes everything either way.

The offer now asks the question it always meant to ask: **is anything left that the next run could skip?**

Two different things answer it, and both are needed. A per-unit completion stamp makes the next run skip a whole platform or collection without fetching it. A recorded launch command makes it skip an individual game at apply time. A run cancelled inside its very first platform has the second without the first — it committed chunks, those shortcuts exist and are correct — and that is a resume in every sense that matters to the user. Keying the offer on stamps alone would have quietly narrowed the feature to runs that finished at least one whole unit.

A recorded command counts only on a **bound** row. The classifier takes an unbound row down the "new" branch before it ever reads the recorded value, so a command recorded against a shortcut that no longer exists is not skip authority — which is also what makes removing every shortcut fall back correctly, by construction rather than by a special case.

The stamp is not a shorthand for the game count either: an installation upgraded from before the launch-command migration can hold a stamp with no recorded games at all, and that platform still skips at fetch time.

The third condition — that bound shortcuts exist — is kept, and it is load-bearing rather than a precaution. The removal paths invalidate only the stamps they can reach: the surgical removal deletes the stamps of the slugs it touched, and the removed-games cleanup deletes rows without touching platform stamps at all. So a platform whose games RomM dropped can keep a stamp that no surviving row points at, and without this condition the panel would offer a resume over an empty library.

Below the button, when there is something to resume, a line now says what it covers: **"N games already synced — a resume continues from there."** It states what would be skipped rather than what remains, because the remainder would need the server's platform list on every panel mount — the enabled platforms are keyed by server id and the stamps by slug, with nothing local bridging them. The line is omitted rather than reading "0 games" in the upgraded-install case where a stamp stands alone.

The paused-memory banner no longer works out the button's name for itself. It is told which button it is pointing at, because deriving the same name in two places is how the two came to disagree. When there is nothing to resume it names the button that actually exists, and it drops its "N of M games done" sentence — that sentence promised a head start the force-clear had removed.

Closes #1789.
