### PR TITLE
fix(sync): hold no database transaction across filesystem work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,26 +248,36 @@ Format: **invariant** — tier — enforced by.
   one shared matcher; the file-I/O rule below is a different hazard with its own seam list and its own failure message,
   and neither entry is evidence about the other)
 - **No file-I/O seam is called while a UoW is open — a Unit of Work wraps database reads and writes, never file or
-  server I/O (CONTEXT.md → Unit of Work, ADR-0006). The four today: `DiscResolver.enumerate_discs` and
-  `.resolve_for_install` (a recursive walk of the ROM's install directory), `CoreInfoProvider.get_emulator_options`
-  (ES-DE config discovery and parse plus a per-option installed-emulator probe), and `SystemResolver` (opens and parses
-  `config.json` — it lives on the RomM HTTP adapter and does no network work, which the name makes easy to misread)** —
-  check — `scripts/check_uow_seam_nesting.py`, second seam family (`IO_SEAM_METHODS`). **"It's only a read" is the
+  server I/O (CONTEXT.md → Unit of Work, ADR-0006)** — check — `scripts/check_uow_seam_nesting.py`, second seam family
+  (`IO_SEAM_METHODS`). The list is **the seams this checker can see and has been told about, never an inventory of the
+  I/O seams that exist**: `DiscResolver.enumerate_discs` / `.resolve_for_install` (a recursive walk of the ROM's install
+  directory), all four `CoreInfoProvider` reads — `get_active_core`, `get_default_emulator`, `get_emulator_options`,
+  `resolve_sandbox_launcher` (each re-probes the flatpak roots for `es_systems.xml` and re-stats it before it may use
+  the parse cache; the options read also globs each option's emulator install, and the launcher read parses
+  `es_find_rules.xml`) — and `SystemResolver` (parses the plugin's **own** bundled `config.json`, not RetroDECK's
+  `retrodeck.json`, and does no network work despite living on the RomM HTTP adapter). Two more families of real I/O
+  seam are left out and the reasons are in the script's docstring; neither is an exemption. **"It's only a read" is the
   reasoning this rule exists to refuse**: `SqliteUnitOfWork.__enter__` issues `BEGIN IMMEDIATE`, so even a read-only UoW
-  takes the database's global write lock, and every other connection gives up after `busy_timeout=5000`. The cost is not
-  this operation's correctness but every other writer's, for as long as the walk takes — and `FakeUnitOfWork` shares no
-  connection, so no unit test notices. Six call sites had drifted across the rule before anything looked (#1779), for
-  the reason the check exists: nothing at a call site reveals that an injected seam touches the disk. What it sees is
-  the deadlock rule's matcher unchanged — an **attribute** call naming one of the four seams, lexically inside a
+  takes the write lock. The database is in WAL, so readers are unaffected — but every other **writer** blocks and gives
+  up after `busy_timeout=5000`, and `FakeUnitOfWork` shares no connection, so no unit test notices. Six call sites had
+  drifted across the rule before anything looked (#1779), for the reason the check exists: nothing at a call site
+  reveals that an injected seam touches the disk. **The rule and the gate come from reading code — no measurement of how
+  long any of those transactions actually held the lock exists, and nothing here should be read as one.** What the check
+  sees is the deadlock rule's matcher unchanged — an **attribute** call naming a listed seam, lexically inside a
   `with <...>uow_factory()` block in the same function scope — so it inherits every blind spot of that half: a seam
-  behind a helper one level down, an alias to a local, a factory attribute whose name does not end in `uow_factory`, and
-  a nested `def`/`lambda` (which resets the scope by design). Matching only attribute calls is deliberate here: the pure
-  `domain.disc_selection.enumerate_discs` shares a name with the seam, is called bare, and touches nothing. Two blind
-  spots are this family's own. `SystemResolver` is call-shaped, so no consumer ever writes the Protocol's name — the
-  list carries `_resolve_system`, the attribute every consumer in `services/` binds it to, which closes the gap by
-  convention rather than by construction. And the list is hand-maintained: a seam whose implementation _grows_ a file
-  read later is undetected until someone adds its name. One `# pragma: no uow-check` covers both families — it
-  suppresses a line, and a line names one seam
+  behind a helper one level down, an alias to a local, a factory attribute whose name does not end in `uow_factory`, a
+  nested `def`/`lambda` (which resets the scope by design), a seam **passed as a bound method**
+  (`run_in_executor(None, self._disc_resolver.enumerate_discs, install)` — an attribute, not a call, and
+  `run_in_executor` is exactly how `disc.py` and `cores.py` reach their `_io` bodies; the same shape
+  `check_read_only_module.py` records for its own gate), and the hand-maintained list itself, which cannot notice a seam
+  whose implementation _grows_ a file read later. Matching only attribute calls is deliberate: the pure
+  `domain.disc_selection.enumerate_discs` shares a name with the seam and does no I/O — it is safe because its call site
+  imports it bare, not because of the name. One blind spot is this family's own: `SystemResolver` is call-shaped, so no
+  consumer writes a method name at all — the list carries `_resolve_system`, the attribute every consumer in `services/`
+  binds it to, which closes the gap by convention rather than by construction. That seam is also the odd one out for a
+  second reason: the adapter memoises its map for the life of the process, so exactly one call ever opens the file, and
+  the entry earns its place because that one call can land inside a UoW. One `# pragma: no uow-check` covers both
+  families — it suppresses the line, and no seam is in both lists, so where a line does name two seams it silences both
 - **Services never call clocks / sleep / uuid / random directly (inject the Protocol)** — check —
   `scripts/check_cosmic_call_bans.sh`
 - **No module in `services/`, `bootstrap/`, `adapters/`, `domain/`, `lib/` or `models/` crosses the ~1000-LOC

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,7 +244,30 @@ Format: **invariant** — tier — enforced by.
 - **Aggregate state mutated only via verb-named methods (no field assignment)** — check —
   `scripts/check_aggregate_field_assignment.py`
 - **No UoW-opening seam (ActiveCoreResolver, RelaunchOptionsResolver, uow_factory) is called while a UoW is open on the
-  same path** — check — `scripts/check_uow_seam_nesting.py`
+  same path** — check — `scripts/check_uow_seam_nesting.py` (the first of the **two** rules that script carries, over
+  one shared matcher; the file-I/O rule below is a different hazard with its own seam list and its own failure message,
+  and neither entry is evidence about the other)
+- **No file-I/O seam is called while a UoW is open — a Unit of Work wraps database reads and writes, never file or
+  server I/O (CONTEXT.md → Unit of Work, ADR-0006). The four today: `DiscResolver.enumerate_discs` and
+  `.resolve_for_install` (a recursive walk of the ROM's install directory), `CoreInfoProvider.get_emulator_options`
+  (ES-DE config discovery and parse plus a per-option installed-emulator probe), and `SystemResolver` (opens and parses
+  `config.json` — it lives on the RomM HTTP adapter and does no network work, which the name makes easy to misread)** —
+  check — `scripts/check_uow_seam_nesting.py`, second seam family (`IO_SEAM_METHODS`). **"It's only a read" is the
+  reasoning this rule exists to refuse**: `SqliteUnitOfWork.__enter__` issues `BEGIN IMMEDIATE`, so even a read-only UoW
+  takes the database's global write lock, and every other connection gives up after `busy_timeout=5000`. The cost is not
+  this operation's correctness but every other writer's, for as long as the walk takes — and `FakeUnitOfWork` shares no
+  connection, so no unit test notices. Six call sites had drifted across the rule before anything looked (#1779), for
+  the reason the check exists: nothing at a call site reveals that an injected seam touches the disk. What it sees is
+  the deadlock rule's matcher unchanged — an **attribute** call naming one of the four seams, lexically inside a
+  `with <...>uow_factory()` block in the same function scope — so it inherits every blind spot of that half: a seam
+  behind a helper one level down, an alias to a local, a factory attribute whose name does not end in `uow_factory`, and
+  a nested `def`/`lambda` (which resets the scope by design). Matching only attribute calls is deliberate here: the pure
+  `domain.disc_selection.enumerate_discs` shares a name with the seam, is called bare, and touches nothing. Two blind
+  spots are this family's own. `SystemResolver` is call-shaped, so no consumer ever writes the Protocol's name — the
+  list carries `_resolve_system`, the attribute every consumer in `services/` binds it to, which closes the gap by
+  convention rather than by construction. And the list is hand-maintained: a seam whose implementation _grows_ a file
+  read later is undetected until someone adds its name. One `# pragma: no uow-check` covers both families — it
+  suppresses a line, and a line names one seam
 - **Services never call clocks / sleep / uuid / random directly (inject the Protocol)** — check —
   `scripts/check_cosmic_call_bans.sh`
 - **No module in `services/`, `bootstrap/`, `adapters/`, `domain/`, `lib/` or `models/` crosses the ~1000-LOC

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,13 +254,14 @@ Format: **invariant** — tier — enforced by.
   directory), all four `CoreInfoProvider` reads — `get_active_core`, `get_default_emulator`, `get_emulator_options`,
   `resolve_sandbox_launcher` (each re-probes the flatpak roots for **its** ES-DE file and re-stats it before it may use
   the parse cache: `es_systems.xml` for the first three, `es_find_rules.xml` for the launcher read, and both for the
-  options read, which globs each option's emulator install through the find rules) — and `SystemResolver` (parses the
+  options read, which globs each option's emulator install through the find rules), `SystemResolver` (parses the
   plugin's **own** bundled `config.json`, not RetroDECK's `retrodeck.json`, and does no network work despite living on
-  the RomM HTTP adapter). Two other families of real I/O seam were weighed and kept out — the reasons are in the
-  script's docstring, and neither is an exemption; nor are those two an inventory of what else touches the disk. **"It's
-  only a read" is the reasoning this rule exists to refuse**: `SqliteUnitOfWork.__enter__` issues `BEGIN IMMEDIATE`, so
-  even a read-only UoW takes the write lock. The database is in WAL, so readers are unaffected — but every other
-  **writer** waits on the lock for up to `busy_timeout=5000` and fails with `SQLITE_BUSY` if it is still held then, and
+  the RomM HTTP adapter), and `SystemSupportedExtensionsFn` / `SystemKnownFn` (two questions to `es_systems.xml` through
+  that same per-call probe). Two other real I/O seams were weighed and kept out — the reasons are in the script's
+  docstring, and neither is an exemption; nor are those two an inventory of what else touches the disk. **"It's only a
+  read" is the reasoning this rule exists to refuse**: `SqliteUnitOfWork.__enter__` issues `BEGIN IMMEDIATE`, so even a
+  read-only UoW takes the write lock. The database is in WAL, so readers are unaffected — but every other **writer**
+  waits on the lock for up to `busy_timeout=5000` and fails with `SQLITE_BUSY` if it is still held then, and
   `FakeUnitOfWork` shares no connection, so no unit test notices. Six call sites had drifted across the rule before
   anything looked (#1779), for the reason the check exists: nothing at a call site reveals that an injected seam touches
   the disk. **The rule and the gate come from reading code — no measurement of how long any of those transactions
@@ -275,9 +276,10 @@ Format: **invariant** — tier — enforced by.
   whose implementation _grows_ a file read later. Matching only attribute calls is deliberate: the pure
   `domain.disc_selection.enumerate_discs` shares a name with the seam and does no I/O — it is safe because its call site
   imports it bare, not because of the name. The call-shaped blind spot is shared with the deadlock rule and only this
-  family closes it: `SystemResolver` has no method name a consumer would write, so the list carries `_resolve_system`,
-  the attribute every consumer in `services/` binds it to — by convention rather than by construction, and the deadlock
-  rule's own call-shaped seams stay open. That seam is also the odd one out for a second reason: the adapter memoises
+  family closes it: its three `__call__`-only seams have no method name a consumer would write, so the list carries the
+  attribute each is bound to (`_resolve_system`, `_system_extensions`, `_system_known`) — by convention rather than by
+  construction, and only while such a name means one thing, which is exactly what keeps `_list_files` out. The deadlock
+  rule's own call-shaped seams stay open. `SystemResolver` is the odd one out for a second reason: the adapter memoises
   its map for the life of the process, so exactly one call ever opens the file, and the entry earns its place because
   that one call can land inside a UoW. One `# pragma: no uow-check` covers both families — it suppresses the line, and
   no seam is in both lists, so where a line does name two seams it silences both

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,32 +252,35 @@ Format: **invariant** — tier — enforced by.
   (`IO_SEAM_METHODS`). The list is **the seams this checker can see and has been told about, never an inventory of the
   I/O seams that exist**: `DiscResolver.enumerate_discs` / `.resolve_for_install` (a recursive walk of the ROM's install
   directory), all four `CoreInfoProvider` reads — `get_active_core`, `get_default_emulator`, `get_emulator_options`,
-  `resolve_sandbox_launcher` (each re-probes the flatpak roots for `es_systems.xml` and re-stats it before it may use
-  the parse cache; the options read also globs each option's emulator install, and the launcher read parses
-  `es_find_rules.xml`) — and `SystemResolver` (parses the plugin's **own** bundled `config.json`, not RetroDECK's
-  `retrodeck.json`, and does no network work despite living on the RomM HTTP adapter). Two more families of real I/O
-  seam are left out and the reasons are in the script's docstring; neither is an exemption. **"It's only a read" is the
-  reasoning this rule exists to refuse**: `SqliteUnitOfWork.__enter__` issues `BEGIN IMMEDIATE`, so even a read-only UoW
-  takes the write lock. The database is in WAL, so readers are unaffected — but every other **writer** blocks and gives
-  up after `busy_timeout=5000`, and `FakeUnitOfWork` shares no connection, so no unit test notices. Six call sites had
-  drifted across the rule before anything looked (#1779), for the reason the check exists: nothing at a call site
-  reveals that an injected seam touches the disk. **The rule and the gate come from reading code — no measurement of how
-  long any of those transactions actually held the lock exists, and nothing here should be read as one.** What the check
-  sees is the deadlock rule's matcher unchanged — an **attribute** call naming a listed seam, lexically inside a
-  `with <...>uow_factory()` block in the same function scope — so it inherits every blind spot of that half: a seam
-  behind a helper one level down, an alias to a local, a factory attribute whose name does not end in `uow_factory`, a
-  nested `def`/`lambda` (which resets the scope by design), a seam **passed as a bound method**
+  `resolve_sandbox_launcher` (each re-probes the flatpak roots for **its** ES-DE file and re-stats it before it may use
+  the parse cache: `es_systems.xml` for the first three, `es_find_rules.xml` for the launcher read, and both for the
+  options read, which globs each option's emulator install through the find rules) — and `SystemResolver` (parses the
+  plugin's **own** bundled `config.json`, not RetroDECK's `retrodeck.json`, and does no network work despite living on
+  the RomM HTTP adapter). Two other families of real I/O seam were weighed and kept out — the reasons are in the
+  script's docstring, and neither is an exemption; nor are those two an inventory of what else touches the disk. **"It's
+  only a read" is the reasoning this rule exists to refuse**: `SqliteUnitOfWork.__enter__` issues `BEGIN IMMEDIATE`, so
+  even a read-only UoW takes the write lock. The database is in WAL, so readers are unaffected — but every other
+  **writer** waits on the lock for up to `busy_timeout=5000` and fails with `SQLITE_BUSY` if it is still held then, and
+  `FakeUnitOfWork` shares no connection, so no unit test notices. Six call sites had drifted across the rule before
+  anything looked (#1779), for the reason the check exists: nothing at a call site reveals that an injected seam touches
+  the disk. **The rule and the gate come from reading code — no measurement of how long any of those transactions
+  actually held the lock exists, and nothing here should be read as one.** What the check sees is the deadlock rule's
+  matcher unchanged — an **attribute** call naming a listed seam, lexically inside a `with <...>uow_factory()` block in
+  the same function scope — so it inherits every blind spot of that half: a seam behind a helper one level down, an
+  alias to a local, a factory attribute whose name does not end in `uow_factory`, a nested `def`/`lambda` (which resets
+  the scope by design), a seam **passed as a bound method**
   (`run_in_executor(None, self._disc_resolver.enumerate_discs, install)` — an attribute, not a call, and
   `run_in_executor` is exactly how `disc.py` and `cores.py` reach their `_io` bodies; the same shape
   `check_read_only_module.py` records for its own gate), and the hand-maintained list itself, which cannot notice a seam
   whose implementation _grows_ a file read later. Matching only attribute calls is deliberate: the pure
   `domain.disc_selection.enumerate_discs` shares a name with the seam and does no I/O — it is safe because its call site
-  imports it bare, not because of the name. One blind spot is this family's own: `SystemResolver` is call-shaped, so no
-  consumer writes a method name at all — the list carries `_resolve_system`, the attribute every consumer in `services/`
-  binds it to, which closes the gap by convention rather than by construction. That seam is also the odd one out for a
-  second reason: the adapter memoises its map for the life of the process, so exactly one call ever opens the file, and
-  the entry earns its place because that one call can land inside a UoW. One `# pragma: no uow-check` covers both
-  families — it suppresses the line, and no seam is in both lists, so where a line does name two seams it silences both
+  imports it bare, not because of the name. The call-shaped blind spot is shared with the deadlock rule and only this
+  family closes it: `SystemResolver` has no method name a consumer would write, so the list carries `_resolve_system`,
+  the attribute every consumer in `services/` binds it to — by convention rather than by construction, and the deadlock
+  rule's own call-shaped seams stay open. That seam is also the odd one out for a second reason: the adapter memoises
+  its map for the life of the process, so exactly one call ever opens the file, and the entry earns its place because
+  that one call can land inside a UoW. One `# pragma: no uow-check` covers both families — it suppresses the line, and
+  no seam is in both lists, so where a line does name two seams it silences both
 - **Services never call clocks / sleep / uuid / random directly (inject the Protocol)** — check —
   `scripts/check_cosmic_call_bans.sh`
 - **No module in `services/`, `bootstrap/`, `adapters/`, `domain/`, `lib/` or `models/` crosses the ~1000-LOC

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -1458,10 +1458,12 @@ backstop short of a Force Full Sync or uninstall/reinstall.
 `get_installed_relaunch_options()` is the read half of the fix: a 0-arg read that returns `[{app_id, launch_options}]`
 for every ROM that is both **installed** (has a `rom_installs` row) and **bound** (its `roms.shortcut_app_id` is set).
 It snapshots the install/ROM rows in one short read UoW, then re-bakes each command **outside** that UoW through the
-same `active_core` / `disc_resolver` seams every other bake site uses — resolving inside the iteration UoW would
-deadlock, since `ActiveCoreResolver.active_core_for_rom` opens its own UoW (the per-connection write lock is not
-re-entrant). Uninstalled and unbound ROMs are skipped by construction. The callable is read-only and **not**
-migration-gated.
+same `active_core` / `disc_resolver` seams every other bake site uses. Each seam is outside for its own reason:
+resolving `active_core` inside the iteration UoW would deadlock, since `ActiveCoreResolver.active_core_for_rom` opens
+its own UoW (the per-connection write lock is not re-entrant), while `disc_resolver` opens none and instead walks the
+install directory — and `BEGIN IMMEDIATE` holds the global write lock even for a read, so a walk inside the UoW stalls
+every other writer for its duration (#1779). Uninstalled and unbound ROMs are skipped by construction. The callable is
+read-only and **not** migration-gated.
 
 The frontend pulls this on mount, once the backend is proven reachable (it reuses the app-id/metadata init's
 retry/backoff, not a second loop), and confirm-sets each entry via the existing `setLaunchOptionsConfirmed`

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -1461,8 +1461,8 @@ It snapshots the install/ROM rows in one short read UoW, then re-bakes each comm
 same `active_core` / `disc_resolver` seams every other bake site uses. Each seam is outside for its own reason:
 resolving `active_core` inside the iteration UoW would deadlock, since `ActiveCoreResolver.active_core_for_rom` opens
 its own UoW (the per-connection write lock is not re-entrant), while `disc_resolver` opens none and instead walks the
-install directory — and `BEGIN IMMEDIATE` holds the global write lock even for a read, so a walk inside the UoW stalls
-every other writer for its duration (#1779). Uninstalled and unbound ROMs are skipped by construction. The callable is
+install directory — and `BEGIN IMMEDIATE` takes the write lock even for a read, so a walk inside the UoW stalls every
+other writer for its duration (#1779). Uninstalled and unbound ROMs are skipped by construction. The callable is
 read-only and **not** migration-gated.
 
 The frontend pulls this on mount, once the backend is proven reachable (it reuses the app-id/metadata init's

--- a/py_modules/adapters/retrodeck_paths.py
+++ b/py_modules/adapters/retrodeck_paths.py
@@ -67,10 +67,11 @@ class RetroDeckPathsAdapter:
             self._last_load_health = RetroDeckConfigHealth.OK
             return config
         except FileNotFoundError:
-            # Missing file is the expected fallback path (fresh install,
-            # no RetroDECK yet) — don't spam the log on every read, and
-            # don't cache the time so the next read picks up a created
-            # file immediately.
+            # Missing file is the expected fallback path (fresh install, no
+            # RetroDECK yet) — don't spam the log on every read. A created file
+            # is picked up on the next read because the TTL guard tests the
+            # cached value before the age, and both failure paths null it; the
+            # unset time here is not what buys that.
             self._cached_config = None
             self._last_load_health = RetroDeckConfigHealth.ABSENT
             return None

--- a/py_modules/services/cores.py
+++ b/py_modules/services/cores.py
@@ -249,11 +249,11 @@ class CoreService:
                     "message": f"ROM {rom_id} is not tracked",
                 }
             platform_slug = rom.platform_slug
-        # Resolve the label between the two transactions: the slug→system
-        # resolver parses config.json and the emulator options probe ES-DE's
-        # config plus each option's install, and a UoW holds SQLite's BEGIN
-        # IMMEDIATE write lock — file I/O inside one stalls every other writer
-        # in the plugin.
+        # Resolve the label between the two transactions: the emulator-options
+        # read re-probes ES-DE's config and each option's install on every call
+        # (the slug→system resolver only on the process's first), and a UoW
+        # holds SQLite's BEGIN IMMEDIATE write lock — file I/O inside one stalls
+        # every other writer for its duration.
         system = self._resolve_system(platform_slug)
         invocation = label_to_invocation(self._core_info.get_emulator_options(system)["options"], label)
         if invocation is None:
@@ -275,6 +275,16 @@ class CoreService:
                     "success": False,
                     "reason": "not_found",
                     "message": f"ROM {rom_id} is not tracked",
+                }
+            if rom.platform_slug != platform_slug:
+                # A re-sync rewrites platform_slug (it is a synced-identity
+                # column). The label was validated against the platform the
+                # snapshot named, so pinning it now would persist a label that
+                # was never checked against the platform it will resolve under.
+                return {
+                    "success": False,
+                    "reason": "core_unavailable",
+                    "message": f"Emulator '{label}' is not available for {rom.platform_slug}",
                 }
             # Enforce the aggregate invariant (strip / reject blank) via the
             # verb method, then persist the resulting label through the pin-only

--- a/py_modules/services/cores.py
+++ b/py_modules/services/cores.py
@@ -248,15 +248,33 @@ class CoreService:
                     "reason": "not_found",
                     "message": f"ROM {rom_id} is not tracked",
                 }
-            system = self._resolve_system(rom.platform_slug)
-            invocation = label_to_invocation(self._core_info.get_emulator_options(system)["options"], label)
-            if invocation is None:
-                # Hard-fail BEFORE any write — never persist a label that does not
-                # resolve to a bakeable emulator (unknown / needs_setup / un-bakeable).
+            platform_slug = rom.platform_slug
+        # Resolve the label between the two transactions: the slug→system
+        # resolver parses config.json and the emulator options probe ES-DE's
+        # config plus each option's install, and a UoW holds SQLite's BEGIN
+        # IMMEDIATE write lock — file I/O inside one stalls every other writer
+        # in the plugin.
+        system = self._resolve_system(platform_slug)
+        invocation = label_to_invocation(self._core_info.get_emulator_options(system)["options"], label)
+        if invocation is None:
+            # Hard-fail BEFORE any write — never persist a label that does not
+            # resolve to a bakeable emulator (unknown / needs_setup / un-bakeable).
+            return {
+                "success": False,
+                "reason": "core_unavailable",
+                "message": f"Emulator '{label}' is not available for {platform_slug}",
+            }
+        with self._uow_factory() as uow:
+            # The row is re-read because the label was resolved against a
+            # snapshot: a background sync, a finishing download or the
+            # removed-game cleanup can retire the ROM between the two
+            # transactions, each on its own connection.
+            rom = uow.roms.get(rom_id)
+            if rom is None:
                 return {
                     "success": False,
-                    "reason": "core_unavailable",
-                    "message": f"Emulator '{label}' is not available for {rom.platform_slug}",
+                    "reason": "not_found",
+                    "message": f"ROM {rom_id} is not tracked",
                 }
             # Enforce the aggregate invariant (strip / reject blank) via the
             # verb method, then persist the resulting label through the pin-only

--- a/py_modules/services/cores.py
+++ b/py_modules/services/cores.py
@@ -281,10 +281,15 @@ class CoreService:
                 # column). The label was validated against the platform the
                 # snapshot named, so pinning it now would persist a label that
                 # was never checked against the platform it will resolve under.
+                # The message says exactly that rather than calling the label
+                # unavailable: re-resolving to find out would cost the ES-DE
+                # read this split exists to keep out of the transaction, and on
+                # a label valid for both platforms "unavailable" is simply
+                # false — the user retries and it works.
                 return {
                     "success": False,
                     "reason": "core_unavailable",
-                    "message": f"Emulator '{label}' is not available for {rom.platform_slug}",
+                    "message": f"Emulator '{label}' was not verified for {rom.platform_slug}; try again",
                 }
             # Enforce the aggregate invariant (strip / reject blank) via the
             # verb method, then persist the resulting label through the pin-only

--- a/py_modules/services/disc.py
+++ b/py_modules/services/disc.py
@@ -159,13 +159,22 @@ class DiscService:
             # The row is re-read because the pick is now decided against a
             # snapshot: a background sync, a finishing download or the
             # removed-game cleanup can retire the ROM between the two
-            # transactions, each on its own connection. The install is only
-            # proven to still exist, never re-bound: the bake resolves over
-            # ``discs``, which were enumerated from the snapshot above, and a
-            # relocated install paired with that older listing would resolve a
-            # disc to a directory it was never listed in.
+            # transactions, each on its own connection. The install is re-read
+            # for the same admission the first transaction applied — it exists
+            # and is folder-backed — but the row is never re-bound: the bake
+            # resolves over ``discs``, which were enumerated from the snapshot
+            # above, and a relocated install paired with that older listing
+            # would resolve a disc to a directory it was never listed in.
+            # That is the accepted cost of the split: a re-install that moves the
+            # ROM in this window still gets its pin, and the returned
+            # ``launch_options`` — which the frontend confirm-sets on the live
+            # shortcut — then names the directory the ROM has left. It is
+            # self-correcting rather than sticky: the startup launch-options
+            # reconcile (#1043) re-bakes every installed+bound ROM from the
+            # current rows on the next plugin load.
             rom = uow.roms.get(rom_id)
-            if rom is None or uow.rom_installs.get(rom_id) is None:
+            current_install = uow.rom_installs.get(rom_id)
+            if rom is None or current_install is None or current_install.rom_dir is None:
                 return {
                     "success": False,
                     "reason": "not_installed",
@@ -177,9 +186,6 @@ class DiscService:
                 rom.pin_selected_disc(filename)
             uow.roms.set_selected_disc(rom_id, rom.selected_disc)
             selected = rom.selected_disc
-        # The bake resolves the ROM's active core through a seam that opens its
-        # OWN UoW, so it runs after the write UoW closes — the non-reentrant
-        # BEGIN IMMEDIATE would otherwise self-deadlock.
         launch_options = self._bake_launch_options(rom_id, install, discs, selected)
         return {"success": True, "launch_options": launch_options, "selected": selected}
 
@@ -192,8 +198,8 @@ class DiscService:
         (the pin just written, or the default when cleared), then folds it over
         the ROM's FULL active core so a per-game/per-platform core still bakes its
         ``-e`` override form rather than a plain launch. Runs after the write UoW
-        has closed: ``active_core_for_rom`` opens its own UoW, so resolving here
-        keeps it from nesting on the same SQLite connection.
+        has closed: ``active_emulator_for_rom`` opens its own UoW, so resolving
+        here keeps it from nesting on the same SQLite connection.
         """
         bake_path = self._disc_resolver.resolve_bake_path(install, discs, selected_disc)
         emulator = self._active_core.active_emulator_for_rom(rom_id)

--- a/py_modules/services/disc.py
+++ b/py_modules/services/disc.py
@@ -159,10 +159,13 @@ class DiscService:
             # The row is re-read because the pick is now decided against a
             # snapshot: a background sync, a finishing download or the
             # removed-game cleanup can retire the ROM between the two
-            # transactions, each on its own connection.
+            # transactions, each on its own connection. The install is only
+            # proven to still exist, never re-bound: the bake resolves over
+            # ``discs``, which were enumerated from the snapshot above, and a
+            # relocated install paired with that older listing would resolve a
+            # disc to a directory it was never listed in.
             rom = uow.roms.get(rom_id)
-            install = uow.rom_installs.get(rom_id)
-            if rom is None or install is None:
+            if rom is None or uow.rom_installs.get(rom_id) is None:
                 return {
                     "success": False,
                     "reason": "not_installed",

--- a/py_modules/services/disc.py
+++ b/py_modules/services/disc.py
@@ -89,9 +89,12 @@ class DiscService:
             install = uow.rom_installs.get(rom_id)
             if rom is None or install is None or install.rom_dir is None:
                 return {"multi_disc": False}
-            discs = self._disc_resolver.enumerate_discs(install)
             selected = rom.selected_disc
             file_path = install.file_path
+        # Enumeration lists the install directory, so it runs on the snapshot
+        # after the read UoW closes: a UoW takes SQLite's BEGIN IMMEDIATE write
+        # lock, and holding one across file I/O stalls every other writer.
+        discs = self._disc_resolver.enumerate_discs(install)
         if len(discs) < 2:
             return {"multi_disc": False}
         # Down-validate the pin: a stale pin (the file is no longer enumerated)
@@ -125,10 +128,6 @@ class DiscService:
         return await self._loop.run_in_executor(None, self._select_disc_io, rom_id, filename)
 
     def _select_disc_io(self, rom_id: int, filename: str | None) -> dict[str, Any]:
-        # The validate + write run inside one UoW; the bake — which calls
-        # ``active_core_for_rom`` (it opens its OWN UoW) — runs AFTER this UoW
-        # closes, so the two never nest on the same SQLite connection (BEGIN
-        # IMMEDIATE would otherwise self-deadlock).
         with self._uow_factory() as uow:
             rom = uow.roms.get(rom_id)
             install = uow.rom_installs.get(rom_id)
@@ -138,20 +137,36 @@ class DiscService:
                     "reason": "not_installed",
                     "message": f"ROM {rom_id} is not installed as a multi-disc ROM",
                 }
-            discs = self._disc_resolver.enumerate_discs(install)
-            if len(discs) < 2:
+        # Enumerate and validate between the two transactions: enumeration lists
+        # the install directory, and a UoW holds SQLite's BEGIN IMMEDIATE write
+        # lock, so file I/O inside one stalls every other writer in the plugin.
+        discs = self._disc_resolver.enumerate_discs(install)
+        if len(discs) < 2:
+            return {
+                "success": False,
+                "reason": ErrorCode.UNSUPPORTED.value,
+                "message": f"ROM {rom_id} is not a multi-disc ROM",
+            }
+        if filename is not None and filename not in {disc.filename for disc in discs}:
+            # B4: hard-fail BEFORE any write — never pin a disc no enumeration
+            # can resolve to a launchable path.
+            return {
+                "success": False,
+                "reason": ErrorCode.NOT_FOUND.value,
+                "message": f"'{filename}' is not a disc of ROM {rom_id}",
+            }
+        with self._uow_factory() as uow:
+            # The row is re-read because the pick is now decided against a
+            # snapshot: a background sync, a finishing download or the
+            # removed-game cleanup can retire the ROM between the two
+            # transactions, each on its own connection.
+            rom = uow.roms.get(rom_id)
+            install = uow.rom_installs.get(rom_id)
+            if rom is None or install is None:
                 return {
                     "success": False,
-                    "reason": ErrorCode.UNSUPPORTED.value,
-                    "message": f"ROM {rom_id} is not a multi-disc ROM",
-                }
-            if filename is not None and filename not in {disc.filename for disc in discs}:
-                # B4: hard-fail BEFORE any write — never pin a disc no
-                # enumeration can resolve to a launchable path.
-                return {
-                    "success": False,
-                    "reason": ErrorCode.NOT_FOUND.value,
-                    "message": f"'{filename}' is not a disc of ROM {rom_id}",
+                    "reason": "not_installed",
+                    "message": f"ROM {rom_id} is not installed as a multi-disc ROM",
                 }
             if filename is None:
                 rom.clear_selected_disc()
@@ -159,6 +174,9 @@ class DiscService:
                 rom.pin_selected_disc(filename)
             uow.roms.set_selected_disc(rom_id, rom.selected_disc)
             selected = rom.selected_disc
+        # The bake resolves the ROM's active core through a seam that opens its
+        # OWN UoW, so it runs after the write UoW closes — the non-reentrant
+        # BEGIN IMMEDIATE would otherwise self-deadlock.
         launch_options = self._bake_launch_options(rom_id, install, discs, selected)
         return {"success": True, "launch_options": launch_options, "selected": selected}
 

--- a/py_modules/services/library/shortcut_launch_resolver.py
+++ b/py_modules/services/library/shortcut_launch_resolver.py
@@ -29,7 +29,11 @@ inside the read UoW and close it before resolving a single one, because
 ``resolve_for_install`` lists the install directory. CONTEXT.md's Unit of Work
 entry keeps a transaction to database reads and writes — a directory walk per
 installed ROM held inside one blocks every other writer in the plugin for as
-long as the walk takes.
+long as the walk takes, because ``BEGIN IMMEDIATE`` takes the global write lock
+even for a read. That boundary IS gated, unlike the one above: the same
+check's second seam family fires on ``resolve_for_install`` named inside the
+``with`` block. It is the same matcher, so it carries the same peer-call blind
+spot — the gate would not have stopped the fold either.
 """
 
 from __future__ import annotations

--- a/py_modules/services/library/shortcut_launch_resolver.py
+++ b/py_modules/services/library/shortcut_launch_resolver.py
@@ -27,13 +27,13 @@ The ``disc_resolver`` seam is held to the same boundary from the other side:
 both install-path readers snapshot their ``(install, selected_disc)`` pairs
 inside the read UoW and close it before resolving a single one, because
 ``resolve_for_install`` lists the install directory. CONTEXT.md's Unit of Work
-entry keeps a transaction to database reads and writes — a directory walk per
-installed ROM held inside one blocks every other writer in the plugin for as
-long as the walk takes, because ``BEGIN IMMEDIATE`` takes the global write lock
-even for a read. That boundary IS gated, unlike the one above: the same
-check's second seam family fires on ``resolve_for_install`` named inside the
-``with`` block. It is the same matcher, so it carries the same peer-call blind
-spot — the gate would not have stopped the fold either.
+entry keeps a transaction to database reads and writes — ``BEGIN IMMEDIATE``
+takes the write lock even for a read, so a directory walk per installed ROM
+held inside one stalls every other writer for as long as the walk takes. The
+same check carries this as its second rule, on the same matcher and with the
+same reach: it fires on ``resolve_for_install`` named inside the ``with``
+block and is silent on the peer-call form. Both boundaries are gated inline;
+neither is gated against the fold.
 """
 
 from __future__ import annotations

--- a/py_modules/services/library/shortcut_launch_resolver.py
+++ b/py_modules/services/library/shortcut_launch_resolver.py
@@ -23,12 +23,13 @@ silent on the peer-call form (``self.do_build_core_overrides(...)`` inside it),
 a blind spot its own docstring records. So the reason not to write the fold is
 the deadlock, not a check that would stop you — nothing will.
 
-One rule this module does not keep, inherited with the code rather than
-introduced by it: both install-path readers hold their UoW open across the disc
-resolver's directory listing, once per installed ROM. CONTEXT.md's Unit of Work
-entry keeps a transaction narrow — database reads and writes, never file I/O —
-so this file is where that fix lands when it comes, and a reader should not
-take the boundary above as evidence the rest is clean.
+The ``disc_resolver`` seam is held to the same boundary from the other side:
+both install-path readers snapshot their ``(install, selected_disc)`` pairs
+inside the read UoW and close it before resolving a single one, because
+``resolve_for_install`` lists the install directory. CONTEXT.md's Unit of Work
+entry keeps a transaction to database reads and writes — a directory walk per
+installed ROM held inside one blocks every other writer in the plugin for as
+long as the walk takes.
 """
 
 from __future__ import annotations
@@ -37,6 +38,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from domain.rom_install import RomInstall
     from domain.shortcut_data import EmulatorInvocation
     from services.protocols import ActiveCoreReader, DiscResolver, UnitOfWorkFactory
 
@@ -98,13 +100,15 @@ class ShortcutLaunchResolver:
         record appear in the map; a ROM not downloaded is absent, and both cases
         reach :func:`build_shortcuts_data` as the same empty launch command.
         """
+        pending: list[tuple[RomInstall, str | None]] = []
         with self._uow_factory() as uow:
-            paths: dict[int, str] = {}
             for install in uow.rom_installs.iter_all():
                 rom = uow.roms.get(install.rom_id)
-                selected_disc = rom.selected_disc if rom is not None else None
-                paths[install.rom_id] = self._disc_resolver.resolve_for_install(install, selected_disc)
-            return paths
+                pending.append((install, rom.selected_disc if rom is not None else None))
+        return {
+            install.rom_id: self._disc_resolver.resolve_for_install(install, selected_disc)
+            for install, selected_disc in pending
+        }
 
     def do_read_installed_paths(self, rom_ids: set[int]) -> dict[int, str]:
         """Read ``{rom_id: bake_path}`` for *rom_ids* via targeted point-lookups.
@@ -118,12 +122,15 @@ class ShortcutLaunchResolver:
         target. A ROM with no install record is absent; both cases reach
         :func:`build_shortcuts_data` as the same empty launch command.
         """
+        pending: list[tuple[RomInstall, str | None]] = []
         with self._uow_factory() as uow:
-            paths: dict[int, str] = {}
             for rom_id in rom_ids:
                 install = uow.rom_installs.get(rom_id)
-                if install is not None:
-                    rom = uow.roms.get(rom_id)
-                    selected_disc = rom.selected_disc if rom is not None else None
-                    paths[rom_id] = self._disc_resolver.resolve_for_install(install, selected_disc)
-            return paths
+                if install is None:
+                    continue
+                rom = uow.roms.get(rom_id)
+                pending.append((install, rom.selected_disc if rom is not None else None))
+        return {
+            install.rom_id: self._disc_resolver.resolve_for_install(install, selected_disc)
+            for install, selected_disc in pending
+        }

--- a/scripts/check_uow_seam_nesting.py
+++ b/scripts/check_uow_seam_nesting.py
@@ -21,7 +21,7 @@ of the block, so **even a read-only UoW is a writer** as far as every other
 connection is concerned, and they each give up after ``busy_timeout=5000``. A
 directory walk or a config parse held inside a UoW therefore stalls every other
 writer in the plugin for as long as the I/O takes. CONTEXT.md's Unit of Work
-entry and [ADR-0006] state the rule — a transaction wraps database reads and
+entry and ADR-0006 state the rule — a transaction wraps database reads and
 writes, never file or server I/O — and until #1779 nothing detected a breach:
 six call sites had drifted across it, because nothing at a call site reveals
 that an injected seam touches the disk. The seams live in

--- a/scripts/check_uow_seam_nesting.py
+++ b/scripts/check_uow_seam_nesting.py
@@ -1,43 +1,90 @@
 #!/usr/bin/env python3
-"""UoW-seam nesting ban — deadlock-prevention enforcement.
+"""UoW-seam nesting ban — what may not be called while a Unit of Work is open.
 
-A Unit of Work opens a SQLite transaction with ``BEGIN IMMEDIATE`` on its
-own connection, and that write lock is **not re-entrant**. Calling a seam
-that opens its OWN UoW while a UoW is already open on the same path blocks
-on the nested ``BEGIN IMMEDIATE`` until ``busy_timeout`` (~5s) elapses, then
-raises ``database is locked``. ``FakeUnitOfWork`` in the unit tests shares no
-real connection, so the deadlock is invisible there — it only surfaces on a
-real device. The hazard has bitten four sites across three issues (#1047,
-#1134 twice, and the migration site fixed via #1155).
+A Unit of Work opens a SQLite transaction with ``BEGIN IMMEDIATE`` on its own
+connection. That single fact carries two separate rules, and this check
+enforces both from one AST walk because the matcher is identical — only the
+seam list and the failure message differ.
 
-The established fix is to snapshot the rows a seam needs *inside* one short
-read UoW, close it, then resolve the seam *outside* any open UoW
+**Rule 1 — a seam that opens its own UoW deadlocks.** The write lock is not
+re-entrant. Calling a seam that opens its OWN UoW while a UoW is already open
+on the same path blocks on the nested ``BEGIN IMMEDIATE`` until
+``busy_timeout`` (~5s) elapses, then raises ``database is locked``.
+``FakeUnitOfWork`` in the unit tests shares no real connection, so the deadlock
+is invisible there — it only surfaces on a real device. The hazard has bitten
+four sites across three issues (#1047, #1134 twice, and the migration site
+fixed via #1155). The seams live in :data:`SEAM_METHODS`.
+
+**Rule 2 — a seam that touches the disk holds the write lock for the whole
+walk.** ``BEGIN IMMEDIATE`` takes the database's global write lock at the top
+of the block, so **even a read-only UoW is a writer** as far as every other
+connection is concerned, and they each give up after ``busy_timeout=5000``. A
+directory walk or a config parse held inside a UoW therefore stalls every other
+writer in the plugin for as long as the I/O takes. CONTEXT.md's Unit of Work
+entry and [ADR-0006] state the rule — a transaction wraps database reads and
+writes, never file or server I/O — and until #1779 nothing detected a breach:
+six call sites had drifted across it, because nothing at a call site reveals
+that an injected seam touches the disk. The seams live in
+:data:`IO_SEAM_METHODS`.
+
+The established fix is the same for both: snapshot the rows a seam needs
+*inside* one short UoW, close it, then call the seam *outside* any open UoW
 (``services/relaunch_options_resolver.py``, ``services/cores.py``,
-``services/disc.py``, ``services/downloads.py`` are the reference shape).
+``services/disc.py``, ``services/downloads.py``,
+``services/library/shortcut_launch_resolver.py`` are the reference shape).
+Re-read anything the write then depends on: the second transaction runs on its
+own connection, so the snapshot may have gone stale.
 
-This check walks ``py_modules/services/`` and fails when a known
-UoW-opening seam is called lexically inside an open
-``with <...>uow_factory() as uow:`` block. The two seam families and the
-bare-factory open live in :data:`SEAM_METHODS` / :data:`UOW_FACTORY_SUFFIX`
-at the top of the file, so registering a future seam is a one-line addition.
+This check walks ``py_modules/services/`` and fails when either family's method
+is called lexically inside an open ``with <...>uow_factory() as uow:`` block.
+The two seam lists and the bare-factory open (:data:`UOW_FACTORY_SUFFIX`, which
+catches a nested open under rule 1) live at the top of the file, so registering
+a future seam is a one-line addition.
 
-The matcher is lexical and conservative (a guardrail, not a prover). It only
-sees calls nested inside a ``with`` block in the same function scope — a seam
-reached through a helper called from inside the UoW is not caught, and a
-nested ``def``/``lambda`` resets the scope (a helper *defined* inside a UoW
-but *called* elsewhere is not flagged). It also matches on the surface syntax:
-aliasing a seam to a local (``fn = resolver.active_core_for_rom; fn(rom_id)``)
-or holding the UoW factory under an attribute whose name does not end in
-``uow_factory`` slips past the name match. **A seam injected as a call-shaped
-Protocol is that same blind spot**: the consumer writes
-``self._candidate_probe(...)``, never the seam's own name, so the entry in
-:data:`SEAM_METHODS` guards only the call sites that name the method — the
-service's own, and any peer holding the object rather than the bound method.
-Closing it means matching the holding attribute too, which is a second list to
-keep in step and is not built. The escape hatch is a trailing comment on the
-seam-call line:
+What the matcher cannot see
+---------------------------
+It is lexical and conservative (a guardrail, not a prover), and these blind
+spots apply to **both** families:
+
+* It only sees calls nested inside a ``with`` block in the same function scope
+  — a seam reached through a helper called from inside the UoW is not caught,
+  and a nested ``def``/``lambda`` resets the scope (a helper *defined* inside a
+  UoW but *called* elsewhere is not flagged).
+* It matches on surface syntax: aliasing a seam to a local
+  (``fn = resolver.active_core_for_rom; fn(rom_id)``) or holding the UoW
+  factory under an attribute whose name does not end in ``uow_factory`` slips
+  past the name match.
+* Both seam lists are hand-maintained. A seam whose implementation *grows* a
+  UoW open or a file read later is not detected until someone adds its name.
+
+One blind spot is not symmetric between the families. **A seam injected as a
+call-shaped Protocol** (``__call__``, no method name of its own) is invisible
+under rule 1: the consumer writes ``self._candidate_probe(...)``, never the
+seam's own name, so the ``current_save_sorting`` / ``has_adoption_candidate``
+entries guard only call sites that name the method — the owning service's own,
+and any peer holding the object rather than the bound method. Closing that
+generally means matching the holding attribute too, which is a second list to
+keep in step and is not built. Rule 2 has one call-shaped seam,
+``SystemResolver``, and closes it the cheap way instead: every consumer in
+``services/`` stores it as ``self._resolve_system``, so **both** the Protocol's
+name and that attribute name are listed. That is a convention, not a
+guarantee — a consumer that binds it under a different attribute slips past.
+
+Conversely, matching only *attribute* calls is what keeps the ``enumerate_discs``
+entry safe: the pure ``domain.disc_selection.enumerate_discs`` is called bare
+(``enumerate_discs(files, ...)``) and does no I/O of its own, so it is never
+mistaken for the seam.
+
+The escape hatch is a trailing comment on the seam-call line:
 
     self._active_core.active_core_for_rom(rom_id)  # pragma: no uow-check
+
+**One pragma covers both families.** It suppresses the line, not a named rule:
+a call site names exactly one seam, and no seam is in both lists (a seam that
+both opened a UoW and walked the disk would be its own design fault), so there
+is never an ambiguity for a second pragma spelling to resolve. Requiring the
+writer to pick the right spelling would only ask them to restate what the
+failure message already told them.
 
 Exit 0 on no findings, exit 1 if any findings (one line per finding).
 """
@@ -51,7 +98,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SERVICES_DIR = REPO_ROOT / "py_modules" / "services"
 
-# --- The seam list -------------------------------------------------------
+# --- Rule 1: seams that open their own Unit of Work ----------------------
 # Method names whose implementation opens its OWN Unit of Work. Calling any
 # of these while a UoW is already open on the same SQLite connection
 # re-enters the non-reentrant ``BEGIN IMMEDIATE`` and deadlocks. Matched by
@@ -72,6 +119,35 @@ SEAM_METHODS: frozenset[str] = frozenset(
     }
 )
 
+# --- Rule 2: seams that touch the filesystem -----------------------------
+# Method names whose implementation reads the disk. None of them opens a UoW,
+# so nothing deadlocks — the cost is duration: the UoW's BEGIN IMMEDIATE holds
+# the global write lock across the whole walk, and every other connection in
+# the plugin gives up at busy_timeout. Each entry names the Protocol it belongs
+# to and the I/O it performs.
+IO_SEAM_METHODS: frozenset[str] = frozenset(
+    {
+        # DiscResolver (services/disc_launch_resolver.py) — recursive walk of the
+        # ROM's install directory, plus an ES-DE config read for the system's
+        # supported extensions.
+        "enumerate_discs",
+        # CoreInfoProvider (adapters/es_de_config.py) — ES-DE config discovery and
+        # parse, plus a per-option probe for whether that emulator is installed.
+        "get_emulator_options",
+        # DiscResolver (services/disc_launch_resolver.py) — the same recursive
+        # walk of the install directory, resolving the persisted disc pin over it.
+        "resolve_for_install",
+        # SystemResolver (services/protocols/paths.py) — opens and parses
+        # RetroDECK's ``config.json``. It is implemented on the RomM HTTP adapter,
+        # which the name makes easy to misread: it does no network work at all,
+        # only the file read. The Protocol is call-shaped, so ``_resolve_system``
+        # is listed with it — that is the attribute every consumer in services/
+        # binds it to, and the only spelling the matcher can see (module docstring).
+        "resolve_system",
+        "_resolve_system",
+    }
+)
+
 # A Unit of Work is opened by *calling* a factory whose final name segment
 # ends with this suffix — ``self._uow_factory()``, ``config.uow_factory()``,
 # a bare ``uow_factory()``. Used both to recognise the enclosing ``with``
@@ -79,6 +155,20 @@ SEAM_METHODS: frozenset[str] = frozenset(
 UOW_FACTORY_SUFFIX = "uow_factory"
 
 ESCAPE_HATCH = "pragma: no uow-check"
+
+# The two remedies are one sentence apart, but the hazard behind them is not:
+# rule 1 hangs this operation, rule 2 hangs every other one. A reader who hits
+# either message has to be able to tell which rule they broke.
+_DEADLOCK_REMEDY = (
+    "snapshot inside the UoW, close it, "
+    "then resolve outside (the nested BEGIN IMMEDIATE deadlocks → 'database is locked')"
+)
+_WRITE_LOCK_REMEDY = (
+    "snapshot inside the UoW, close it, "
+    "then do the I/O outside (BEGIN IMMEDIATE holds the global write lock even for a "
+    "read-only UoW, so every other writer in the plugin blocks for as long as the I/O "
+    "takes, then fails at busy_timeout)"
+)
 
 
 def _final_name(func: ast.expr) -> str | None:
@@ -103,33 +193,36 @@ def _is_uow_opener(node: ast.expr) -> bool:
     return name is not None and name.endswith(UOW_FACTORY_SUFFIX)
 
 
-def _seam_method(node: ast.Call) -> str | None:
-    """Return the seam method name a call invokes, or None."""
+def _classify(node: ast.Call) -> tuple[str, str] | None:
+    """Return ``(detail, remedy)`` for a hazardous call, or None.
+
+    Only attribute calls are considered for the two seam families, so a
+    same-named module-level function (``domain.disc_selection.enumerate_discs``)
+    is never mistaken for the seam it shares a name with.
+    """
     func = node.func
-    if isinstance(func, ast.Attribute) and func.attr in SEAM_METHODS:
-        return func.attr
+    if isinstance(func, ast.Attribute):
+        if func.attr in SEAM_METHODS:
+            return f"UoW-opening seam '.{func.attr}(...)'", _DEADLOCK_REMEDY
+        if func.attr in IO_SEAM_METHODS:
+            return f"file-I/O seam '.{func.attr}(...)'", _WRITE_LOCK_REMEDY
+    if _is_uow_opener(node):
+        return f"nested UoW open '{_final_name(func)}(...)'", _DEADLOCK_REMEDY
     return None
 
 
 def _finding_for_call(node: ast.Call, source_lines: list[str], rel: str) -> str | None:
     """Classify one call reached while a UoW is open. None = not a hazard."""
-    seam = _seam_method(node)
-    if seam is not None:
-        detail = f"UoW-opening seam '.{seam}(...)'"
-    elif _is_uow_opener(node):
-        detail = f"nested UoW open '{_final_name(node.func)}(...)'"
-    else:
+    classified = _classify(node)
+    if classified is None:
         return None
+    detail, remedy = classified
 
     line_idx = node.lineno - 1
     if 0 <= line_idx < len(source_lines) and ESCAPE_HATCH in source_lines[line_idx]:
         return None
 
-    return (
-        f"{rel}:{node.lineno}:{node.col_offset} "
-        f"{detail} called while a UoW is open — snapshot inside the UoW, close it, "
-        f"then resolve outside (the nested BEGIN IMMEDIATE deadlocks → 'database is locked')"
-    )
+    return f"{rel}:{node.lineno}:{node.col_offset} {detail} called while a UoW is open — {remedy}"
 
 
 def _scan(node: ast.AST, in_uow: bool, source_lines: list[str], rel: str, findings: list[str]) -> None:
@@ -174,7 +267,7 @@ def _scan(node: ast.AST, in_uow: bool, source_lines: list[str], rel: str, findin
 
 
 def scan_source(source: str, filename: str = "<source>") -> list[str]:
-    """Return every nested-UoW-seam finding in one module's *source* text."""
+    """Return every in-UoW seam finding in one module's *source* text."""
     try:
         tree = ast.parse(source, filename=filename)
     except SyntaxError:
@@ -187,7 +280,7 @@ def scan_source(source: str, filename: str = "<source>") -> list[str]:
 
 
 def find_violations(services_dir: Path = SERVICES_DIR) -> list[str]:
-    """Walk *services_dir* and return every nested-UoW-seam finding."""
+    """Walk *services_dir* and return every in-UoW seam finding."""
     findings: list[str] = []
     if not services_dir.is_dir():
         return findings
@@ -209,13 +302,25 @@ def main(argv: list[str]) -> int:
     if findings:
         for line in findings:
             print(line)
-        print()
-        print(
-            "ERROR: a UoW-opening seam (ActiveCoreResolver / RelaunchOptionsResolver / "
-            "uow_factory) must not be called while a UoW is open on the same path "
-            "(CLAUDE.md → Invariant register). Snapshot inside the UoW, close it, then "
-            "resolve outside."
-        )
+        # Only summarise the rules that actually fired, so the closing advice
+        # matches the findings above it.
+        if any(_DEADLOCK_REMEDY in line for line in findings):
+            print()
+            print(
+                "ERROR: a UoW-opening seam (ActiveCoreResolver / RelaunchOptionsResolver / "
+                "uow_factory) must not be called while a UoW is open on the same path "
+                "(CLAUDE.md → Invariant register). Snapshot inside the UoW, close it, then "
+                "resolve outside."
+            )
+        if any(_WRITE_LOCK_REMEDY in line for line in findings):
+            print()
+            print(
+                "ERROR: a file-I/O seam (DiscResolver / CoreInfoProvider / SystemResolver) "
+                "must not be called while a UoW is open — a Unit of Work wraps database "
+                "reads and writes only, never file or server I/O (CLAUDE.md → Invariant "
+                "register, CONTEXT.md → Unit of Work, ADR-0006). Snapshot inside the UoW, "
+                "close it, then do the I/O outside."
+            )
         return 1
     print(f"OK: no nested UoW-seam calls in {SERVICES_DIR.relative_to(REPO_ROOT)}.")
     return 0

--- a/scripts/check_uow_seam_nesting.py
+++ b/scripts/check_uow_seam_nesting.py
@@ -73,14 +73,17 @@ own) has no method name to match: the consumer writes
 ``self._candidate_probe(...)``, never the seam's own name. Rule 1 leaves it
 open — the ``current_save_sorting`` / ``has_adoption_candidate`` entries guard
 only call sites that name the method, which is the owning service's own and any
-peer holding the object rather than the bound method. Rule 2's one call-shaped
-seam, ``SystemResolver``, is closed the cheap way instead: every consumer in
-``services/`` binds it to ``self._resolve_system``, so that attribute name is
-listed beside ``resolve_system``, the implementation's own method name
-(``RommHttpAdapter.resolve_system``, for a peer holding the object). That is a
-convention, not a guarantee — a consumer binding it under a different attribute
-slips past. Doing the same for rule 1 means a second list of holding attributes
-to keep in step, and is not built.
+peer holding the object rather than the bound method. Rule 2's three
+call-shaped seams are closed the cheap way instead: every consumer in
+``services/`` binds each to one attribute — ``self._resolve_system``,
+``self._system_extensions``, ``self._system_known`` — and those attribute names
+are what the list carries (``resolve_system`` is listed beside its own, being
+the implementation's real method name, ``RommHttpAdapter.resolve_system``, for
+a peer holding the object; the other two have no such twin). That is a
+convention, not a guarantee — a consumer binding one under a different
+attribute slips past, and it only works while the attribute name means one
+thing. Doing the same for rule 1 means a second list of holding attributes to
+keep in step, and is not built.
 
 Conversely, matching only *attribute* calls is what keeps the ``enumerate_discs``
 entry safe: the pure ``domain.disc_selection.enumerate_discs`` does no I/O of
@@ -94,16 +97,13 @@ two decisions, not a survey of what touches the disk. Neither is exempt from the
 rule — a UoW held across either is a breach — and the reason is not that their
 I/O matters less:
 
-* The **call-shaped file seams** — ``SystemSupportedExtensionsFn`` and
-  ``SystemKnownFn`` (both reach ``es_systems.xml``) and ``DirectoryFileListerFn``
-  (a directory listing). These are matchable *today*: every consumer happens to
-  bind them to ``self._system_extensions`` / ``self._system_known`` /
-  ``self._list_files``, so listing those attribute names would work on exactly
-  the convention that carries ``_resolve_system``. Leaving them out is a scope
-  decision, not a limit of the mechanism. What does differ is the quality of the
-  match: ``get_emulator_options`` names one seam and nothing else, whereas
-  ``_list_files`` is a name any class might bind to something unrelated, so an
-  entry would key the gate on a naming coincidence.
+* ``DirectoryFileListerFn`` — a directory listing, and its consumer binds it to
+  ``self._list_files``. Its two call-shaped siblings are *in* the list, matched
+  by the attribute they are bound to, so the mechanism plainly reaches this
+  shape; what stops this one is the name. ``_list_files`` says nothing about
+  which seam it holds — any class might bind it to something unrelated — so an
+  entry would key the gate on a coincidence, where ``_system_extensions`` and
+  ``_resolve_system`` each mean one thing.
 * ``RetroDeckPaths``'s path getters sit behind a 30-second TTL cache
   (``adapters/retrodeck_paths.py``), so a call is usually a dict lookup and a
   ban would fire mostly where nothing is spent — which teaches writers to reach
@@ -193,6 +193,16 @@ IO_SEAM_METHODS: frozenset[str] = frozenset(
         # `resolve_system`, the implementation's own method name.
         "resolve_system",
         "_resolve_system",
+        # SystemSupportedExtensionsFn / SystemKnownFn (services/protocols/paths.py)
+        # — two questions to es_systems.xml, through the same every-call flatpak
+        # probe as the CoreInfoProvider reads above. Both Protocols are
+        # call-shaped, and unlike SystemResolver there is no method name a
+        # service could write beside the attribute: the implementations
+        # (CoreResolver.get_supported_extensions / .is_known_system) are on no
+        # Protocol a service holds. So the attribute is all there is, and it is
+        # matchable because each of these means one thing in the tree.
+        "_system_extensions",
+        "_system_known",
     }
 )
 

--- a/scripts/check_uow_seam_nesting.py
+++ b/scripts/check_uow_seam_nesting.py
@@ -18,13 +18,14 @@ fixed via #1155). The seams live in :data:`SEAM_METHODS`.
 **Rule 2 — a seam that touches the disk holds the write lock across the I/O.**
 ``BEGIN IMMEDIATE`` takes the write lock at the top of the block, so **even a
 read-only UoW is a writer**. The database runs in WAL, so readers are
-unaffected; any other *writer* that arrives blocks and gives up after
-``busy_timeout=5000``. A directory walk or a config parse held inside a UoW
-therefore stalls those writers for as long as the I/O takes. CONTEXT.md's Unit
-of Work entry and ADR-0006 state the rule — a transaction wraps database reads
-and writes, never file or server I/O — and until #1779 nothing detected a
-breach: six call sites had drifted across it, because nothing at a call site
-reveals that an injected seam touches the disk. The seams live in
+unaffected; any other *writer* that arrives waits on the lock for up to
+``busy_timeout=5000`` and fails with ``SQLITE_BUSY`` only if it is still held
+then. A directory walk or a config parse held inside a UoW therefore stalls
+those writers for as long as the I/O takes. CONTEXT.md's Unit of Work entry and
+ADR-0006 state the rule — a transaction wraps database reads and writes, never
+file or server I/O — and until #1779 nothing detected a breach: six call sites
+had drifted across it, because nothing at a call site reveals that an injected
+seam touches the disk. The seams live in
 :data:`IO_SEAM_METHODS`. Both the rule and this check come from reading the
 code; nothing here rests on a measurement of how long any of those
 transactions actually held the lock.
@@ -66,30 +67,32 @@ spots apply to **both** families:
 * Both seam lists are hand-maintained. A seam whose implementation *grows* a
   UoW open or a file read later is not detected until someone adds its name.
 
-One blind spot is rule 1's alone. **A seam injected as a call-shaped Protocol**
-(``__call__``, no method name of its own) is invisible to it: the consumer
-writes ``self._candidate_probe(...)``, never the seam's own name, so the
-``current_save_sorting`` / ``has_adoption_candidate`` entries guard only call
-sites that name the method — the owning service's own, and any peer holding the
-object rather than the bound method. Closing that generally means matching the
-holding attribute too, which is a second list to keep in step and is not built.
-Rule 2 has one call-shaped seam, ``SystemResolver``, and closes it the cheap way
-instead: every consumer in ``services/`` binds it to ``self._resolve_system``,
-so that attribute name is listed beside ``resolve_system``, the implementation's
-own method name (``RommHttpAdapter.resolve_system``, for a peer holding the
-object). That is a convention, not a guarantee — a consumer that binds it under
-a different attribute slips past.
+One blind spot is **shared by both families, and only one of them closes it**.
+A seam injected as a call-shaped Protocol (``__call__``, no method name of its
+own) has no method name to match: the consumer writes
+``self._candidate_probe(...)``, never the seam's own name. Rule 1 leaves it
+open — the ``current_save_sorting`` / ``has_adoption_candidate`` entries guard
+only call sites that name the method, which is the owning service's own and any
+peer holding the object rather than the bound method. Rule 2's one call-shaped
+seam, ``SystemResolver``, is closed the cheap way instead: every consumer in
+``services/`` binds it to ``self._resolve_system``, so that attribute name is
+listed beside ``resolve_system``, the implementation's own method name
+(``RommHttpAdapter.resolve_system``, for a peer holding the object). That is a
+convention, not a guarantee — a consumer binding it under a different attribute
+slips past. Doing the same for rule 1 means a second list of holding attributes
+to keep in step, and is not built.
 
 Conversely, matching only *attribute* calls is what keeps the ``enumerate_discs``
 entry safe: the pure ``domain.disc_selection.enumerate_discs`` does no I/O of
 its own, and its one consumer imports it bare. Written dotted it *would* be
 flagged — the safety is in the call site's bare import, not in the name.
 
-Seams deliberately left out
----------------------------
-Two families of disk-touching seam are outside :data:`IO_SEAM_METHODS`. Neither
-is exempt from the rule — a UoW held across either is a breach — and the reason
-is not that their I/O matters less:
+Seams considered and left out
+-----------------------------
+These were weighed for :data:`IO_SEAM_METHODS` and kept out. It is a record of
+two decisions, not a survey of what touches the disk. Neither is exempt from the
+rule — a UoW held across either is a breach — and the reason is not that their
+I/O matters less:
 
 * The **call-shaped file seams** — ``SystemSupportedExtensionsFn`` and
   ``SystemKnownFn`` (both reach ``es_systems.xml``) and ``DirectoryFileListerFn``
@@ -98,26 +101,25 @@ is not that their I/O matters less:
   ``self._list_files``, so listing those attribute names would work on exactly
   the convention that carries ``_resolve_system``. Leaving them out is a scope
   decision, not a limit of the mechanism. What does differ is the quality of the
-  match: ``enumerate_discs`` or ``get_emulator_options`` name one seam and
-  nothing else, whereas ``_list_files`` is a name any class might bind to
-  something unrelated, so an entry would key the gate on a naming coincidence.
+  match: ``get_emulator_options`` names one seam and nothing else, whereas
+  ``_list_files`` is a name any class might bind to something unrelated, so an
+  entry would key the gate on a naming coincidence.
 * ``RetroDeckPaths``'s path getters sit behind a 30-second TTL cache
   (``adapters/retrodeck_paths.py``), so a call is usually a dict lookup and a
   ban would fire mostly where nothing is spent — which teaches writers to reach
-  for a pragma instead of looking. The caveat is that the cache is only warm
-  when there is a file to cache: a missing ``retrodeck.json`` deliberately
-  records no cache time, so on a machine without RetroDECK every getter reopens.
+  for a pragma instead of looking. The caveat is that only a successfully-read
+  config is ever cached, and the TTL guard tests the cached value first, so on a
+  machine without RetroDECK every getter reopens.
 
 The escape hatch is a trailing comment on the seam-call line:
 
     self._active_core.active_core_for_rom(rom_id)  # pragma: no uow-check
 
 **One pragma covers both families,** because it suppresses the *line*, not a
-named rule. No seam is in both lists, and where one line names two seams —
-``get_emulator_options(self._resolve_system(slug))`` was the pre-#1779
-``services/cores.py`` shape, on one line — the pragma silences both. A second
-spelling would only ask the writer to restate what the failure message already
-told them, and would have to be written twice on that line.
+named rule — so a line naming more than one seam, such as
+``get_emulator_options(self._resolve_system(slug))``, is silenced by the single
+comment on it. A rule-named spelling would only ask the writer to restate what
+the failure message already told them.
 
 Exit 0 on no findings, exit 1 if any findings (one line per finding).
 """
@@ -169,12 +171,12 @@ IO_SEAM_METHODS: frozenset[str] = frozenset(
         "resolve_for_install",
         # CoreInfoProvider (services/protocols/paths.py) — all four reads of
         # RetroDECK's ES-DE configuration. Each re-probes the flatpak install
-        # roots for es_systems.xml and re-stats it before it may answer from the
-        # parse cache; get_emulator_options additionally globs every option's
-        # emulator install, and resolve_sandbox_launcher reads es_find_rules.xml.
-        # Listing one of the four would be arbitrary — services/firmware.py calls
-        # two of them inside one loop, and services/active_core_resolver.py the
-        # other two.
+        # roots for ITS file and re-stats it before it may answer from the parse
+        # cache: es_systems.xml for the first three, es_find_rules.xml for
+        # resolve_sandbox_launcher. get_emulator_options touches both — it globs
+        # every option's emulator install through the find rules. Listing one of
+        # the four would be arbitrary: services/firmware.py calls two of them
+        # inside one loop, and services/active_core_resolver.py the other two.
         "get_active_core",
         "get_default_emulator",
         "get_emulator_options",
@@ -203,8 +205,8 @@ UOW_FACTORY_SUFFIX = "uow_factory"
 ESCAPE_HATCH = "pragma: no uow-check"
 
 # The two remedies are one sentence apart, but the hazard behind them is not:
-# rule 1 hangs this operation, rule 2 hangs every other one. A reader who hits
-# either message has to be able to tell which rule they broke.
+# rule 1 hangs this operation, rule 2 holds every other writer up. A reader who
+# hits either message has to be able to tell which rule they broke.
 _DEADLOCK_REMEDY = (
     "snapshot inside the UoW, close it, "
     "then resolve outside (the nested BEGIN IMMEDIATE deadlocks → 'database is locked')"
@@ -212,8 +214,8 @@ _DEADLOCK_REMEDY = (
 _WRITE_LOCK_REMEDY = (
     "snapshot inside the UoW, close it, "
     "then do the I/O outside (BEGIN IMMEDIATE holds the write lock even for a "
-    "read-only UoW, so every other writer in the plugin blocks for as long as the I/O "
-    "takes, then fails at busy_timeout)"
+    "read-only UoW, so every other writer in the plugin waits for as long as the I/O "
+    "takes, up to busy_timeout)"
 )
 
 

--- a/scripts/check_uow_seam_nesting.py
+++ b/scripts/check_uow_seam_nesting.py
@@ -15,17 +15,19 @@ is invisible there — it only surfaces on a real device. The hazard has bitten
 four sites across three issues (#1047, #1134 twice, and the migration site
 fixed via #1155). The seams live in :data:`SEAM_METHODS`.
 
-**Rule 2 — a seam that touches the disk holds the write lock for the whole
-walk.** ``BEGIN IMMEDIATE`` takes the database's global write lock at the top
-of the block, so **even a read-only UoW is a writer** as far as every other
-connection is concerned, and they each give up after ``busy_timeout=5000``. A
-directory walk or a config parse held inside a UoW therefore stalls every other
-writer in the plugin for as long as the I/O takes. CONTEXT.md's Unit of Work
-entry and ADR-0006 state the rule — a transaction wraps database reads and
-writes, never file or server I/O — and until #1779 nothing detected a breach:
-six call sites had drifted across it, because nothing at a call site reveals
-that an injected seam touches the disk. The seams live in
-:data:`IO_SEAM_METHODS`.
+**Rule 2 — a seam that touches the disk holds the write lock across the I/O.**
+``BEGIN IMMEDIATE`` takes the write lock at the top of the block, so **even a
+read-only UoW is a writer**. The database runs in WAL, so readers are
+unaffected; any other *writer* that arrives blocks and gives up after
+``busy_timeout=5000``. A directory walk or a config parse held inside a UoW
+therefore stalls those writers for as long as the I/O takes. CONTEXT.md's Unit
+of Work entry and ADR-0006 state the rule — a transaction wraps database reads
+and writes, never file or server I/O — and until #1779 nothing detected a
+breach: six call sites had drifted across it, because nothing at a call site
+reveals that an injected seam touches the disk. The seams live in
+:data:`IO_SEAM_METHODS`. Both the rule and this check come from reading the
+code; nothing here rests on a measurement of how long any of those
+transactions actually held the lock.
 
 The established fix is the same for both: snapshot the rows a seam needs
 *inside* one short UoW, close it, then call the seam *outside* any open UoW
@@ -54,37 +56,68 @@ spots apply to **both** families:
   (``fn = resolver.active_core_for_rom; fn(rom_id)``) or holding the UoW
   factory under an attribute whose name does not end in ``uow_factory`` slips
   past the name match.
+* It classifies a call by its own ``func``, so a seam **passed as a bound
+  method** is invisible — ``run_in_executor(None, resolver.enumerate_discs,
+  install)`` inside a UoW is an attribute, not a call, and is not flagged. That
+  matters more than the shape suggests: ``run_in_executor`` is how
+  ``services/disc.py`` and ``services/cores.py`` reach their ``_io`` bodies in
+  the first place. ``scripts/check_read_only_module.py`` records the same shape
+  for its own gate.
 * Both seam lists are hand-maintained. A seam whose implementation *grows* a
   UoW open or a file read later is not detected until someone adds its name.
 
-One blind spot is not symmetric between the families. **A seam injected as a
-call-shaped Protocol** (``__call__``, no method name of its own) is invisible
-under rule 1: the consumer writes ``self._candidate_probe(...)``, never the
-seam's own name, so the ``current_save_sorting`` / ``has_adoption_candidate``
-entries guard only call sites that name the method — the owning service's own,
-and any peer holding the object rather than the bound method. Closing that
-generally means matching the holding attribute too, which is a second list to
-keep in step and is not built. Rule 2 has one call-shaped seam,
-``SystemResolver``, and closes it the cheap way instead: every consumer in
-``services/`` stores it as ``self._resolve_system``, so **both** the Protocol's
-name and that attribute name are listed. That is a convention, not a
-guarantee — a consumer that binds it under a different attribute slips past.
+One blind spot is rule 1's alone. **A seam injected as a call-shaped Protocol**
+(``__call__``, no method name of its own) is invisible to it: the consumer
+writes ``self._candidate_probe(...)``, never the seam's own name, so the
+``current_save_sorting`` / ``has_adoption_candidate`` entries guard only call
+sites that name the method — the owning service's own, and any peer holding the
+object rather than the bound method. Closing that generally means matching the
+holding attribute too, which is a second list to keep in step and is not built.
+Rule 2 has one call-shaped seam, ``SystemResolver``, and closes it the cheap way
+instead: every consumer in ``services/`` binds it to ``self._resolve_system``,
+so that attribute name is listed beside ``resolve_system``, the implementation's
+own method name (``RommHttpAdapter.resolve_system``, for a peer holding the
+object). That is a convention, not a guarantee — a consumer that binds it under
+a different attribute slips past.
 
 Conversely, matching only *attribute* calls is what keeps the ``enumerate_discs``
-entry safe: the pure ``domain.disc_selection.enumerate_discs`` is called bare
-(``enumerate_discs(files, ...)``) and does no I/O of its own, so it is never
-mistaken for the seam.
+entry safe: the pure ``domain.disc_selection.enumerate_discs`` does no I/O of
+its own, and its one consumer imports it bare. Written dotted it *would* be
+flagged — the safety is in the call site's bare import, not in the name.
+
+Seams deliberately left out
+---------------------------
+Two families of disk-touching seam are outside :data:`IO_SEAM_METHODS`. Neither
+is exempt from the rule — a UoW held across either is a breach — and the reason
+is not that their I/O matters less:
+
+* The **call-shaped file seams** — ``SystemSupportedExtensionsFn`` and
+  ``SystemKnownFn`` (both reach ``es_systems.xml``) and ``DirectoryFileListerFn``
+  (a directory listing). These are matchable *today*: every consumer happens to
+  bind them to ``self._system_extensions`` / ``self._system_known`` /
+  ``self._list_files``, so listing those attribute names would work on exactly
+  the convention that carries ``_resolve_system``. Leaving them out is a scope
+  decision, not a limit of the mechanism. What does differ is the quality of the
+  match: ``enumerate_discs`` or ``get_emulator_options`` name one seam and
+  nothing else, whereas ``_list_files`` is a name any class might bind to
+  something unrelated, so an entry would key the gate on a naming coincidence.
+* ``RetroDeckPaths``'s path getters sit behind a 30-second TTL cache
+  (``adapters/retrodeck_paths.py``), so a call is usually a dict lookup and a
+  ban would fire mostly where nothing is spent — which teaches writers to reach
+  for a pragma instead of looking. The caveat is that the cache is only warm
+  when there is a file to cache: a missing ``retrodeck.json`` deliberately
+  records no cache time, so on a machine without RetroDECK every getter reopens.
 
 The escape hatch is a trailing comment on the seam-call line:
 
     self._active_core.active_core_for_rom(rom_id)  # pragma: no uow-check
 
-**One pragma covers both families.** It suppresses the line, not a named rule:
-a call site names exactly one seam, and no seam is in both lists (a seam that
-both opened a UoW and walked the disk would be its own design fault), so there
-is never an ambiguity for a second pragma spelling to resolve. Requiring the
-writer to pick the right spelling would only ask them to restate what the
-failure message already told them.
+**One pragma covers both families,** because it suppresses the *line*, not a
+named rule. No seam is in both lists, and where one line names two seams —
+``get_emulator_options(self._resolve_system(slug))`` was the pre-#1779
+``services/cores.py`` shape, on one line — the pragma silences both. A second
+spelling would only ask the writer to restate what the failure message already
+told them, and would have to be written twice on that line.
 
 Exit 0 on no findings, exit 1 if any findings (one line per finding).
 """
@@ -122,27 +155,40 @@ SEAM_METHODS: frozenset[str] = frozenset(
 # --- Rule 2: seams that touch the filesystem -----------------------------
 # Method names whose implementation reads the disk. None of them opens a UoW,
 # so nothing deadlocks — the cost is duration: the UoW's BEGIN IMMEDIATE holds
-# the global write lock across the whole walk, and every other connection in
-# the plugin gives up at busy_timeout. Each entry names the Protocol it belongs
-# to and the I/O it performs.
+# the write lock across the whole walk, and any other writer that arrives gives
+# up at busy_timeout. Each entry names the Protocol it belongs to and the I/O it
+# performs. What is deliberately NOT here, and why, is in the module docstring.
 IO_SEAM_METHODS: frozenset[str] = frozenset(
     {
-        # DiscResolver (services/disc_launch_resolver.py) — recursive walk of the
-        # ROM's install directory, plus an ES-DE config read for the system's
+        # DiscResolver (services/protocols/cross_service.py) — recursive walk of
+        # the ROM's install directory, plus an ES-DE config read for the system's
         # supported extensions.
         "enumerate_discs",
-        # CoreInfoProvider (adapters/es_de_config.py) — ES-DE config discovery and
-        # parse, plus a per-option probe for whether that emulator is installed.
-        "get_emulator_options",
-        # DiscResolver (services/disc_launch_resolver.py) — the same recursive
-        # walk of the install directory, resolving the persisted disc pin over it.
+        # DiscResolver — the same recursive walk, resolving the persisted disc
+        # pin over it.
         "resolve_for_install",
-        # SystemResolver (services/protocols/paths.py) — opens and parses
-        # RetroDECK's ``config.json``. It is implemented on the RomM HTTP adapter,
-        # which the name makes easy to misread: it does no network work at all,
-        # only the file read. The Protocol is call-shaped, so ``_resolve_system``
-        # is listed with it — that is the attribute every consumer in services/
-        # binds it to, and the only spelling the matcher can see (module docstring).
+        # CoreInfoProvider (services/protocols/paths.py) — all four reads of
+        # RetroDECK's ES-DE configuration. Each re-probes the flatpak install
+        # roots for es_systems.xml and re-stats it before it may answer from the
+        # parse cache; get_emulator_options additionally globs every option's
+        # emulator install, and resolve_sandbox_launcher reads es_find_rules.xml.
+        # Listing one of the four would be arbitrary — services/firmware.py calls
+        # two of them inside one loop, and services/active_core_resolver.py the
+        # other two.
+        "get_active_core",
+        "get_default_emulator",
+        "get_emulator_options",
+        "resolve_sandbox_launcher",
+        # SystemResolver (services/protocols/paths.py) — parses the plugin's OWN
+        # bundled config.json (plugin root, else defaults/config.json) for its
+        # platform_map. Implemented on the RomM HTTP adapter, which the name makes
+        # easy to misread twice over: it does no network work, and the file is not
+        # RetroDECK's retrodeck.json. It is also the odd one out — the adapter
+        # memoises the map for the life of the process, so exactly one call ever
+        # opens the file. The entry earns its place because that one call can land
+        # inside a UoW. The Protocol is call-shaped, so `_resolve_system` — the
+        # attribute every consumer in services/ binds it to — is listed beside
+        # `resolve_system`, the implementation's own method name.
         "resolve_system",
         "_resolve_system",
     }
@@ -165,7 +211,7 @@ _DEADLOCK_REMEDY = (
 )
 _WRITE_LOCK_REMEDY = (
     "snapshot inside the UoW, close it, "
-    "then do the I/O outside (BEGIN IMMEDIATE holds the global write lock even for a "
+    "then do the I/O outside (BEGIN IMMEDIATE holds the write lock even for a "
     "read-only UoW, so every other writer in the plugin blocks for as long as the I/O "
     "takes, then fails at busy_timeout)"
 )
@@ -196,9 +242,11 @@ def _is_uow_opener(node: ast.expr) -> bool:
 def _classify(node: ast.Call) -> tuple[str, str] | None:
     """Return ``(detail, remedy)`` for a hazardous call, or None.
 
-    Only attribute calls are considered for the two seam families, so a
-    same-named module-level function (``domain.disc_selection.enumerate_discs``)
-    is never mistaken for the seam it shares a name with.
+    Only attribute calls are considered for the two seam families. A
+    module-level function sharing a seam's name
+    (``domain.disc_selection.enumerate_discs``) is therefore missed while its
+    call site imports it bare, which is how the one in the tree is written; a
+    dotted call to the same function would be flagged.
     """
     func = node.func
     if isinstance(func, ast.Attribute):

--- a/tests/fakes/fake_unit_of_work.py
+++ b/tests/fakes/fake_unit_of_work.py
@@ -99,7 +99,19 @@ class FakeUnitOfWork:
         self.committed = False
         self.rolled_back = False
         self.enter_count = 0
+        self.exit_count = 0
         self._snapshot: _Snapshot | None = None
+
+    @property
+    def is_open(self) -> bool:
+        """Whether a ``with`` block is open on this unit right now.
+
+        The real ``SqliteUnitOfWork`` holds ``BEGIN IMMEDIATE`` — SQLite's
+        global write lock — for exactly this window, and the fake shares no
+        connection, so a test cannot observe the lock and has to observe the
+        window instead. Reads True inside any depth of nesting.
+        """
+        return self.enter_count > self.exit_count
 
     def __enter__(self) -> FakeUnitOfWork:
         self.enter_count += 1
@@ -126,6 +138,7 @@ class FakeUnitOfWork:
         exc: BaseException | None,
         tb: TracebackType | None,
     ) -> None:
+        self.exit_count += 1
         snapshot = self._snapshot
         self._snapshot = None
         if exc_type is None:

--- a/tests/fakes/uow_open_probe.py
+++ b/tests/fakes/uow_open_probe.py
@@ -26,10 +26,11 @@ if TYPE_CHECKING:
 def record_uow_open(uow: FakeUnitOfWork, seam: object, method: str) -> list[bool]:
     """Wrap ``seam.method`` so every call appends ``uow.is_open`` to the returned list.
 
-    *seam* is a fake the service under test was injected with; the wrapper
-    delegates to the original, so the fake's own behavior and recording are
-    unchanged. The returned list grows as the service runs — read it after the
-    call under test.
+    *seam* is the object holding the seam — usually a fake the service under
+    test was injected with, but a service patching its own bound seam attribute
+    works the same way. The wrapper delegates to the original, so the holder's
+    own behavior and recording are unchanged. The returned list grows as the
+    service runs — read it after the call under test.
     """
     original: Callable[..., Any] = getattr(seam, method)
     observed: list[bool] = []

--- a/tests/fakes/uow_open_probe.py
+++ b/tests/fakes/uow_open_probe.py
@@ -1,0 +1,42 @@
+"""Records whether a Unit of Work was open when a seam ran.
+
+CONTEXT.md's Unit of Work entry keeps a transaction to database reads and
+writes: the real ``SqliteUnitOfWork`` opens with ``BEGIN IMMEDIATE``, SQLite's
+global write lock, so a seam doing file or server I/O inside one blocks every
+other connection in the plugin until ``busy_timeout`` gives up. A test driving
+:class:`FakeUnitOfWork` shares no connection and can never see that lock — the
+observable is the ORDER, so this wraps one seam method and records, per call,
+whether a unit was open at the moment it ran.
+
+An assertion on the recorded list is non-vacuous both ways: ``[False]`` says the
+seam ran once and ran outside, and an empty list — the seam never reached —
+fails the same assertion rather than passing it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from fakes.fake_unit_of_work import FakeUnitOfWork
+
+
+def record_uow_open(uow: FakeUnitOfWork, seam: object, method: str) -> list[bool]:
+    """Wrap ``seam.method`` so every call appends ``uow.is_open`` to the returned list.
+
+    *seam* is a fake the service under test was injected with; the wrapper
+    delegates to the original, so the fake's own behavior and recording are
+    unchanged. The returned list grows as the service runs — read it after the
+    call under test.
+    """
+    original: Callable[..., Any] = getattr(seam, method)
+    observed: list[bool] = []
+
+    def recording(*args: Any, **kwargs: Any) -> Any:
+        observed.append(uow.is_open)
+        return original(*args, **kwargs)
+
+    setattr(seam, method, recording)
+    return observed

--- a/tests/scripts/test_check_uow_seam_nesting.py
+++ b/tests/scripts/test_check_uow_seam_nesting.py
@@ -5,6 +5,12 @@ The check is loaded via ``importlib`` because ``scripts/`` is not on
 ``scan_source`` core function with small source snippets; the tmp-path
 fixture exercises the directory walk + the ``main`` entry point,
 monkeypatching the script's ``REPO_ROOT`` / ``SERVICES_DIR`` constants.
+
+The check carries two rules over one matcher — a seam that opens its own UoW
+(deadlock) and a seam that touches the disk (write lock held across the I/O).
+The first two classes cover the UoW-opening family, ``TestIoSeams*`` the
+file-I/O family, and :class:`TestFamiliesAreDistinguishable` pins that a reader
+of either failure can tell which rule they broke.
 """
 
 from __future__ import annotations
@@ -235,6 +241,246 @@ class TestScanSourceClean:
         assert check.scan_source("def (:\n", "broken.py") == []
 
 
+class TestIoSeamsViolations:
+    """The file-I/O family (#1779) — the six sites stage 1 fixed."""
+
+    def test_resolve_for_install_inside_uow_is_flagged(self):
+        # The pre-#1779 shortcut_launch_resolver shape: resolve each install's
+        # disc path (a directory walk) inside the open read UoW.
+        findings = check.scan_source(
+            "class S:\n"
+            "    def scan(self):\n"
+            "        paths = {}\n"
+            "        with self._uow_factory() as uow:\n"
+            "            for install in uow.rom_installs.iter_all():\n"
+            "                paths[install.rom_id] = self._disc_resolver.resolve_for_install(install, None)\n"
+            "        return paths\n",
+            "svc.py",
+        )
+        assert len(findings) == 1
+        assert "svc.py:6" in findings[0]
+        assert "resolve_for_install" in findings[0]
+
+    def test_enumerate_discs_inside_uow_is_flagged(self):
+        findings = check.scan_source(
+            "class S:\n"
+            "    def go(self, rom_id):\n"
+            "        with self._uow_factory() as uow:\n"
+            "            install = uow.rom_installs.get(rom_id)\n"
+            "            discs = self._disc_resolver.enumerate_discs(install)\n"
+            "        return discs\n",
+            "svc.py",
+        )
+        assert len(findings) == 1
+        assert "enumerate_discs" in findings[0]
+
+    def test_get_emulator_options_inside_uow_is_flagged(self):
+        findings = check.scan_source(
+            "class S:\n"
+            "    def go(self, system):\n"
+            "        with self._uow_factory() as uow:\n"
+            "            options = self._core_info.get_emulator_options(system)\n"
+            "        return options\n",
+            "svc.py",
+        )
+        assert len(findings) == 1
+        assert "get_emulator_options" in findings[0]
+
+    def test_private_resolve_system_attribute_inside_uow_is_flagged(self):
+        # SystemResolver is call-shaped, so no consumer ever writes the Protocol's
+        # own name — the attribute they all bind it to is what must be matched.
+        findings = check.scan_source(
+            "class S:\n"
+            "    def go(self, rom_id):\n"
+            "        with self._uow_factory() as uow:\n"
+            "            rom = uow.roms.get(rom_id)\n"
+            "            system = self._resolve_system(rom.platform_slug)\n"
+            "        return system\n",
+            "svc.py",
+        )
+        assert len(findings) == 1
+        assert "_resolve_system" in findings[0]
+
+    def test_public_resolve_system_attribute_inside_uow_is_flagged(self):
+        # A peer holding the resolver object rather than the bound method.
+        findings = check.scan_source(
+            "class S:\n"
+            "    def go(self, slug):\n"
+            "        with self._uow_factory() as uow:\n"
+            "            system = self._paths.resolve_system(slug)\n"
+            "        return system\n",
+            "svc.py",
+        )
+        assert len(findings) == 1
+        assert "resolve_system" in findings[0]
+
+    def test_io_seam_inside_try_within_uow_is_flagged(self):
+        findings = check.scan_source(
+            "class S:\n"
+            "    def go(self, install):\n"
+            "        with self._uow_factory() as uow:\n"
+            "            try:\n"
+            "                discs = self._disc_resolver.enumerate_discs(install)\n"
+            "            except OSError:\n"
+            "                discs = []\n"
+            "        return discs\n",
+            "svc.py",
+        )
+        assert len(findings) == 1
+        assert "enumerate_discs" in findings[0]
+
+    def test_io_seam_inside_config_held_factory_is_flagged(self):
+        findings = check.scan_source(
+            "class S:\n"
+            "    def go(self, install):\n"
+            "        with config.uow_factory() as uow:\n"
+            "            return self._disc_resolver.enumerate_discs(install)\n",
+            "svc.py",
+        )
+        assert len(findings) == 1
+        assert "enumerate_discs" in findings[0]
+
+
+class TestIoSeamsClean:
+    def test_io_seam_after_uow_closes_is_clean(self):
+        # The canonical #1779 fix: snapshot inside the UoW, walk the disk after.
+        findings = check.scan_source(
+            "class S:\n"
+            "    def scan(self):\n"
+            "        pending = []\n"
+            "        with self._uow_factory() as uow:\n"
+            "            for install in uow.rom_installs.iter_all():\n"
+            "                pending.append(install)\n"
+            "        return [self._disc_resolver.resolve_for_install(i, None) for i in pending]\n",
+            "svc.py",
+        )
+        assert findings == []
+
+    def test_io_seam_never_inside_any_uow_is_clean(self):
+        findings = check.scan_source(
+            "class S:\n    def go(self, install):\n        return self._disc_resolver.enumerate_discs(install)\n",
+            "svc.py",
+        )
+        assert findings == []
+
+    def test_bare_module_function_of_the_same_name_is_clean(self):
+        # ``domain.disc_selection.enumerate_discs`` is a pure list transform that
+        # touches nothing, and it is called by name. Only attribute calls are
+        # seams, so the shared name costs nothing.
+        findings = check.scan_source(
+            "from domain.disc_selection import enumerate_discs\n"
+            "class S:\n"
+            "    def go(self, rom_id):\n"
+            "        with self._uow_factory() as uow:\n"
+            "            files = uow.rom_installs.get(rom_id).files\n"
+            "            discs = enumerate_discs(files, None)\n"
+            "        return discs\n",
+            "svc.py",
+        )
+        assert findings == []
+
+    def test_io_seam_in_helper_defined_inside_uow_is_clean(self):
+        # Same scope reset as the UoW-opening family: a nested def is a new scope.
+        findings = check.scan_source(
+            "class S:\n"
+            "    def go(self, install):\n"
+            "        with self._uow_factory() as uow:\n"
+            "            def helper():\n"
+            "                return self._disc_resolver.enumerate_discs(install)\n"
+            "            uow.roms.touch(1)\n"
+            "        return helper\n",
+            "svc.py",
+        )
+        assert findings == []
+
+    def test_io_seam_in_lambda_inside_uow_is_clean(self):
+        findings = check.scan_source(
+            "class S:\n"
+            "    def go(self, install):\n"
+            "        with self._uow_factory() as uow:\n"
+            "            fn = lambda: self._disc_resolver.enumerate_discs(install)\n"
+            "        return fn\n",
+            "svc.py",
+        )
+        assert findings == []
+
+    def test_escape_hatch_suppresses_an_io_finding(self):
+        # One pragma spelling covers both families.
+        findings = check.scan_source(
+            "class S:\n"
+            "    def go(self, install):\n"
+            "        with self._uow_factory() as uow:\n"
+            "            d = self._disc_resolver.enumerate_discs(install)  # pragma: no uow-check\n"
+            "        return d\n",
+            "svc.py",
+        )
+        assert findings == []
+
+
+class TestFamiliesAreDistinguishable:
+    """Each family names its own hazard — the messages must not collapse."""
+
+    def _one(self, source: str) -> str:
+        findings = check.scan_source(source, "svc.py")
+        assert len(findings) == 1
+        return findings[0]
+
+    def test_uow_opening_seam_reports_the_deadlock(self):
+        finding = self._one(
+            "class S:\n"
+            "    def go(self, rom_id):\n"
+            "        with self._uow_factory() as uow:\n"
+            "            return self._active_core.active_core_for_rom(rom_id)\n"
+        )
+        assert "UoW-opening seam" in finding
+        assert "deadlock" in finding
+        assert "database is locked" in finding
+        assert "file-I/O seam" not in finding
+
+    def test_io_seam_reports_the_held_write_lock(self):
+        finding = self._one(
+            "class S:\n"
+            "    def go(self, install):\n"
+            "        with self._uow_factory() as uow:\n"
+            "            return self._disc_resolver.enumerate_discs(install)\n"
+        )
+        assert "file-I/O seam" in finding
+        assert "global write lock" in finding
+        assert "busy_timeout" in finding
+        assert "deadlock" not in finding
+        assert "UoW-opening seam" not in finding
+
+    def test_nested_open_is_reported_as_the_deadlock_rule(self):
+        finding = self._one(
+            "class S:\n"
+            "    def run(self):\n"
+            "        with self._uow_factory() as uow:\n"
+            "            with self._uow_factory() as uow2:\n"
+            "                uow2.roms.touch(1)\n"
+        )
+        assert "nested UoW open" in finding
+        assert "database is locked" in finding
+
+    def test_both_families_in_one_block_are_reported_separately(self):
+        findings = check.scan_source(
+            "class S:\n"
+            "    def go(self, rom_id, install):\n"
+            "        with self._uow_factory() as uow:\n"
+            "            core = self._active_core.active_core_for_rom(rom_id)\n"
+            "            discs = self._disc_resolver.enumerate_discs(install)\n"
+            "        return core, discs\n",
+            "svc.py",
+        )
+        assert len(findings) == 2
+        assert sum("UoW-opening seam" in f for f in findings) == 1
+        assert sum("file-I/O seam" in f for f in findings) == 1
+
+    def test_no_seam_is_in_both_families(self):
+        # The one-pragma-covers-both argument in the module docstring rests on a
+        # call site naming exactly one rule.
+        assert not check.SEAM_METHODS & check.IO_SEAM_METHODS
+
+
 class TestFindViolationsWalk:
     def test_walk_finds_and_relativises(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
         services_dir = tmp_path / "py_modules" / "services"
@@ -275,7 +521,8 @@ class TestMainEntryPoint:
         assert check.main(["-h"]) == 0
 
     def test_real_repo_run_is_clean(self, capsys):
-        # The four motivating sites are fixed; the real services/ tree must pass.
+        # Both families' motivating sites are fixed — the four deadlock ones and
+        # the six file-I/O ones (#1779); the real services/ tree must pass.
         rc = check.main([])
         assert rc == 0
         assert "OK:" in capsys.readouterr().out
@@ -298,3 +545,48 @@ class TestMainEntryPoint:
         out = capsys.readouterr().out
         assert "active_core_for_rom" in out
         assert "ERROR:" in out
+        # Only the rule that fired is summarised.
+        assert "file-I/O seam" not in out
+
+    def test_main_summarises_only_the_io_rule_for_io_findings(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+    ):
+        services_dir = tmp_path / "py_modules" / "services"
+        services_dir.mkdir(parents=True)
+        (services_dir / "bad.py").write_text(
+            "class S:\n"
+            "    def go(self, install):\n"
+            "        with self._uow_factory() as uow:\n"
+            "            return self._disc_resolver.resolve_for_install(install, None)\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(check, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(check, "SERVICES_DIR", services_dir)
+
+        rc = check.main([])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "resolve_for_install" in out
+        assert "never file or server I/O" in out
+        assert "UoW-opening seam" not in out
+
+    def test_main_summarises_both_rules_when_both_fire(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys):
+        services_dir = tmp_path / "py_modules" / "services"
+        services_dir.mkdir(parents=True)
+        (services_dir / "bad.py").write_text(
+            "class S:\n"
+            "    def go(self, rom_id, install):\n"
+            "        with self._uow_factory() as uow:\n"
+            "            core = self._active_core.active_core_for_rom(rom_id)\n"
+            "            return core, self._disc_resolver.enumerate_discs(install)\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(check, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(check, "SERVICES_DIR", services_dir)
+
+        rc = check.main([])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert out.count("ERROR:") == 2
+        assert "must not be called while a UoW is open on the same path" in out
+        assert "never file or server I/O" in out

--- a/tests/scripts/test_check_uow_seam_nesting.py
+++ b/tests/scripts/test_check_uow_seam_nesting.py
@@ -20,10 +20,10 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import pytest
+
 if TYPE_CHECKING:
     from types import ModuleType
-
-    import pytest
 
 _SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_uow_seam_nesting.py"
 
@@ -242,7 +242,7 @@ class TestScanSourceClean:
 
 
 class TestIoSeamsViolations:
-    """The file-I/O family (#1779) — the six sites stage 1 fixed."""
+    """The file-I/O family: every shape the matcher must flag (#1779)."""
 
     def test_resolve_for_install_inside_uow_is_flagged(self):
         # The pre-#1779 shortcut_launch_resolver shape: resolve each install's
@@ -274,17 +274,24 @@ class TestIoSeamsViolations:
         assert len(findings) == 1
         assert "enumerate_discs" in findings[0]
 
-    def test_get_emulator_options_inside_uow_is_flagged(self):
+    @pytest.mark.parametrize(
+        "method",
+        ["get_active_core", "get_default_emulator", "get_emulator_options", "resolve_sandbox_launcher"],
+    )
+    def test_every_core_info_read_inside_uow_is_flagged(self, method: str):
+        # All four CoreInfoProvider reads re-probe the same ES-DE files, so the
+        # family covers the Protocol, not one method of it.
         findings = check.scan_source(
             "class S:\n"
             "    def go(self, system):\n"
             "        with self._uow_factory() as uow:\n"
-            "            options = self._core_info.get_emulator_options(system)\n"
-            "        return options\n",
+            f"            answer = self._core_info.{method}(system)\n"
+            "        return answer\n",
             "svc.py",
         )
         assert len(findings) == 1
-        assert "get_emulator_options" in findings[0]
+        assert method in findings[0]
+        assert "file-I/O seam" in findings[0]
 
     def test_private_resolve_system_attribute_inside_uow_is_flagged(self):
         # SystemResolver is call-shaped, so no consumer ever writes the Protocol's
@@ -416,6 +423,29 @@ class TestIoSeamsClean:
         )
         assert findings == []
 
+    def test_one_pragma_suppresses_two_seams_on_one_line(self):
+        # The pre-#1779 cores.py shape: both seams on a single line. The pragma
+        # suppresses the line, so it silences both — there is no second spelling
+        # to get wrong. The un-pragma'd twin proves the line really carries two.
+        line = "            o = self._core_info.get_emulator_options(self._resolve_system(slug))"
+        source = "class S:\n    def go(self, slug):\n        with self._uow_factory() as uow:\n{}\n        return o\n"
+
+        assert len(check.scan_source(source.format(line), "svc.py")) == 2
+        assert check.scan_source(source.format(line + "  # pragma: no uow-check"), "svc.py") == []
+
+    def test_bound_method_passed_as_an_argument_is_a_known_blind_spot(self):
+        # NOT a desired outcome — a recorded limit. Classification looks at a
+        # call's own func, so a seam handed to run_in_executor is an attribute,
+        # not a call, and passes. Closing it should turn this test red so the
+        # docstrings that name the blind spot get corrected with it. The called
+        # twin proves the seam is one the family otherwise catches here.
+        body = "class S:\n    def go(self, install):\n        with self._uow_factory() as uow:\n            return {}\n"
+
+        assert (
+            check.scan_source(body.format("self._loop.run_in_executor(None, self._d.enumerate_discs, i)"), "s.py") == []
+        )
+        assert len(check.scan_source(body.format("self._d.enumerate_discs(install)"), "s.py")) == 1
+
 
 class TestFamiliesAreDistinguishable:
     """Each family names its own hazard — the messages must not collapse."""
@@ -445,7 +475,7 @@ class TestFamiliesAreDistinguishable:
             "            return self._disc_resolver.enumerate_discs(install)\n"
         )
         assert "file-I/O seam" in finding
-        assert "global write lock" in finding
+        assert "write lock" in finding
         assert "busy_timeout" in finding
         assert "deadlock" not in finding
         assert "UoW-opening seam" not in finding

--- a/tests/scripts/test_check_uow_seam_nesting.py
+++ b/tests/scripts/test_check_uow_seam_nesting.py
@@ -293,6 +293,23 @@ class TestIoSeamsViolations:
         assert method in findings[0]
         assert "file-I/O seam" in findings[0]
 
+    @pytest.mark.parametrize("attribute", ["_resolve_system", "_system_extensions", "_system_known"])
+    def test_call_shaped_seams_are_matched_by_their_holding_attribute(self, attribute: str):
+        # These Protocols are __call__-only, so no consumer ever writes a method
+        # name — the attribute each is bound to is the only thing to match, and
+        # it works because each of these names means one thing in the tree.
+        findings = check.scan_source(
+            "class S:\n"
+            "    def go(self, system):\n"
+            "        with self._uow_factory() as uow:\n"
+            f"            answer = self.{attribute}(system)\n"
+            "        return answer\n",
+            "svc.py",
+        )
+        assert len(findings) == 1
+        assert attribute in findings[0]
+        assert "file-I/O seam" in findings[0]
+
     def test_private_resolve_system_attribute_inside_uow_is_flagged(self):
         # SystemResolver is call-shaped, so no consumer ever writes the Protocol's
         # own name — the attribute they all bind it to is what must be matched.

--- a/tests/scripts/test_check_uow_seam_nesting.py
+++ b/tests/scripts/test_check_uow_seam_nesting.py
@@ -424,9 +424,10 @@ class TestIoSeamsClean:
         assert findings == []
 
     def test_one_pragma_suppresses_two_seams_on_one_line(self):
-        # The pre-#1779 cores.py shape: both seams on a single line. The pragma
-        # suppresses the line, so it silences both — there is no second spelling
-        # to get wrong. The un-pragma'd twin proves the line really carries two.
+        # Nothing forces a seam onto its own line: one expression can name two.
+        # The pragma suppresses the line, so it silences both — there is no
+        # second spelling to get wrong. The un-pragma'd twin proves the line
+        # really carries two.
         line = "            o = self._core_info.get_emulator_options(self._resolve_system(slug))"
         source = "class S:\n    def go(self, slug):\n        with self._uow_factory() as uow:\n{}\n        return o\n"
 

--- a/tests/services/library/test_shortcut_launch_resolver.py
+++ b/tests/services/library/test_shortcut_launch_resolver.py
@@ -7,8 +7,12 @@ seam the sync's bake sites draw from — rather than a mock of it.
 The disc-resolved install paths (``do_scan_installed_paths`` /
 ``do_read_installed_paths``) are pinned in ``tests/services/test_disc_bake_sites.py``
 alongside the other launch-bake sites, so a change to the disc pin's handling
-fails every site at once.
+fails every site at once. What is pinned HERE about those two is the boundary
+that belongs to this module rather than to the disc pin: neither of them may
+hold a Unit of Work open across the resolver's directory listing.
 """
+
+from fakes.uow_open_probe import record_uow_open
 
 from domain.shortcut_data import EmulatorInvocation
 
@@ -66,3 +70,37 @@ class TestBuildCoreOverrides:
             [{"id": 10, "platform_slug": "n64"}]
         )
         assert result == {}
+
+
+class TestInstallPathReadsCloseTheUnitOfWorkFirst:
+    """Neither install-path read holds a UoW open across the disc resolver.
+
+    ``resolve_for_install`` lists the install directory, once per installed ROM.
+    A UoW takes SQLite's ``BEGIN IMMEDIATE`` write lock, so a listing held
+    inside one blocks every other writer in the plugin for the whole scan
+    (CONTEXT.md → Unit of Work, #1779). ``FakeUnitOfWork`` shares no connection,
+    so what a test can see is the ordering: the rows are snapshotted inside the
+    transaction and every resolve runs after it closes.
+    """
+
+    def test_scan_resolves_after_the_unit_of_work_closes(self, plugin):
+        _seed_install(plugin, 10, file_path="/roms/psx/a.chd", platform_slug="psx")
+        _seed_install(plugin, 11, file_path="/roms/psx/b.chd", platform_slug="psx")
+        resolver = plugin._sync_service._shortcut_launch_resolver
+        open_at_resolve = record_uow_open(plugin._uow, resolver._disc_resolver, "resolve_for_install")
+
+        paths = resolver.do_scan_installed_paths()
+
+        assert set(paths) == {10, 11}
+        assert open_at_resolve == [False, False]
+
+    def test_read_resolves_after_the_unit_of_work_closes(self, plugin):
+        _seed_install(plugin, 10, file_path="/roms/psx/a.chd", platform_slug="psx")
+        _seed_install(plugin, 11, file_path="/roms/psx/b.chd", platform_slug="psx")
+        resolver = plugin._sync_service._shortcut_launch_resolver
+        open_at_resolve = record_uow_open(plugin._uow, resolver._disc_resolver, "resolve_for_install")
+
+        paths = resolver.do_read_installed_paths({10, 11})
+
+        assert set(paths) == {10, 11}
+        assert open_at_resolve == [False, False]

--- a/tests/services/test_cores.py
+++ b/tests/services/test_cores.py
@@ -722,13 +722,34 @@ def _retire_rom_between_transactions(uow: FakeUnitOfWork, core_info: FakeCoreInf
     core_info.get_emulator_options = retiring
 
 
+def _move_platform_between_transactions(
+    uow: FakeUnitOfWork, core_info: FakeCoreInfoProvider, rom_id: int, *, platform_slug: str
+) -> None:
+    """Re-sync the ROM onto a different platform while the options are read.
+
+    ``platform_slug`` is a synced-identity column, so a sync UPSERT landing in
+    the window between the two transactions rewrites it — and the label was
+    resolved against the platform the first transaction read.
+    """
+    get_emulator_options = core_info.get_emulator_options
+
+    def resyncing(system_name):
+        with uow:
+            _seed_rom(uow, rom_id=rom_id, platform_slug=platform_slug, shortcut_app_id=99)
+        return get_emulator_options(system_name)
+
+    core_info.get_emulator_options = resyncing
+
+
 class TestSetGameCoreTransactionBoundary:
     """The label resolution runs between transactions, never inside one.
 
-    The slug→system resolver parses ``config.json`` and the emulator-options
-    read probes ES-DE's config plus each option's install. A UoW takes SQLite's
-    ``BEGIN IMMEDIATE`` write lock, so either read held inside one stalls every
-    other writer in the plugin (CONTEXT.md → Unit of Work, #1779).
+    The emulator-options read re-probes ES-DE's config and each option's
+    install on every call; the slug→system resolver parses the plugin's own
+    ``config.json`` once and memoises it for the life of the process, so it is
+    the first call that can land on the file. A UoW takes SQLite's ``BEGIN
+    IMMEDIATE`` write lock, so either read held inside one stalls every other
+    writer for its duration (CONTEXT.md → Unit of Work, #1779).
     ``FakeUnitOfWork`` shares no connection, so what a test can see is the
     ordering.
     """
@@ -755,3 +776,19 @@ class TestSetGameCoreTransactionBoundary:
         assert result["success"] is False
         assert result["reason"] == "not_found"
         assert "42" in result["message"]
+
+    def test_platform_moved_between_transactions_refuses_the_pin(self, event_loop, service, uow, core_info):
+        # The label resolved against "snes"; the row is "psx" by the time it
+        # would be written, so it was never checked against the platform it will
+        # resolve under. The single-transaction version could not see this.
+        _seed_rom(uow, rom_id=42, platform_slug="snes", shortcut_app_id=99)
+        _seed_install(uow, rom_id=42, file_path="/roms/snes/mario.sfc")
+        _move_platform_between_transactions(uow, core_info, 42, platform_slug="psx")
+
+        result = event_loop.run_until_complete(service.set_game_core(42, "bsnes"))
+
+        assert result["success"] is False
+        assert result["reason"] == "core_unavailable"
+        assert "psx" in result["message"]
+        with uow as u:
+            assert u.roms.get(42).emulator_override is None

--- a/tests/services/test_cores.py
+++ b/tests/services/test_cores.py
@@ -789,6 +789,11 @@ class TestSetGameCoreTransactionBoundary:
 
         assert result["success"] is False
         assert result["reason"] == "core_unavailable"
+        # Names the platform the row moved to, but claims only what was checked:
+        # whether the label works there was never resolved, and finding out would
+        # cost the ES-DE read this split keeps out of the transaction.
         assert "psx" in result["message"]
+        assert "not verified" in result["message"]
+        assert "not available" not in result["message"]
         with uow as u:
             assert u.roms.get(42).emulator_override is None

--- a/tests/services/test_cores.py
+++ b/tests/services/test_cores.py
@@ -12,6 +12,7 @@ from fakes.fake_core_info_provider import FakeCoreInfoProvider, libretro_option,
 from fakes.fake_disc_resolver import FakeDiscResolver
 from fakes.fake_settings_persister import FakeSettingsPersister
 from fakes.fake_unit_of_work import FakeUnitOfWork, FakeUnitOfWorkFactory
+from fakes.uow_open_probe import record_uow_open
 
 from domain.disc_selection import Disc
 from domain.emulator_commands import options_to_payload
@@ -699,3 +700,58 @@ class TestCoreChangePreservesPinnedDisc:
             '"%EMULATOR_RETROARCH% -L /var/config/retroarch/cores/bsnes_libretro.so %ROM%" '
             '"/roms/snes/mario.sfc"'
         )
+
+
+# ── transaction boundary ───────────────────────────────────────────────
+
+
+def _retire_rom_between_transactions(uow: FakeUnitOfWork, core_info: FakeCoreInfoProvider, rom_id: int) -> None:
+    """Delete the ROM row while the emulator options are being read.
+
+    That read is the window between ``set_game_core``'s read transaction and
+    its write transaction — the moment a background sync, a finishing download
+    or the removed-game cleanup can retire the ROM from its own connection.
+    """
+    get_emulator_options = core_info.get_emulator_options
+
+    def retiring(system_name):
+        with uow:
+            uow.roms.delete(rom_id)
+        return get_emulator_options(system_name)
+
+    core_info.get_emulator_options = retiring
+
+
+class TestSetGameCoreTransactionBoundary:
+    """The label resolution runs between transactions, never inside one.
+
+    The slug→system resolver parses ``config.json`` and the emulator-options
+    read probes ES-DE's config plus each option's install. A UoW takes SQLite's
+    ``BEGIN IMMEDIATE`` write lock, so either read held inside one stalls every
+    other writer in the plugin (CONTEXT.md → Unit of Work, #1779).
+    ``FakeUnitOfWork`` shares no connection, so what a test can see is the
+    ordering.
+    """
+
+    def test_label_is_resolved_outside_the_uow(self, event_loop, service, uow, core_info):
+        _seed_rom(uow, rom_id=42, platform_slug="snes", shortcut_app_id=99)
+        _seed_install(uow, rom_id=42, file_path="/roms/snes/mario.sfc")
+        open_at_system = record_uow_open(uow, service, "_resolve_system")
+        open_at_options = record_uow_open(uow, core_info, "get_emulator_options")
+
+        result = event_loop.run_until_complete(service.set_game_core(42, "bsnes"))
+
+        assert result["success"] is True
+        assert open_at_system == [False]
+        assert open_at_options == [False]
+
+    def test_rom_retired_between_transactions_fails_not_found(self, event_loop, service, uow, core_info):
+        _seed_rom(uow, rom_id=42, platform_slug="snes", shortcut_app_id=99)
+        _seed_install(uow, rom_id=42, file_path="/roms/snes/mario.sfc")
+        _retire_rom_between_transactions(uow, core_info, 42)
+
+        result = event_loop.run_until_complete(service.set_game_core(42, "bsnes"))
+
+        assert result["success"] is False
+        assert result["reason"] == "not_found"
+        assert "42" in result["message"]

--- a/tests/services/test_disc.py
+++ b/tests/services/test_disc.py
@@ -259,6 +259,24 @@ def _retire_between_transactions(uow: FakeUnitOfWork, disc_resolver: FakeDiscRes
     disc_resolver.enumerate_discs = retiring
 
 
+def _relocate_between_transactions(uow: FakeUnitOfWork, disc_resolver: FakeDiscResolver, rom_id: int, *, rom_dir: str):
+    """Move the install to a different directory while the picker enumerates.
+
+    The same window as :func:`_retire_between_transactions`, with the install
+    replaced rather than deleted — a RetroDECK-home migration relocating the
+    ROM. The enumerated disc list still describes the old directory.
+    """
+    enumerate_discs = disc_resolver.enumerate_discs
+
+    def relocating(install):
+        discs = enumerate_discs(install)
+        with uow:
+            _seed_install(uow, rom_id=rom_id, rom_dir=rom_dir)
+        return discs
+
+    disc_resolver.enumerate_discs = relocating
+
+
 class TestTransactionBoundary:
     """Enumeration and the bake run between transactions, never inside one.
 
@@ -302,6 +320,20 @@ class TestTransactionBoundary:
         assert result["success"] is False
         assert result["reason"] == "not_installed"
         assert "message" in result
+
+    def test_bake_resolves_over_the_install_the_discs_were_enumerated_from(
+        self, event_loop, service, uow, disc_resolver
+    ):
+        _seed_rom(uow, rom_id=1, selected_disc=None)
+        _seed_install(uow, rom_id=1, rom_dir=_ROM_DIR)
+        _relocate_between_transactions(uow, disc_resolver, 1, rom_dir="/roms/psx/moved")
+
+        result = event_loop.run_until_complete(service.select_disc(1, _DISC2))
+
+        assert result["success"] is True
+        # The bake resolves the pin over the enumerated list, so it must see the
+        # install that list came from — the relocated one was never enumerated.
+        assert disc_resolver.calls[-1] == (_ROM_DIR, _DISC2)
 
     def test_install_retired_between_transactions_fails_not_installed(self, event_loop, service, uow, disc_resolver):
         _seed_rom(uow, rom_id=1, selected_disc=None)

--- a/tests/services/test_disc.py
+++ b/tests/services/test_disc.py
@@ -10,6 +10,7 @@ import pytest
 from fakes.fake_active_core_resolver import FakeActiveCoreResolver
 from fakes.fake_disc_resolver import FakeDiscResolver
 from fakes.fake_unit_of_work import FakeUnitOfWork, FakeUnitOfWorkFactory
+from fakes.uow_open_probe import record_uow_open
 
 from domain.disc_selection import Disc
 from domain.rom import Rom
@@ -233,3 +234,84 @@ class TestSelectDisc:
         result = event_loop.run_until_complete(service.select_disc(999, _DISC1))
         assert result["success"] is False
         assert result["reason"] == "not_installed"
+
+
+# ── transaction boundary ───────────────────────────────────────────────
+
+
+def _retire_between_transactions(uow: FakeUnitOfWork, disc_resolver: FakeDiscResolver, rom_id: int, *, drop_rom: bool):
+    """Delete the ROM row (or only its install) while the picker enumerates.
+
+    Enumeration is the window between ``select_disc``'s read transaction and
+    its write transaction — the moment a background sync, a finishing download
+    or the removed-game cleanup can retire the ROM from its own connection.
+    """
+    enumerate_discs = disc_resolver.enumerate_discs
+
+    def retiring(install):
+        with uow:
+            if drop_rom:
+                uow.roms.delete(rom_id)
+            else:
+                uow.rom_installs.delete(rom_id)
+        return enumerate_discs(install)
+
+    disc_resolver.enumerate_discs = retiring
+
+
+class TestTransactionBoundary:
+    """Enumeration and the bake run between transactions, never inside one.
+
+    ``enumerate_discs`` lists the install directory, and the bake resolves the
+    ROM's active core through a seam that opens its own UoW. A UoW takes
+    SQLite's non-reentrant ``BEGIN IMMEDIATE`` write lock, so file I/O held
+    inside one stalls every other writer in the plugin and a nested open
+    self-deadlocks (CONTEXT.md → Unit of Work, #1779). ``FakeUnitOfWork``
+    shares no connection, so what a test can see is the ordering.
+    """
+
+    def test_get_disc_selection_enumerates_outside_the_uow(self, event_loop, service, uow, disc_resolver):
+        _seed_rom(uow, rom_id=1, selected_disc=_DISC2)
+        _seed_install(uow, rom_id=1, rom_dir=_ROM_DIR)
+        open_at_enumerate = record_uow_open(uow, disc_resolver, "enumerate_discs")
+
+        result = event_loop.run_until_complete(service.get_disc_selection(1))
+
+        assert result["multi_disc"] is True
+        assert open_at_enumerate == [False]
+
+    def test_select_disc_enumerates_and_bakes_outside_the_uow(self, event_loop, service, uow, disc_resolver):
+        _seed_rom(uow, rom_id=1, selected_disc=None)
+        _seed_install(uow, rom_id=1, rom_dir=_ROM_DIR)
+        open_at_enumerate = record_uow_open(uow, disc_resolver, "enumerate_discs")
+        open_at_bake = record_uow_open(uow, disc_resolver, "resolve_bake_path")
+
+        result = event_loop.run_until_complete(service.select_disc(1, _DISC2))
+
+        assert result["success"] is True
+        assert open_at_enumerate == [False]
+        assert open_at_bake == [False]
+
+    def test_rom_retired_between_transactions_fails_not_installed(self, event_loop, service, uow, disc_resolver):
+        _seed_rom(uow, rom_id=1, selected_disc=None)
+        _seed_install(uow, rom_id=1, rom_dir=_ROM_DIR)
+        _retire_between_transactions(uow, disc_resolver, 1, drop_rom=True)
+
+        result = event_loop.run_until_complete(service.select_disc(1, _DISC2))
+
+        assert result["success"] is False
+        assert result["reason"] == "not_installed"
+        assert "message" in result
+
+    def test_install_retired_between_transactions_fails_not_installed(self, event_loop, service, uow, disc_resolver):
+        _seed_rom(uow, rom_id=1, selected_disc=None)
+        _seed_install(uow, rom_id=1, rom_dir=_ROM_DIR)
+        _retire_between_transactions(uow, disc_resolver, 1, drop_rom=False)
+
+        result = event_loop.run_until_complete(service.select_disc(1, _DISC2))
+
+        assert result["success"] is False
+        assert result["reason"] == "not_installed"
+        # Nothing was pinned on the surviving row.
+        with uow_unwrap(uow) as u:
+            assert u.roms.get(1).selected_disc is None

--- a/tests/services/test_disc.py
+++ b/tests/services/test_disc.py
@@ -277,6 +277,24 @@ def _relocate_between_transactions(uow: FakeUnitOfWork, disc_resolver: FakeDiscR
     disc_resolver.enumerate_discs = relocating
 
 
+def _unfold_install_between_transactions(uow: FakeUnitOfWork, disc_resolver: FakeDiscResolver, rom_id: int) -> None:
+    """Replace the folder-backed install with a single-file one while enumerating.
+
+    The same window as :func:`_retire_between_transactions`, with the install
+    re-installed as a single file (``rom_dir`` NULL) — the shape the first
+    transaction refuses outright, arriving after it has already admitted the ROM.
+    """
+    enumerate_discs = disc_resolver.enumerate_discs
+
+    def unfolding(install):
+        discs = enumerate_discs(install)
+        with uow:
+            _seed_install(uow, rom_id=rom_id, rom_dir=None)
+        return discs
+
+    disc_resolver.enumerate_discs = unfolding
+
+
 class TestTransactionBoundary:
     """Enumeration and the bake run between transactions, never inside one.
 
@@ -345,5 +363,21 @@ class TestTransactionBoundary:
         assert result["success"] is False
         assert result["reason"] == "not_installed"
         # Nothing was pinned on the surviving row.
+        with uow_unwrap(uow) as u:
+            assert u.roms.get(1).selected_disc is None
+
+    def test_install_unfolded_between_transactions_fails_not_installed(self, event_loop, service, uow, disc_resolver):
+        # A folder-backed install re-installed as a single file in the window is
+        # the shape the read transaction refuses up front; the write transaction
+        # applies the same admission rather than pinning a disc onto a ROM that
+        # no longer has a disc folder.
+        _seed_rom(uow, rom_id=1, selected_disc=None)
+        _seed_install(uow, rom_id=1, rom_dir=_ROM_DIR)
+        _unfold_install_between_transactions(uow, disc_resolver, 1)
+
+        result = event_loop.run_until_complete(service.select_disc(1, _DISC2))
+
+        assert result["success"] is False
+        assert result["reason"] == "not_installed"
         with uow_unwrap(uow) as u:
             assert u.roms.get(1).selected_disc is None


### PR DESCRIPTION
A Unit of Work opens with `BEGIN IMMEDIATE`, so it takes the database's write lock at the top of the block — a read-only one too, deliberately, to keep a read-then-write transaction off `SQLITE_BUSY_SNAPSHOT` under concurrent WAL commits. Readers are unaffected; another writer waits up to `busy_timeout=5000` and fails with `SQLITE_BUSY` only if the lock is still held then. CONTEXT.md's Unit of Work entry and ADR-0006 keep a transaction to database reads and writes for that reason.

Six call sites had drifted across the rule. Two are the sync's install-path reads, which walked every installed ROM's directory inside one open transaction — the preview does that over the whole library. The other four are the disc picker's two callables and the per-game emulator write, each holding a transaction across a directory listing or an ES-DE config parse. Nothing at any of those call sites reveals that an injected seam touches the disk, which is why the drift went unnoticed.

All six now snapshot inside a short transaction, close it, and do the I/O outside. The three that also write reopen a transaction for the write and re-read what the write depends on: a background sync, a finishing download or the removed-game cleanup runs on another thread with its own connection, so a ROM row or an install record really can change in between. Each reopened transaction re-checks the exact admission its first transaction made — the row exists, the install exists and is still folder-backed, the ROM is still on the platform its label was resolved against — and returns that method's existing refusal when it no longer holds. No new failure reason, no input that previously succeeded now refuses.

One consequence is disclosed rather than removed: the disc pick bakes its launch command over the install its disc list was enumerated from, not over the re-read one, because resolving a pinned disc against a directory it was never listed in is worse than resolving it against a directory the ROM has since left. A relocation landing in that window leaves a stale command until the startup launch-options reconcile re-bakes it.

`scripts/check_uow_seam_nesting.py` gains a second seam family so the rule stops depending on review. It reuses the deadlock family's matcher and states its own hazard: nine seam names — the four `CoreInfoProvider` reads, the two `DiscResolver` walks, the platform-map read and the two ES-DE questions bound as call-shaped seams. Run over the pre-fix tree it reports exactly the six sites this PR fixes, and nothing else. Two families of disk-touching seam were weighed and kept out, with the reasons recorded; the list is what the checker has been told about, never an inventory of what touches the disk.

This came from reading the code, not from a reported symptom, and nothing here rests on a measurement of how long any of those transactions actually held the lock. What is defensible is narrower than an improvement: a transaction was held across work that gains nothing from being inside it. The related gap — that nothing catches `sqlite3.OperationalError`, so a genuinely contended caller raises instead of reporting "busy" — is #1798.

Closes #1779.
