### PR TITLE
feat(qam): the wide-page frame

### DIFF
--- a/docs/adr/0029-wide-qam-pages-drive-steams-friends-expansion.md
+++ b/docs/adr/0029-wide-qam-pages-drive-steams-friends-expansion.md
@@ -61,8 +61,11 @@ change, no unmount), when the QAM closes (`useQuickAccessVisible`), and from the
   itself is 855 px wide in both states and proves nothing.
 - **The flag is Steam's and global.** A page that leaks it leaves Steam's own QAM expanded until the Friends tab toggles
   it back. The four clearing paths above are the whole discipline.
-- **`window.origin`, never a literal origin.** `postMessage` throws on a target-origin mismatch, and one of the callers
-  is `onDismount`, where a throw abandons the rest of the plugin's teardown. The spike found this with 72 failing tests.
+- **`window.origin`, never a literal origin.** It addresses the message to the one window meant to receive it and always
+  matches it. A well-formed target origin that does not match is checked at delivery and the message is discarded in
+  silence, so a literal is a failure with no symptom but a panel that never widens; `"*"` is always delivered, but to
+  any document in the window. The spike shipped a literal first and found it through 72 failing tests — which is the
+  test environment's stricter behaviour (happy-dom throws where a browser discards), not the device's.
 - **A wide page needs a definite height.** Steam's tabbed page fills its parent instead of growing, and nothing in the
   QAM chain provides a height; a `min-height` clips. The wide frame measures the remaining viewport and lets its regions
   scroll inside it.

--- a/docs/architecture/qam-panel.md
+++ b/docs/architecture/qam-panel.md
@@ -43,8 +43,9 @@ How a page gets wide, measured on the device (Big Picture, CEF Chrome 126) rathe
   `transform: translateX(506px)`, so 348 px stay visible. Steam's `Expanded` class sets `translateX(0)`. The class
   follows one MobX observable on the FriendsUI store, which listens for `message` events on the SharedJSContext window —
   the window plugin code runs in. A wide page posts `{ message: "QamFriendsExpanded" }` to `window` on mount and
-  `{ message: "QamFriendsHidden" }` when it lets go. The target origin is always `window.origin`: `postMessage` throws
-  on a mismatch, and one caller is `onDismount`, where a throw abandons the rest of the plugin's teardown.
+  `{ message: "QamFriendsHidden" }` when it lets go. The target origin is always `window.origin`, which addresses the
+  message to that window and always matches it. A well-formed target origin that does not match is checked at delivery
+  and the message is discarded in silence, so a literal one would leave the panel simply never widening.
 - Every tab's content panel carries `max-width: 300px`; only Steam's Friends panel lifts it. A wide page injects one
   stylesheet whose `:has()` rule lifts the cap for a marker class on the plugin's own subtree. Class names come from
   `quickAccessMenuClasses`, which can be `undefined`; `[id^="quickaccess_content_"]` is the fallback selector. Decky

--- a/docs/architecture/qam-panel.md
+++ b/docs/architecture/qam-panel.md
@@ -27,6 +27,8 @@ without restating it. The width mechanism's decision record is
 | `src/components/DownloadQueue.tsx`                            | Downloads                                                                                                            |
 | `src/components/SystemPage.tsx`                               | System — retires into Library › Platforms                                                                            |
 | `src/utils/deckyUiInternals.ts`                               | Honest typing for `@decky/ui` values that come from a webpack probe; the wide frame's class names and `Tabs` go here |
+| `src/utils/qamExpansion.ts`                                   | The panel's width: the expand and hide messages, the injected `max-width` rule, and the four paths that clear both   |
+| `src/components/qam/`                                         | The wide-page frame: `WidePage` (Back row, title, tabs, measured height) and `ListDetail`                            |
 | `src/utils/` module stores                                    | State that must outlive a page: sync progress, pending preview, downloads, prune, notices                            |
 
 ## Two widths
@@ -263,12 +265,13 @@ The pages land in this order under #1808, each with the open work that already s
 1. **The wide frame** ([#1813](https://github.com/danielcopper/romm-tender/issues/1813)) — the two levers and their
    clearing paths, the Back row, tabs, list and detail, the measured height. No page uses it yet; it is the one piece
    that rests on Steam internals and is reviewed on its own.
-2. **Sync** ([#1814](https://github.com/danielcopper/romm-tender/issues/1814)) — the new page, Main's four-state button
+2. **Library** ([#1815](https://github.com/danielcopper/romm-tender/issues/1815)) — Platforms and Collections; System
+   and the Data Management platform modal retire. Carries #164, #1803's frontend half, #1016's frontend half, #1020's
+   collections fix. May land as two PRs, Platforms then Collections. Second on purpose: the emu-atlas work under #1735
+   renders its BIOS and core changes into the new Platforms detail instead of the retiring System page.
+3. **Sync** ([#1814](https://github.com/danielcopper/romm-tender/issues/1814)) — the new page, Main's four-state button
    and the Last sync row, Skip preview persisted, the run-list read, the per-platform preview breakdown. Carries #886's
    presentation half.
-3. **Library** ([#1815](https://github.com/danielcopper/romm-tender/issues/1815)) — Platforms and Collections; System
-   and the Data Management platform modal retire. Carries #164, #1803's frontend half, #1016's frontend half, #1020's
-   collections fix. May land as two PRs, Platforms then Collections.
 4. **Settings** ([#1816](https://github.com/danielcopper/romm-tender/issues/1816)) — the sections, Steam Library, the
    homes for the `input_driver` fix and the save-sort migration with their notices on Main. Carries #1020's URL and
    double-press fixes.

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -169,6 +169,8 @@ vi.mock("@decky/ui", async () => {
     appActionButtonClasses: undefined,
     appDetailsClasses: undefined,
     playSectionClasses: undefined,
+    quickAccessMenuClasses: undefined,
+    Tabs: undefined,
     findSP: vi.fn(() => undefined),
     ConfirmModal: (p: AnyProps) => ce("div", { "data-testid": "confirm-modal" }, p.children as never),
     DialogButton: ({

--- a/src/components/qam/ListDetail.test.tsx
+++ b/src/components/qam/ListDetail.test.tsx
@@ -70,6 +70,24 @@ describe("ListDetail", () => {
     expect(screen.getByRole("button", { name: "Nintendo 64" })).toBeInTheDocument();
   });
 
+  it("reports a selection only when it changes", () => {
+    const onSelect = vi.fn();
+    render(<ControlledHost onSelect={onSelect} />);
+
+    // focusin fires again for every move between controls inside one row, and on
+    // the way back from the detail pane. A page may do real work on onSelect, so
+    // the same id must not arrive twice.
+    fireEvent.focusIn(screen.getByRole("button", { name: /Nintendo 64/ }));
+    fireEvent.focusIn(screen.getByRole("button", { name: /Nintendo 64/ }));
+
+    expect(onSelect).not.toHaveBeenCalled();
+
+    fireEvent.focusIn(screen.getByRole("button", { name: /PlayStation/ }));
+    fireEvent.focusIn(screen.getByRole("button", { name: /PlayStation/ }));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
   it("leaves A to the row's own control", () => {
     const onSelect = vi.fn();
     const onToggle = vi.fn();

--- a/src/components/qam/ListDetail.test.tsx
+++ b/src/components/qam/ListDetail.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * ListDetail tests — focus selects, and A stays with the row's own control.
+ *
+ * The @decky/ui stub in `src/test-setup.ts` renders every Focusable as a div
+ * that forwards onFocus, so focus moving onto a row is driven with a real
+ * focusin event rather than Steam's gamepad engine.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useState, type FC } from "react";
+import { ListDetail, type ListDetailItem } from "./ListDetail";
+
+const PLATFORMS = [
+  { id: "n64", name: "Nintendo 64" },
+  { id: "psx", name: "PlayStation" },
+];
+
+function platformItems(onToggle: (id: string) => void): ListDetailItem[] {
+  return PLATFORMS.map((platform) => ({
+    id: platform.id,
+    render: (selected: boolean) => (
+      <button onClick={() => onToggle(platform.id)}>
+        {platform.name}
+        {selected ? " (selected)" : ""}
+      </button>
+    ),
+  }));
+}
+
+/** A page-shaped host: it owns the selection, as a real wide page does. */
+const ControlledHost: FC<{ onSelect?: (id: string) => void; onToggle?: (id: string) => void }> = ({
+  onSelect,
+  onToggle,
+}) => {
+  const [selectedId, setSelectedId] = useState<string | null>("n64");
+  return (
+    <ListDetail
+      items={platformItems(onToggle ?? (() => {}))}
+      selectedId={selectedId}
+      onSelect={(id) => {
+        setSelectedId(id);
+        onSelect?.(id);
+      }}
+      renderDetail={(id) => <div>detail for {id ?? "nothing"}</div>}
+    />
+  );
+};
+
+describe("ListDetail", () => {
+  it("selects the row that takes focus and swaps the detail with it", () => {
+    const onSelect = vi.fn();
+    render(<ControlledHost onSelect={onSelect} />);
+
+    expect(screen.getByText("detail for n64")).toBeInTheDocument();
+    fireEvent.focusIn(screen.getByRole("button", { name: /PlayStation/ }));
+
+    expect(onSelect).toHaveBeenCalledWith("psx");
+    expect(screen.getByText("detail for psx")).toBeInTheDocument();
+    expect(screen.queryByText("detail for n64")).not.toBeInTheDocument();
+  });
+
+  it("tells the row whether it is the selected one", () => {
+    render(<ControlledHost />);
+
+    expect(screen.getByRole("button", { name: "Nintendo 64 (selected)" })).toBeInTheDocument();
+    fireEvent.focusIn(screen.getByRole("button", { name: "PlayStation" }));
+
+    expect(screen.getByRole("button", { name: "PlayStation (selected)" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Nintendo 64" })).toBeInTheDocument();
+  });
+
+  it("leaves A to the row's own control", () => {
+    const onSelect = vi.fn();
+    const onToggle = vi.fn();
+    render(<ControlledHost onSelect={onSelect} onToggle={onToggle} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "PlayStation" }));
+
+    expect(onToggle).toHaveBeenCalledWith("psx");
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("puts the list and the detail in two separately navigable regions", () => {
+    render(<ControlledHost />);
+    const [list, detail] = [...screen.getAllByTestId("focusable")[0]!.children] as HTMLElement[];
+
+    expect(list).toContainElement(screen.getByRole("button", { name: /Nintendo 64/ }));
+    expect(list).toContainElement(screen.getByRole("button", { name: /PlayStation/ }));
+    expect(detail).toContainElement(screen.getByText("detail for n64"));
+    expect(list?.style.overflow).toBe("auto");
+    expect(detail?.style.overflow).toBe("auto");
+  });
+
+  it("renders a detail for an empty selection", () => {
+    render(
+      <ListDetail
+        items={[]}
+        selectedId={null}
+        onSelect={vi.fn()}
+        renderDetail={(id) => <div>{id ?? "nothing"}</div>}
+      />,
+    );
+
+    expect(screen.getByText("nothing")).toBeInTheDocument();
+  });
+});

--- a/src/components/qam/ListDetail.tsx
+++ b/src/components/qam/ListDetail.tsx
@@ -36,8 +36,16 @@ export const ListDetail: FC<ListDetailProps> = ({ items, selectedId, onSelect, r
     <Focusable flow-children="vertical" style={{ ...regionStyle, flex: `0 0 ${LIST_WIDTH}`, width: LIST_WIDTH }}>
       {items.map((item) => (
         // React delivers onFocus through focusin, so this fires for focus
-        // landing on whatever control the row itself renders.
-        <Focusable key={item.id} onFocus={() => onSelect(item.id)}>
+        // landing on whatever control the row itself renders — and again for
+        // every move between controls inside the same row, or on the way back
+        // from the detail pane. Only a real change is reported, so a page may
+        // treat onSelect as an event and do work on it.
+        <Focusable
+          key={item.id}
+          onFocus={() => {
+            if (item.id !== selectedId) onSelect(item.id);
+          }}
+        >
           {item.render(item.id === selectedId)}
         </Focusable>
       ))}

--- a/src/components/qam/ListDetail.tsx
+++ b/src/components/qam/ListDetail.tsx
@@ -1,0 +1,49 @@
+/**
+ * The list-and-detail layout of a wide QAM page: the list on the left, the
+ * focused entry's detail on the right, each scrolling on its own inside the
+ * frame's measured height.
+ *
+ * Focus selects — moving through the list changes the detail at once, as Steam's
+ * own settings do. The row's own control keeps A, so this component never
+ * intercepts it; a row that carries a toggle still toggles on press.
+ *
+ * Selection is controlled: the page owns `selectedId` and decides what a change
+ * means for the rest of it.
+ */
+
+import type { FC, ReactNode } from "react";
+import { Focusable } from "@decky/ui";
+
+export interface ListDetailItem {
+  id: string;
+  render: (selected: boolean) => ReactNode;
+}
+
+export interface ListDetailProps {
+  items: ListDetailItem[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  renderDetail: (selectedId: string | null) => ReactNode;
+}
+
+// The list takes about a third of the 806 px a wide tab panel offers.
+const LIST_WIDTH = "264px";
+
+const regionStyle = { height: "100%", overflow: "auto", minHeight: 0 } as const;
+
+export const ListDetail: FC<ListDetailProps> = ({ items, selectedId, onSelect, renderDetail }) => (
+  <Focusable flow-children="horizontal" style={{ display: "flex", gap: "12px", height: "100%", minHeight: 0 }}>
+    <Focusable flow-children="vertical" style={{ ...regionStyle, flex: `0 0 ${LIST_WIDTH}`, width: LIST_WIDTH }}>
+      {items.map((item) => (
+        // React delivers onFocus through focusin, so this fires for focus
+        // landing on whatever control the row itself renders.
+        <Focusable key={item.id} onFocus={() => onSelect(item.id)}>
+          {item.render(item.id === selectedId)}
+        </Focusable>
+      ))}
+    </Focusable>
+    <Focusable flow-children="vertical" style={{ ...regionStyle, flex: "1 1 auto", minWidth: 0 }}>
+      {renderDetail(selectedId)}
+    </Focusable>
+  </Focusable>
+);

--- a/src/components/qam/WidePage.test.tsx
+++ b/src/components/qam/WidePage.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * WidePage tests — the frame's own contract: the Back row, the title, a body
+ * with a definite measured height, and a tab bar that survives Steam's `Tabs`
+ * probe coming back undefined.
+ *
+ * `Tabs` is read at module scope, so each test loads a fresh copy of the
+ * component through `loadWidePage` with the probe answer it wants. The width
+ * levers the frame also holds are pinned in `src/utils/qamExpansion.test.tsx`.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { FC, ReactNode } from "react";
+import type { WidePageProps, WidePageTab } from "./WidePage";
+
+interface StubTabsProps {
+  tabs: WidePageTab[];
+  activeTab: string;
+  onShowTab: (tabId: string) => void;
+}
+
+/** Stand-in for Steam's tabbed page: a bar of titles plus the active content. */
+const StubTabs: FC<StubTabsProps> = ({ tabs, activeTab, onShowTab }) => (
+  <div data-testid="steam-tabs">
+    {tabs.map((tab) => (
+      <button key={tab.id} onClick={() => onShowTab(tab.id)}>
+        {tab.title}
+      </button>
+    ))}
+    <div>{tabs.find((tab) => tab.id === activeTab)?.content}</div>
+  </div>
+);
+
+async function loadWidePage(tabs: FC<StubTabsProps> | undefined): Promise<FC<WidePageProps>> {
+  vi.resetModules();
+  vi.doMock("../../utils/deckyUiInternals", () => ({ quickAccessMenuClasses: undefined, Tabs: tabs }));
+  return (await import("./WidePage")).WidePage;
+}
+
+const TAB_SET: WidePageTab[] = [
+  { id: "platforms", title: "Platforms", content: <div>platform detail</div> },
+  { id: "collections", title: "Collections", content: <div>collection detail</div> },
+];
+
+function body(): HTMLElement {
+  return screen.getByTestId("wide-page-body");
+}
+
+describe("WidePage", () => {
+  it("renders the Back row, the title and the page body", async () => {
+    const WidePage = await loadWidePage(StubTabs);
+    const onBack = vi.fn();
+
+    render(
+      <WidePage title="Settings" onBack={onBack}>
+        <div>page body</div>
+      </WidePage>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+    expect(screen.getByText("page body")).toBeInTheDocument();
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives the body a definite height taken from the remaining viewport", async () => {
+    const WidePage = await loadWidePage(StubTabs);
+
+    render(
+      <WidePage title="Settings" onBack={vi.fn()}>
+        <div>page body</div>
+      </WidePage>,
+    );
+
+    // happy-dom reports every rect at the origin, so the body's top is 0 and the
+    // measurement is the viewport minus the frame's bottom gap.
+    expect(window.innerHeight).toBeGreaterThan(240);
+    expect(body().style.height).toBe(`${window.innerHeight - 12}px`);
+    // Steam's tabbed page fills its parent instead of growing: a min-height
+    // leaves the body with no height at all and the page clips.
+    expect(body().style.minHeight).toBe("");
+  });
+
+  it("never measures the body below its floor", async () => {
+    vi.stubGlobal("innerHeight", 100);
+    const WidePage = await loadWidePage(StubTabs);
+
+    render(
+      <WidePage title="Settings" onBack={vi.fn()}>
+        <div>page body</div>
+      </WidePage>,
+    );
+
+    expect(body().style.height).toBe("240px");
+  });
+
+  it("renders tabs through Steam's tabbed page and reports a switch", async () => {
+    const WidePage = await loadWidePage(StubTabs);
+    const onShowTab = vi.fn();
+
+    render(<WidePage title="Library" onBack={vi.fn()} tabs={TAB_SET} activeTab="platforms" onShowTab={onShowTab} />);
+    fireEvent.click(screen.getByRole("button", { name: "Collections" }));
+
+    expect(screen.getByTestId("steam-tabs")).toBeInTheDocument();
+    expect(screen.getByText("platform detail")).toBeInTheDocument();
+    expect(onShowTab).toHaveBeenCalledWith("collections");
+  });
+
+  it("renders the active tab's content without a bar when the Tabs probe missed", async () => {
+    const WidePage = await loadWidePage(undefined);
+
+    render(<WidePage title="Library" onBack={vi.fn()} tabs={TAB_SET} activeTab="collections" onShowTab={vi.fn()} />);
+
+    expect(screen.queryByTestId("steam-tabs")).not.toBeInTheDocument();
+    expect(screen.getByText("collection detail")).toBeInTheDocument();
+    expect(screen.queryByText("platform detail")).not.toBeInTheDocument();
+  });
+
+  it("still renders the frame when the active tab has no content", async () => {
+    const WidePage = await loadWidePage(undefined);
+    const emptyTabs: WidePageTab[] = [{ id: "platforms", title: "Platforms", content: null as ReactNode }];
+
+    render(<WidePage title="Library" onBack={vi.fn()} tabs={emptyTabs} activeTab="missing" onShowTab={vi.fn()} />);
+
+    expect(screen.getByText("Library")).toBeInTheDocument();
+    expect(body()).toBeEmptyDOMElement();
+  });
+});

--- a/src/components/qam/WidePage.test.tsx
+++ b/src/components/qam/WidePage.test.tsx
@@ -82,6 +82,8 @@ describe("WidePage", () => {
   });
 
   it("never measures the body below its floor", async () => {
+    // Undone by the `vi.unstubAllGlobals()` in src/test-setup.ts's global
+    // afterEach, so the viewport is back to its default for the next test.
     vi.stubGlobal("innerHeight", 100);
     const WidePage = await loadWidePage(StubTabs);
 

--- a/src/components/qam/WidePage.test.tsx
+++ b/src/components/qam/WidePage.test.tsx
@@ -1,16 +1,19 @@
 /**
  * WidePage tests — the frame's own contract: the Back row, the title, a body
- * with a definite measured height, and a tab bar that survives Steam's `Tabs`
- * probe coming back undefined.
+ * with a definite measured height, a tab bar that survives Steam's `Tabs` probe
+ * coming back undefined, and the two ends of the width the frame is for.
  *
  * `Tabs` is read at module scope, so each test loads a fresh copy of the
- * component through `loadWidePage` with the probe answer it wants. The width
- * levers the frame also holds are pinned in `src/utils/qamExpansion.test.tsx`.
+ * component through `loadWidePage` with the probe answer it wants. What the
+ * width levers themselves do once engaged is pinned in
+ * `src/utils/qamExpansion.test.tsx`, against its own fake page; what is pinned
+ * here is that this frame is what engages them.
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import type { FC, ReactNode } from "react";
+import { WIDE_ROOT_CLASS } from "../../utils/qamExpansion";
 import type { WidePageProps, WidePageTab } from "./WidePage";
 
 interface StubTabsProps {
@@ -47,6 +50,10 @@ function body(): HTMLElement {
 }
 
 describe("WidePage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("renders the Back row, the title and the page body", async () => {
     const WidePage = await loadWidePage(StubTabs);
     const onBack = vi.fn();
@@ -116,6 +123,52 @@ describe("WidePage", () => {
     expect(screen.queryByTestId("steam-tabs")).not.toBeInTheDocument();
     expect(screen.getByText("collection detail")).toBeInTheDocument();
     expect(screen.queryByText("platform detail")).not.toBeInTheDocument();
+  });
+
+  it("marks its root with the class the injected width rule matches", async () => {
+    const WidePage = await loadWidePage(StubTabs);
+
+    const { container } = render(
+      <WidePage title="Settings" onBack={vi.fn()}>
+        <div>page body</div>
+      </WidePage>,
+    );
+
+    // The injected `:has()` rule keys on this class: drop it and every wide page
+    // renders 300 px wide inside an 854 px panel, with nothing raised anywhere.
+    // It sits on the root because that is the element the width hook is handed —
+    // one decision, which this pins as one.
+    expect(container.firstElementChild).toHaveClass(WIDE_ROOT_CLASS);
+  });
+
+  it("engages the panel's width levers while it is mounted", async () => {
+    const WidePage = await loadWidePage(StubTabs);
+    const post = vi.spyOn(window, "postMessage").mockImplementation(() => {});
+
+    render(
+      <WidePage title="Settings" onBack={vi.fn()}>
+        <div>page body</div>
+      </WidePage>,
+    );
+
+    // The frame holding `useWideQamPanel` is the whole reason a page is wide.
+    // Dropping the hook while the module stays imported elsewhere leaves the
+    // rest of this file green.
+    expect(post).toHaveBeenCalledWith({ message: "QamFriendsExpanded" }, window.origin);
+  });
+
+  it("takes no children beside tabs, whose body is the active tab's content", async () => {
+    const WidePage = await loadWidePage(StubTabs);
+
+    render(
+      // @ts-expect-error `children` sits in the no-tabs branch of WidePageProps: passed here it would render nowhere.
+      <WidePage title="Library" onBack={vi.fn()} tabs={TAB_SET} activeTab="platforms" onShowTab={vi.fn()}>
+        <div>dropped</div>
+      </WidePage>,
+    );
+
+    expect(screen.getByText("platform detail")).toBeInTheDocument();
+    expect(screen.queryByText("dropped")).not.toBeInTheDocument();
   });
 
   it("still renders the frame when the active tab has no content", async () => {

--- a/src/components/qam/WidePage.tsx
+++ b/src/components/qam/WidePage.tsx
@@ -20,15 +20,18 @@ export interface WidePageTab {
   content: ReactNode;
 }
 
-/** A page has all three tab props or none of them. */
+/**
+ * A page has all three tab props or none of them, and `children` belongs to the
+ * second case alone: a tabbed page's body is the active tab's `content`, so
+ * children passed beside `tabs` would render nowhere.
+ */
 type TabProps =
-  | { tabs: WidePageTab[]; activeTab: string; onShowTab: (tabId: string) => void }
-  | { tabs?: undefined; activeTab?: undefined; onShowTab?: undefined };
+  | { tabs: WidePageTab[]; activeTab: string; onShowTab: (tabId: string) => void; children?: undefined }
+  | { tabs?: undefined; activeTab?: undefined; onShowTab?: undefined; children?: ReactNode };
 
 export type WidePageProps = {
   title: string;
   onBack: () => void;
-  children?: ReactNode;
 } & TabProps;
 
 // Floor under the measured body, so a viewport read taken before Steam has laid

--- a/src/components/qam/WidePage.tsx
+++ b/src/components/qam/WidePage.tsx
@@ -1,0 +1,98 @@
+/**
+ * The shell every wide QAM page renders inside: the marker class that lets the
+ * injected rule lift Steam's 300 px tab-panel cap, the Back row and title, an
+ * optional L1/R1 tab bar, and a body of a definite, measured height.
+ *
+ * The page's own content is `children`, or — when the page has tabs — the
+ * `content` of each tab, which Steam's `Tabs` renders itself.
+ *
+ * Structure and vocabulary: `docs/architecture/qam-panel.md`.
+ */
+
+import { useLayoutEffect, useRef, useState, type FC, type ReactNode } from "react";
+import { ButtonItem, PanelSection, PanelSectionRow } from "@decky/ui";
+import { Tabs } from "../../utils/deckyUiInternals";
+import { WIDE_ROOT_CLASS, useWideQamPanel } from "../../utils/qamExpansion";
+
+export interface WidePageTab {
+  id: string;
+  title: string;
+  content: ReactNode;
+}
+
+/** A page has all three tab props or none of them. */
+type TabProps =
+  | { tabs: WidePageTab[]; activeTab: string; onShowTab: (tabId: string) => void }
+  | { tabs?: undefined; activeTab?: undefined; onShowTab?: undefined };
+
+export type WidePageProps = {
+  title: string;
+  onBack: () => void;
+  children?: ReactNode;
+} & TabProps;
+
+// Floor under the measured body, so a viewport read taken before Steam has laid
+// the panel out cannot collapse the page to nothing.
+const MIN_BODY_HEIGHT = 240;
+
+// Breathing room under the body, kept off the measurement so the page never
+// ends flush against the panel's bottom edge.
+const BODY_BOTTOM_GAP = 12;
+
+/**
+ * The remaining viewport below `body`, which is the height a wide page gets to
+ * work with: Steam's tabbed page fills its parent rather than growing, and
+ * nothing in the QAM chain hands the plugin's panel a height.
+ */
+function remainingViewportHeight(body: HTMLElement, view: Window): number {
+  return Math.max(MIN_BODY_HEIGHT, view.innerHeight - body.getBoundingClientRect().top - BODY_BOTTOM_GAP);
+}
+
+export const WidePage: FC<WidePageProps> = ({ title, onBack, tabs, activeTab, onShowTab, children }) => {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const bodyRef = useRef<HTMLDivElement>(null);
+  const [bodyHeight, setBodyHeight] = useState<number | null>(null);
+
+  useWideQamPanel(rootRef);
+
+  useLayoutEffect(() => {
+    const body = bodyRef.current;
+    const view = body?.ownerDocument.defaultView;
+    if (!body || !view) return;
+
+    const measure = () => setBodyHeight(remainingViewportHeight(body, view));
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(body.ownerDocument.documentElement);
+    return () => observer.disconnect();
+  }, []);
+
+  // A `min-height` is not enough here — Steam's tabbed page fills its parent and
+  // clips instead of growing, so the body needs a definite height.
+  const bodyStyle = { height: bodyHeight === null ? undefined : `${bodyHeight}px`, overflow: "hidden" };
+
+  let body: ReactNode = children;
+  if (tabs) {
+    body = Tabs ? (
+      <Tabs tabs={tabs} activeTab={activeTab} onShowTab={onShowTab} />
+    ) : (
+      tabs.find((tab) => tab.id === activeTab)?.content
+    );
+  }
+
+  return (
+    <div className={WIDE_ROOT_CLASS} ref={rootRef}>
+      <PanelSection>
+        <PanelSectionRow>
+          <ButtonItem layout="below" onClick={onBack}>
+            Back
+          </ButtonItem>
+        </PanelSectionRow>
+      </PanelSection>
+      <div style={{ padding: "0 16px 8px", fontSize: "16px", fontWeight: 600, color: "#dcdedf" }}>{title}</div>
+      <div ref={bodyRef} style={bodyStyle} data-testid="wide-page-body">
+        {body}
+      </div>
+    </div>
+  );
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1009,9 +1009,12 @@ export default definePlugin(() => {
     content: <QAMPanel />,
     alwaysRender: true,
     onDismount() {
-      // First: the panel width is a global Steam flag, and a page still mounted
-      // here has no React cleanup left to clear it. Leaving it set would keep
-      // Steam's own QAM expanded until its Friends tab toggles it back.
+      // Ahead of every step below that can throw: the panel width is a global
+      // Steam flag with no React cleanup left to clear it here, so a teardown
+      // that dies halfway must not be what leaves Steam's own QAM expanded.
+      // Safe in that position because this call cannot throw itself — the width
+      // message goes to `window.origin`, the one target origin postMessage
+      // accepts.
       collapseQamOnDismount();
       syncContinuationController.abort();
       destroySessionManager();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -59,6 +59,7 @@ import { setSaveSortMigrationStatus } from "./utils/saveSortMigrationStore";
 import { setVersionError, setServerRetryProgress } from "./utils/connectionState";
 import { initSessionManager, destroySessionManager } from "./utils/sessionManager";
 import { findOutermostScrollParent } from "./utils/scrollHelpers";
+import { collapseQamOnDismount } from "./utils/qamExpansion";
 import { detach } from "./utils/detach";
 import type {
   SyncProgress,
@@ -1008,6 +1009,10 @@ export default definePlugin(() => {
     content: <QAMPanel />,
     alwaysRender: true,
     onDismount() {
+      // First: the panel width is a global Steam flag, and a page still mounted
+      // here has no React cleanup left to clear it. Leaving it set would keep
+      // Steam's own QAM expanded until its Friends tab toggles it back.
+      collapseQamOnDismount();
       syncContinuationController.abort();
       destroySessionManager();
       unregisterLaunchInterceptor();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1012,9 +1012,6 @@ export default definePlugin(() => {
       // Ahead of every step below that can throw: the panel width is a global
       // Steam flag with no React cleanup left to clear it here, so a teardown
       // that dies halfway must not be what leaves Steam's own QAM expanded.
-      // Safe in that position because this call cannot throw itself — the width
-      // message goes to `window.origin`, the one target origin postMessage
-      // accepts.
       collapseQamOnDismount();
       syncContinuationController.abort();
       destroySessionManager();

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -176,16 +176,19 @@ vi.mock("@decky/ui", () => {
     // Focusable forwards onButtonDown as a real DOM "decky-button-down"
     // listener so tests can drive gamepad input via
     // fireEvent(el, new CustomEvent("decky-button-down", { detail: { button } })).
-    // Other FooterLegend-only props (flow-children, actionDescriptionMap, …)
-    // are dropped — they have no DOM effect under happy-dom.
+    // onFocus is forwarded because a Focusable is how the list-and-detail layout
+    // learns that focus moved to a row — dropping it would make focus-selects
+    // vacuously untestable. Other FooterLegend-only props (flow-children,
+    // actionDescriptionMap, …) are dropped — they have no DOM effect under happy-dom.
     Focusable: ({
       children,
       style,
       onButtonDown,
+      onFocus,
       role,
       tabIndex,
       "aria-label": ariaLabel,
-    }: AnyProps & { style?: unknown; onButtonDown?: (evt: unknown) => void }) =>
+    }: AnyProps & { style?: unknown; onButtonDown?: (evt: unknown) => void; onFocus?: (evt: unknown) => void }) =>
       createElement(
         "div",
         {
@@ -193,6 +196,7 @@ vi.mock("@decky/ui", () => {
           style,
           role,
           tabIndex,
+          onFocus,
           "aria-label": ariaLabel,
           ref: (el: HTMLDivElement | null) => {
             if (!el) return;
@@ -270,5 +274,13 @@ vi.mock("@decky/ui", () => {
     basicAppDetailsSectionStylerClasses: undefined,
     appDetailsClasses: undefined,
     playSectionClasses: undefined,
+    // The wide-QAM probes. Undefined is the honest default here: happy-dom has
+    // no Steam webpack modules, so a test that wants the class names or the
+    // tabbed page mocks `src/utils/deckyUiInternals` with its own values.
+    quickAccessMenuClasses: undefined,
+    Tabs: undefined,
+    // The QAM is open for any test that renders a wide page; the hook's
+    // clear-on-close path is exercised in src/utils/qamExpansion.test.tsx.
+    useQuickAccessVisible: () => true,
   };
 });

--- a/src/utils/deckyUiInternals.ts
+++ b/src/utils/deckyUiInternals.ts
@@ -15,12 +15,16 @@
  * here, typed honestly.
  */
 
+import type { FC } from "react";
 import {
   appActionButtonClasses as _appActionButtonClasses,
   basicAppDetailsSectionStylerClasses as _basicAppDetailsSectionStylerClasses,
   appDetailsClasses as _appDetailsClasses,
   playSectionClasses as _playSectionClasses,
+  quickAccessMenuClasses as _quickAccessMenuClasses,
+  Tabs as _Tabs,
   findSP as _findSP,
+  type TabsProps,
 } from "@decky/ui";
 
 export const appActionButtonClasses: typeof _appActionButtonClasses | undefined = _appActionButtonClasses;
@@ -28,5 +32,14 @@ export const basicAppDetailsSectionStylerClasses: typeof _basicAppDetailsSection
   _basicAppDetailsSectionStylerClasses;
 export const appDetailsClasses: typeof _appDetailsClasses | undefined = _appDetailsClasses;
 export const playSectionClasses: typeof _playSectionClasses | undefined = _playSectionClasses;
+export const quickAccessMenuClasses: typeof _quickAccessMenuClasses | undefined = _quickAccessMenuClasses;
+
+/**
+ * Steam's L1/R1 tabbed page, found through a `findModuleByExport` probe on the
+ * shape of its render function — so it is `undefined` whenever that probe misses.
+ * Upstream types it `any`, which hides both the absence and the props; a
+ * component type states what the frame actually passes it.
+ */
+export const Tabs: FC<TabsProps> | undefined = _Tabs;
 
 export const findSP = (): Window | undefined => _findSP();

--- a/src/utils/qamExpansion.test.tsx
+++ b/src/utils/qamExpansion.test.tsx
@@ -1,0 +1,238 @@
+/**
+ * qamExpansion tests — the two levers that widen the QAM panel, and the four
+ * paths that have to clear them again.
+ *
+ * The levers themselves are Steam internals that happy-dom cannot show: no
+ * FriendsUI store listens for the message, and no 300 px cap exists to lift. What
+ * IS pinnable is everything the plugin owns — which message goes out, to which
+ * target origin, which selector the injected rule is written against, and that
+ * every exit path posts the hide message and drops the stylesheet.
+ *
+ * `quickAccessMenuClasses` is read once at module scope (the probe answers the
+ * same value for the process), so each test loads a fresh copy of the module
+ * through `loadQamExpansion` with the probe value it wants.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, act } from "@testing-library/react";
+import { useRef, useSyncExternalStore, type FC } from "react";
+
+// --- @decky/ui: only useQuickAccessVisible, backed by a store the tests flip.
+// deckyUiInternals is mocked too, so nothing else in this graph reaches @decky/ui.
+let qamVisible = true;
+const visibilityListeners = new Set<() => void>();
+const subscribeVisibility = (onChange: () => void) => {
+  visibilityListeners.add(onChange);
+  return () => {
+    visibilityListeners.delete(onChange);
+  };
+};
+
+vi.mock("@decky/ui", () => ({
+  useQuickAccessVisible: () => useSyncExternalStore(subscribeVisibility, () => qamVisible),
+}));
+
+const ACTIVE_TAB_CLASS = "ActiveTab_hash";
+const TAB_PANEL_CLASS = "TabGroupPanel_hash";
+const PROBE_CLASSES = { ActiveTab: ACTIVE_TAB_CLASS, TabGroupPanel: TAB_PANEL_CLASS };
+
+type QamExpansion = typeof import("./qamExpansion");
+
+/**
+ * A fresh copy of the module with `classes` as the webpack probe's answer.
+ * `vi.doMock` rather than a hoisted `vi.mock`: the hoisted factory's result is
+ * cached for the file, so both probe outcomes could not be exercised in one run.
+ */
+async function loadQamExpansion(classes: Record<string, string> | undefined): Promise<QamExpansion> {
+  vi.resetModules();
+  vi.doMock("./deckyUiInternals", () => ({ quickAccessMenuClasses: classes, Tabs: undefined }));
+  return await import("./qamExpansion");
+}
+
+/**
+ * The QAM shape the hook walks up through: the tab panel Decky's tab renders
+ * into, inside the parent Steam marks with `ActiveTab`.
+ */
+function mountQamDom(): { host: HTMLElement; panelParent: HTMLElement } {
+  const panelParent = document.createElement("div");
+  panelParent.className = ACTIVE_TAB_CLASS;
+  const panel = document.createElement("div");
+  panel.id = "quickaccess_content_999";
+  panel.className = TAB_PANEL_CLASS;
+  const host = document.createElement("div");
+  panel.appendChild(host);
+  panelParent.appendChild(panel);
+  document.body.appendChild(panelParent);
+  return { host, panelParent };
+}
+
+function renderWidePage(mod: QamExpansion, host: HTMLElement) {
+  const Page: FC = () => {
+    const rootRef = useRef<HTMLDivElement>(null);
+    mod.useWideQamPanel(rootRef);
+    return <div ref={rootRef} className={mod.WIDE_ROOT_CLASS} />;
+  };
+  return render(<Page />, { container: host });
+}
+
+/** Every injected stylesheet carrying the wide-page rule. */
+function wideStyles(markerClass: string): HTMLStyleElement[] {
+  return [...document.head.querySelectorAll("style")].filter((el) => el.textContent.includes(markerClass));
+}
+
+describe("setQamExpanded", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("names Steam's own expand and hide messages", async () => {
+    const { setQamExpanded } = await loadQamExpansion(PROBE_CLASSES);
+    const post = vi.spyOn(window, "postMessage").mockImplementation(() => {});
+
+    setQamExpanded(true);
+    setQamExpanded(false);
+
+    expect(post.mock.calls).toEqual([
+      [{ message: "QamFriendsExpanded" }, window.origin],
+      [{ message: "QamFriendsHidden" }, window.origin],
+    ]);
+  });
+
+  it("posts to window.origin, the only target origin that does not throw", async () => {
+    const { setQamExpanded } = await loadQamExpansion(PROBE_CLASSES);
+
+    // A literal origin is what the spike shipped first: postMessage rejects a
+    // target origin that is not the window's own, and one caller is onDismount,
+    // where the throw abandons the rest of the plugin's teardown.
+    expect(() => window.postMessage({ message: "QamFriendsExpanded" }, "https://steamloopback.host")).toThrow();
+    expect(() => setQamExpanded(true)).not.toThrow();
+    expect(() => setQamExpanded(false)).not.toThrow();
+  });
+});
+
+describe("useWideQamPanel", () => {
+  let post: ReturnType<typeof vi.spyOn<Window, "postMessage">>;
+
+  const lastMessage = () => {
+    const { calls } = post.mock;
+    return (calls[calls.length - 1]?.[0] as { message: string } | undefined)?.message;
+  };
+
+  beforeEach(() => {
+    qamVisible = true;
+    visibilityListeners.clear();
+    post = vi.spyOn(window, "postMessage").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.replaceChildren();
+    document.head.replaceChildren();
+  });
+
+  it("expands and injects the rule while the page is mounted", async () => {
+    const mod = await loadQamExpansion(PROBE_CLASSES);
+    const { host } = mountQamDom();
+
+    renderWidePage(mod, host);
+
+    expect(lastMessage()).toBe("QamFriendsExpanded");
+    expect(wideStyles(mod.WIDE_ROOT_CLASS)).toHaveLength(1);
+  });
+
+  it("never expands when the page mounts under an inactive Decky tab", async () => {
+    const mod = await loadQamExpansion(PROBE_CLASSES);
+    const { host, panelParent } = mountQamDom();
+    panelParent.classList.remove(ACTIVE_TAB_CLASS);
+
+    // The plugin's panel renders on while another QAM tab is active
+    // (`alwaysRender`), so a wide page can mount here. Expanding and retracting
+    // across two renders would flash Steam's own panel open.
+    renderWidePage(mod, host);
+
+    expect(post).not.toHaveBeenCalled();
+    expect(wideStyles(mod.WIDE_ROOT_CLASS)).toHaveLength(0);
+  });
+
+  it("clears on unmount", async () => {
+    const mod = await loadQamExpansion(PROBE_CLASSES);
+    const { host } = mountQamDom();
+    const { unmount } = renderWidePage(mod, host);
+
+    unmount();
+
+    expect(lastMessage()).toBe("QamFriendsHidden");
+    expect(wideStyles(mod.WIDE_ROOT_CLASS)).toHaveLength(0);
+  });
+
+  it("clears when the Decky tab stops being the active QAM tab, and re-expands when it returns", async () => {
+    const mod = await loadQamExpansion(PROBE_CLASSES);
+    const { host, panelParent } = mountQamDom();
+    renderWidePage(mod, host);
+
+    // A QAM tab switch is a class change on the panel's parent, not an unmount:
+    // the plugin's panel renders on (`alwaysRender`), so only the observer sees it.
+    await act(async () => {
+      panelParent.classList.remove(ACTIVE_TAB_CLASS);
+    });
+
+    expect(lastMessage()).toBe("QamFriendsHidden");
+    expect(wideStyles(mod.WIDE_ROOT_CLASS)).toHaveLength(0);
+
+    await act(async () => {
+      panelParent.classList.add(ACTIVE_TAB_CLASS);
+    });
+
+    expect(lastMessage()).toBe("QamFriendsExpanded");
+    expect(wideStyles(mod.WIDE_ROOT_CLASS)).toHaveLength(1);
+  });
+
+  it("clears when the QAM closes", async () => {
+    const mod = await loadQamExpansion(PROBE_CLASSES);
+    const { host } = mountQamDom();
+    renderWidePage(mod, host);
+
+    act(() => {
+      qamVisible = false;
+      for (const listener of visibilityListeners) listener();
+    });
+
+    expect(lastMessage()).toBe("QamFriendsHidden");
+    expect(wideStyles(mod.WIDE_ROOT_CLASS)).toHaveLength(0);
+  });
+
+  it("clears from the plugin's dismount, where no React cleanup runs", async () => {
+    const mod = await loadQamExpansion(PROBE_CLASSES);
+    const { host } = mountQamDom();
+    renderWidePage(mod, host);
+
+    mod.collapseQamOnDismount();
+
+    expect(lastMessage()).toBe("QamFriendsHidden");
+    expect(wideStyles(mod.WIDE_ROOT_CLASS)).toHaveLength(0);
+  });
+
+  it("writes the rule against the probe's tab-panel class when it resolves", async () => {
+    const mod = await loadQamExpansion(PROBE_CLASSES);
+    const { host } = mountQamDom();
+    renderWidePage(mod, host);
+
+    const css = wideStyles(mod.WIDE_ROOT_CLASS)[0]?.textContent ?? "";
+    expect(css).toContain(`.${TAB_PANEL_CLASS}:has(.${mod.WIDE_ROOT_CLASS})`);
+    expect(css).toContain("max-width: none");
+    expect(css).not.toContain("quickaccess_content_");
+  });
+
+  it("falls back to the panel's id prefix when the probe is undefined", async () => {
+    const mod = await loadQamExpansion(undefined);
+    const { host } = mountQamDom();
+    renderWidePage(mod, host);
+
+    const css = wideStyles(mod.WIDE_ROOT_CLASS)[0]?.textContent ?? "";
+    expect(css).toContain(`[id^="quickaccess_content_"]:has(.${mod.WIDE_ROOT_CLASS})`);
+    expect(css).not.toContain(TAB_PANEL_CLASS);
+    // Nothing names the active-tab class either, so the tab question cannot be
+    // asked — the page still expands rather than staying permanently narrow.
+    expect(lastMessage()).toBe("QamFriendsExpanded");
+  });
+});

--- a/src/utils/qamExpansion.test.tsx
+++ b/src/utils/qamExpansion.test.tsx
@@ -111,12 +111,13 @@ describe("setQamExpanded", () => {
     ]);
   });
 
-  it("posts to window.origin, the only target origin that does not throw", async () => {
+  it("passes the window's own origin rather than the literal the spike shipped first", async () => {
     const { setQamExpanded } = await loadQamExpansion(PROBE_CLASSES);
 
-    // A literal origin is what the spike shipped first: postMessage rejects a
-    // target origin that is not the window's own, and one caller is onDismount,
-    // where the throw abandons the rest of the plugin's teardown.
+    // The throw below is happy-dom's, not the browser's: Chrome parses a
+    // well-formed target origin and then discards the message at delivery when
+    // it does not match. So this pins the module against a literal only HERE —
+    // on the device the same mistake is silent, and the panel just never widens.
     expect(() => window.postMessage({ message: "QamFriendsExpanded" }, "https://steamloopback.host")).toThrow();
     expect(() => setQamExpanded(true)).not.toThrow();
     expect(() => setQamExpanded(false)).not.toThrow();

--- a/src/utils/qamExpansion.test.tsx
+++ b/src/utils/qamExpansion.test.tsx
@@ -49,20 +49,33 @@ async function loadQamExpansion(classes: Record<string, string> | undefined): Pr
   return await import("./qamExpansion");
 }
 
+interface QamFixture {
+  host: HTMLElement;
+  /** The element the observer has to watch: the parent of the id-bearing panel. */
+  panelParent: HTMLElement;
+}
+
 /**
- * The QAM shape the hook walks up through: the tab panel Decky's tab renders
- * into, inside the parent Steam marks with `ActiveTab`.
+ * The QAM shape the hook walks up through: the panel Decky's tab renders into,
+ * inside the parent Steam marks with `ActiveTab`.
+ *
+ * `tabPanelClassOn` says which element carries `TabGroupPanel` — the panel
+ * itself, or an ancestor. The spike could not tell the two apart, because
+ * `:has()` matches from any ancestor, so both shapes have to work.
  */
-function mountQamDom(): { host: HTMLElement; panelParent: HTMLElement } {
-  const panelParent = document.createElement("div");
+function mountQamDom(tabPanelClassOn: "panel" | "ancestor" = "panel", doc: Document = document): QamFixture {
+  const ancestor = doc.createElement("div");
+  const panelParent = doc.createElement("div");
   panelParent.className = ACTIVE_TAB_CLASS;
-  const panel = document.createElement("div");
+  const panel = doc.createElement("div");
   panel.id = "quickaccess_content_999";
-  panel.className = TAB_PANEL_CLASS;
-  const host = document.createElement("div");
+  const host = doc.createElement("div");
+
+  (tabPanelClassOn === "panel" ? panel : ancestor).className = TAB_PANEL_CLASS;
   panel.appendChild(host);
   panelParent.appendChild(panel);
-  document.body.appendChild(panelParent);
+  ancestor.appendChild(panelParent);
+  doc.body.appendChild(ancestor);
   return { host, panelParent };
 }
 
@@ -75,9 +88,9 @@ function renderWidePage(mod: QamExpansion, host: HTMLElement) {
   return render(<Page />, { container: host });
 }
 
-/** Every injected stylesheet carrying the wide-page rule. */
-function wideStyles(markerClass: string): HTMLStyleElement[] {
-  return [...document.head.querySelectorAll("style")].filter((el) => el.textContent.includes(markerClass));
+/** Every stylesheet in `doc` carrying the wide-page rule. */
+function wideStyles(markerClass: string, doc: Document = document): HTMLStyleElement[] {
+  return [...doc.head.querySelectorAll("style")].filter((el) => el.textContent.includes(markerClass));
 }
 
 describe("setQamExpanded", () => {
@@ -138,6 +151,53 @@ describe("useWideQamPanel", () => {
 
     expect(lastMessage()).toBe("QamFriendsExpanded");
     expect(wideStyles(mod.WIDE_ROOT_CLASS)).toHaveLength(1);
+  });
+
+  it("injects the rule into the page's own document, not the one plugin code runs in", async () => {
+    const mod = await loadQamExpansion(PROBE_CLASSES);
+    // Plugin JS runs in the SharedJSContext document; the QAM panel and the wide
+    // page's root live in a rendered-UI document. A rule injected into the
+    // ambient one would leave the panel expanded and its content still capped,
+    // with nothing to show for it.
+    const panelDoc = document.implementation.createHTMLDocument("qam");
+    const { host } = mountQamDom("panel", panelDoc);
+
+    renderWidePage(mod, host);
+
+    expect(wideStyles(mod.WIDE_ROOT_CLASS, panelDoc)).toHaveLength(1);
+    expect(wideStyles(mod.WIDE_ROOT_CLASS)).toHaveLength(0);
+
+    mod.collapseQamOnDismount();
+
+    expect(wideStyles(mod.WIDE_ROOT_CLASS, panelDoc)).toHaveLength(0);
+  });
+
+  it("watches the parent of the panel's id, not of whatever carries the tab-panel class", async () => {
+    const mod = await loadQamExpansion(PROBE_CLASSES);
+    const { host, panelParent } = mountQamDom("ancestor");
+
+    // Walking to the TabGroupPanel element instead would land a level too high:
+    // its parent carries no ActiveTab, so the page would never expand at all.
+    renderWidePage(mod, host);
+
+    expect(lastMessage()).toBe("QamFriendsExpanded");
+
+    await act(async () => {
+      panelParent.classList.remove(ACTIVE_TAB_CLASS);
+    });
+
+    expect(lastMessage()).toBe("QamFriendsHidden");
+  });
+
+  it("posts nothing from dismount when no wide page took the panel", async () => {
+    const mod = await loadQamExpansion(PROBE_CLASSES);
+
+    // The flag is Steam's own: an unconditional hide would retract a Friends
+    // panel the user opened, and the frame has no consumer yet, so every plugin
+    // dismount would do exactly that.
+    mod.collapseQamOnDismount();
+
+    expect(post).not.toHaveBeenCalled();
   });
 
   it("never expands when the page mounts under an inactive Decky tab", async () => {

--- a/src/utils/qamExpansion.ts
+++ b/src/utils/qamExpansion.ts
@@ -54,9 +54,11 @@ let injectedStyle: HTMLStyleElement | null = null;
  * events on the window plugin code runs in and flips one MobX observable, which
  * carries the `Expanded` class that un-shifts the QAM's placeholder.
  *
- * The target origin is always `window.origin`, never a literal: `postMessage`
- * throws on a mismatch, and one caller is `onDismount`, where a throw abandons
- * the rest of the plugin's teardown.
+ * The target origin is `window.origin`: it addresses the message to the one
+ * window meant to receive it, and always matches, so the message is always
+ * delivered. Neither alternative is wanted — a literal that ever stops matching
+ * is checked at delivery and discarded in silence, leaving a panel that simply
+ * never widens, and `"*"` is delivered to any document in the window.
  */
 export function setQamExpanded(expanded: boolean): void {
   window.postMessage({ message: expanded ? "QamFriendsExpanded" : "QamFriendsHidden" }, window.origin);

--- a/src/utils/qamExpansion.ts
+++ b/src/utils/qamExpansion.ts
@@ -23,19 +23,31 @@ export const WIDE_ROOT_CLASS = "romm-wide-qam-root";
 const WIDE_PANEL_STYLE_ID = "romm-wide-qam-styles";
 
 // Decky registers a single QAM tab (`QuickAccessTab.Decky = 999`), so the
-// plugin's tab panel is `#quickaccess_content_999` — the fallback for a
-// `quickAccessMenuClasses` probe that came back undefined.
+// plugin's panel is `#quickaccess_content_999`. This is the handle for walking
+// the DOM: the id is on the panel itself, whereas `TabGroupPanel` is a class
+// whose element the spike never isolated — `:has()` matches from any ancestor,
+// so a rule that works proves nothing about which element carries it.
+const PANEL_ID_SELECTOR = '[id^="quickaccess_content_"]';
+
 const TAB_PANEL_SELECTOR = quickAccessMenuClasses?.TabGroupPanel
   ? `.${quickAccessMenuClasses.TabGroupPanel}`
-  : '[id^="quickaccess_content_"]';
+  : PANEL_ID_SELECTOR;
 
-// Every tab's content panel is capped at 300 px; only Steam's own Friends panel
-// lifts it. The cap sits on the panel and on its first child, so both need the
-// rule, and `:has()` scopes it to a panel holding a wide page of ours.
+// Steam caps every tab's content panel at 300 px and lifts it only for its own
+// Friends panel (ADR-0029). Covering the panel and its children is the shape
+// the spike proved on the device; which of the two carries the cap was never
+// isolated, so both stay. `:has()` scopes the lift to a panel holding a wide
+// page of ours.
 const WIDE_PANEL_CSS = `
 ${TAB_PANEL_SELECTOR}:has(.${WIDE_ROOT_CLASS}) { max-width: none; }
 ${TAB_PANEL_SELECTOR}:has(.${WIDE_ROOT_CLASS}) > * { max-width: none; }
 `;
+
+// The stylesheet a wide page has up, held by reference rather than looked up by
+// id: it lives in the page's own document, and plugin code runs in a different
+// one, so the ambient `document` cannot reach it. One reference is enough — the
+// panel's router mounts one page at a time.
+let injectedStyle: HTMLStyleElement | null = null;
 
 /**
  * Drive Steam's Friends-tab expansion. The FriendsUI store listens for `message`
@@ -50,17 +62,36 @@ export function setQamExpanded(expanded: boolean): void {
   window.postMessage({ message: expanded ? "QamFriendsExpanded" : "QamFriendsHidden" }, window.origin);
 }
 
-function removeWidePanelStyle(): void {
-  document.getElementById(WIDE_PANEL_STYLE_ID)?.remove();
+/**
+ * Give the panel's width back, if this plugin ever took it. A no-op otherwise:
+ * the flag is Steam's own and global, so posting the hide message unasked would
+ * retract a Friends panel the user opened.
+ */
+function collapseWidePanel(): void {
+  const style = injectedStyle;
+  if (!style) return;
+  injectedStyle = null;
+  style.remove();
+  setQamExpanded(false);
+}
+
+function expandWidePanel(root: HTMLElement): void {
+  if (injectedStyle) return;
+  setQamExpanded(true);
+  const doc = root.ownerDocument;
+  const style = doc.createElement("style");
+  style.id = WIDE_PANEL_STYLE_ID;
+  style.textContent = WIDE_PANEL_CSS;
+  doc.head.appendChild(style);
+  injectedStyle = style;
 }
 
 /**
- * Collapse the panel from the plugin's `onDismount`, where no React cleanup
- * runs any more. Safe to call when no wide page was ever mounted.
+ * Collapse the panel from the plugin's `onDismount`, where no React cleanup runs
+ * any more.
  */
 export function collapseQamOnDismount(): void {
-  setQamExpanded(false);
-  removeWidePanelStyle();
+  collapseWidePanel();
 }
 
 /**
@@ -77,10 +108,11 @@ export function useWideQamPanel(rootRef: RefObject<HTMLElement | null>): void {
   const qamVisible = useQuickAccessVisible();
 
   useEffect(() => {
-    if (!qamVisible) return;
+    const root = rootRef.current;
+    if (!qamVisible || !root) return;
 
     const activeTabClass = quickAccessMenuClasses?.ActiveTab;
-    const panelParent = rootRef.current?.closest(TAB_PANEL_SELECTOR)?.parentElement;
+    const panelParent = root.closest(PANEL_ID_SELECTOR)?.parentElement;
 
     // True while the question cannot be asked — no panel around us, or a probe
     // that came back undefined so there is no class name to look for. The other
@@ -88,25 +120,7 @@ export function useWideQamPanel(rootRef: RefObject<HTMLElement | null>): void {
     // leaked expansion the QAM-close, unmount and dismount paths still clear.
     const deckyTabActive = () => !activeTabClass || !panelParent || panelParent.classList.contains(activeTabClass);
 
-    let injected: HTMLStyleElement | null = null;
-
-    const expand = () => {
-      if (injected) return;
-      setQamExpanded(true);
-      injected = document.createElement("style");
-      injected.id = WIDE_PANEL_STYLE_ID;
-      injected.textContent = WIDE_PANEL_CSS;
-      document.head.appendChild(injected);
-    };
-
-    const collapse = () => {
-      if (!injected) return;
-      setQamExpanded(false);
-      injected.remove();
-      injected = null;
-    };
-
-    const syncPanelWidth = () => (deckyTabActive() ? expand() : collapse());
+    const syncPanelWidth = () => (deckyTabActive() ? expandWidePanel(root) : collapseWidePanel());
     syncPanelWidth();
 
     // Switching QAM tabs changes the parent's class and unmounts nothing, so the
@@ -119,7 +133,7 @@ export function useWideQamPanel(rootRef: RefObject<HTMLElement | null>): void {
 
     return () => {
       observer?.disconnect();
-      collapse();
+      collapseWidePanel();
     };
   }, [qamVisible, rootRef]);
 }

--- a/src/utils/qamExpansion.ts
+++ b/src/utils/qamExpansion.ts
@@ -1,0 +1,125 @@
+/**
+ * The two levers that widen the plugin's Quick Access Menu panel from 348 px to
+ * 854 px, and the paths that clear them again.
+ *
+ * Steam ships no API for either. Both are internals with no compatibility
+ * promise, measured on the device rather than read from documentation; the
+ * decision to use them, and what it rests on, is
+ * `docs/adr/0029-wide-qam-pages-drive-steams-friends-expansion.md`.
+ *
+ * The flag the first lever sets is Steam's own and global, so whoever sets it
+ * clears it: a wide page that leaks it leaves Steam's QAM expanded until the
+ * Friends tab toggles it back. `useWideQamPanel` covers the three paths a
+ * mounted page can observe; `collapseQamOnDismount` is the fourth.
+ */
+
+import { useEffect, type RefObject } from "react";
+import { useQuickAccessVisible } from "@decky/ui";
+import { quickAccessMenuClasses } from "./deckyUiInternals";
+
+/** Marker class on a wide page's root, matched by the injected `:has()` rule. */
+export const WIDE_ROOT_CLASS = "romm-wide-qam-root";
+
+const WIDE_PANEL_STYLE_ID = "romm-wide-qam-styles";
+
+// Decky registers a single QAM tab (`QuickAccessTab.Decky = 999`), so the
+// plugin's tab panel is `#quickaccess_content_999` — the fallback for a
+// `quickAccessMenuClasses` probe that came back undefined.
+const TAB_PANEL_SELECTOR = quickAccessMenuClasses?.TabGroupPanel
+  ? `.${quickAccessMenuClasses.TabGroupPanel}`
+  : '[id^="quickaccess_content_"]';
+
+// Every tab's content panel is capped at 300 px; only Steam's own Friends panel
+// lifts it. The cap sits on the panel and on its first child, so both need the
+// rule, and `:has()` scopes it to a panel holding a wide page of ours.
+const WIDE_PANEL_CSS = `
+${TAB_PANEL_SELECTOR}:has(.${WIDE_ROOT_CLASS}) { max-width: none; }
+${TAB_PANEL_SELECTOR}:has(.${WIDE_ROOT_CLASS}) > * { max-width: none; }
+`;
+
+/**
+ * Drive Steam's Friends-tab expansion. The FriendsUI store listens for `message`
+ * events on the window plugin code runs in and flips one MobX observable, which
+ * carries the `Expanded` class that un-shifts the QAM's placeholder.
+ *
+ * The target origin is always `window.origin`, never a literal: `postMessage`
+ * throws on a mismatch, and one caller is `onDismount`, where a throw abandons
+ * the rest of the plugin's teardown.
+ */
+export function setQamExpanded(expanded: boolean): void {
+  window.postMessage({ message: expanded ? "QamFriendsExpanded" : "QamFriendsHidden" }, window.origin);
+}
+
+function removeWidePanelStyle(): void {
+  document.getElementById(WIDE_PANEL_STYLE_ID)?.remove();
+}
+
+/**
+ * Collapse the panel from the plugin's `onDismount`, where no React cleanup
+ * runs any more. Safe to call when no wide page was ever mounted.
+ */
+export function collapseQamOnDismount(): void {
+  setQamExpanded(false);
+  removeWidePanelStyle();
+}
+
+/**
+ * Hold the panel wide for as long as the page owning `rootRef` is mounted, the
+ * Decky tab is the active QAM tab, and the QAM is open. Losing any of the three
+ * posts the hide message and drops the stylesheet; regaining it re-expands.
+ *
+ * The tab question is answered from the DOM inside the effect rather than from
+ * React state: the plugin's panel renders on when another QAM tab is active
+ * (`alwaysRender`), so a page mounting there would expand on its first pass and
+ * retract on the next — a visible flash of Steam's own panel.
+ */
+export function useWideQamPanel(rootRef: RefObject<HTMLElement | null>): void {
+  const qamVisible = useQuickAccessVisible();
+
+  useEffect(() => {
+    if (!qamVisible) return;
+
+    const activeTabClass = quickAccessMenuClasses?.ActiveTab;
+    const panelParent = rootRef.current?.closest(TAB_PANEL_SELECTOR)?.parentElement;
+
+    // True while the question cannot be asked — no panel around us, or a probe
+    // that came back undefined so there is no class name to look for. The other
+    // default would make every wide page permanently narrow; this one costs a
+    // leaked expansion the QAM-close, unmount and dismount paths still clear.
+    const deckyTabActive = () => !activeTabClass || !panelParent || panelParent.classList.contains(activeTabClass);
+
+    let injected: HTMLStyleElement | null = null;
+
+    const expand = () => {
+      if (injected) return;
+      setQamExpanded(true);
+      injected = document.createElement("style");
+      injected.id = WIDE_PANEL_STYLE_ID;
+      injected.textContent = WIDE_PANEL_CSS;
+      document.head.appendChild(injected);
+    };
+
+    const collapse = () => {
+      if (!injected) return;
+      setQamExpanded(false);
+      injected.remove();
+      injected = null;
+    };
+
+    const syncPanelWidth = () => (deckyTabActive() ? expand() : collapse());
+    syncPanelWidth();
+
+    // Switching QAM tabs changes the parent's class and unmounts nothing, so the
+    // observer is the only thing that sees it.
+    let observer: MutationObserver | null = null;
+    if (activeTabClass && panelParent) {
+      observer = new MutationObserver(syncPanelWidth);
+      observer.observe(panelParent, { attributes: true, attributeFilter: ["class"] });
+    }
+
+    return () => {
+      observer?.disconnect();
+      collapse();
+    };
+  }, [qamVisible, rootRef]);
+}

--- a/src/utils/qamExpansion.ts
+++ b/src/utils/qamExpansion.ts
@@ -34,10 +34,11 @@ const TAB_PANEL_SELECTOR = quickAccessMenuClasses?.TabGroupPanel
   : PANEL_ID_SELECTOR;
 
 // Steam caps every tab's content panel at 300 px and lifts it only for its own
-// Friends panel (ADR-0029). Covering the panel and its children is the shape
-// the spike proved on the device; which of the two carries the cap was never
-// isolated, so both stay. `:has()` scopes the lift to a panel holding a wide
-// page of ours.
+// Friends panel, through the compound selector `.TabGroupPanel.tab_Friends`
+// (ADR-0029) — one element carrying both classes, which is evidence the cap
+// sits on the panel element itself. The `> *` line is cheap insurance against
+// it sitting one level in, kept until a device check settles which it is.
+// `:has()` scopes the lift to a panel holding a wide page of ours.
 const WIDE_PANEL_CSS = `
 ${TAB_PANEL_SELECTOR}:has(.${WIDE_ROOT_CLASS}) { max-width: none; }
 ${TAB_PANEL_SELECTOR}:has(.${WIDE_ROOT_CLASS}) > * { max-width: none; }
@@ -45,8 +46,14 @@ ${TAB_PANEL_SELECTOR}:has(.${WIDE_ROOT_CLASS}) > * { max-width: none; }
 
 // The stylesheet a wide page has up, held by reference rather than looked up by
 // id: it lives in the page's own document, and plugin code runs in a different
-// one, so the ambient `document` cannot reach it. One reference is enough — the
-// panel's router mounts one page at a time.
+// one, so the ambient `document` cannot reach it.
+//
+// One reference for the module, which holds only while at most one wide page is
+// mounted — the panel's router replaces the mounted page, it never stacks two.
+// Break that and the reference stops belonging to anyone: the second page's
+// mount is a no-op on an expansion it did not take, and its unmount collapses
+// the panel under the first — stylesheet dropped, hide message posted, and the
+// page still on screen has no path back to wide short of a QAM tab switch.
 let injectedStyle: HTMLStyleElement | null = null;
 
 /**


### PR DESCRIPTION
Closes #1813.

The shell every wide QAM page will render in, with no page using it yet. Structure and vocabulary: `docs/architecture/qam-panel.md`; the width decision: ADR-0029.

- `src/utils/qamExpansion.ts`: the two levers that widen the panel from 348 px to 854 px — the `QamFriendsExpanded` window message and one `:has()` stylesheet that lifts the tab panel's 300 px cap for a marker class on the page's own subtree, injected into the page's own document. `useWideQamPanel` holds both while the page is mounted, the Decky tab is the active QAM tab and the QAM is open, and clears them on each exit; `collapseQamOnDismount` is the fourth path, called first in `onDismount`.
- `src/utils/deckyUiInternals.ts`: `quickAccessMenuClasses` and `Tabs` typed `| undefined`, with `[id^="quickaccess_content_"]` as the fallback selector.
- `src/components/qam/WidePage.tsx`: Back row, title, optional L1/R1 tabs on Steam's `Tabs`, and a body whose height is measured from the remaining viewport rather than left to a `min-height`.
- `src/components/qam/ListDetail.tsx`: list on the left, detail on the right, both scrolling on their own; focus selects, and A stays with the row's own control.
- 28 tests: the target origin is `window.origin`, the levers clear on all four paths, the fallback selector, the height, the tabs, focus selection, and the frame's binding to the marker class and the levers.
- Docs: the new modules in `qam-panel.md`, Library moved ahead of Sync in the sequence, and one corrected sentence in ADR-0029 — a mismatched `postMessage` target origin drops the message in a browser; the throw the spike saw was happy-dom's.

The device measurement (854 px at `.ViewPlaceholder`, 348 px again after Back, a tab switch and closing the QAM) is recorded in a comment on this PR.
