### PR TITLE
docs: remove the reduced-availability notice from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@
 
 </div>
 
-> [!NOTE]
-> **Reduced availability until ~end of August 2026** — a new addition to the family means slower responses on issues and
-> PRs for the next few weeks. See #1584 for details. Thanks for your patience!
-
 A [Decky Loader](https://decky.xyz/) plugin that syncs your self-hosted [RomM](https://github.com/rommapp/romm) library
 into Steam as non-steam shortcuts. Games appear directly in your Steam library, launch through
 [RetroDECK](https://retrodeck.net/), and can keep their saves in sync across devices through your RomM server.


### PR DESCRIPTION
The notice at the top of the README announced slower responses on issues and PRs through the end of August 2026. That period is over, so it comes out and the README opens on the project description again.