### PR TITLE
feat(qam): the wide-page frame, verified on the device

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -495,6 +495,17 @@ Format: **invariant** — tier — enforced by.
   (`src/components/RomMGameInfoPanel.test.tsx`); the store side and every new write site on either are prompt-only,
   because a checker scoped to the store's own function bodies would be green on the case this rule was written for. The
   reasons behind the two writer mechanisms live at `writerForRom` and `RomBinding` — do not restate them here
+- **Every row a reader must be able to reach on a wide QAM page is a row Steam can focus — a toggle, a button, or a
+  `Focusable` carrying an activate handler, including a table row with no action of its own, so the reader can walk the
+  table** — prompt-only — nothing checks it, and the frontend suite cannot see it: happy-dom has no nav tree, so a page
+  whose rows are unreachable renders exactly like one whose rows are not, and a mouse-driven dev loop never meets the
+  problem either. A region scrolls only by moving focus — Steam's plain `ScrollPanel` binds no gamepad direction — so an
+  unreachable row is also an unscrollable one, and everything below the fold is simply out of reach with a controller.
+  The trap is that a bare `Focusable` is a container rather than a focus stop: the base panel sets `focusable` only from
+  a caller prop or an `onActivate`/`onOKButton`, and `GetFocusable()` answers `"none"` for a node with neither and no
+  focusable children. The rule spans every page the wide frame will host, and the frame cannot carry it: it holds a
+  page's content as opaque nodes, never as rows it could check. Detail: `docs/architecture/qam-panel.md`, "Building
+  blocks"
 
 When a change applies a guard / sanitize / backup / grouping pattern, sweep for sibling sites of the same pattern — the
 register is what that sweep checks against.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -461,10 +461,11 @@ sync (no Force Full Sync). Same-name-**within-one-label** still unions.
 What the plugin's Quick Access Menu panel shows at one time, chosen by the panel's router (`Page` in
 `src/types/navigation.ts`). Exactly one page is mounted at a time; navigating to another unmounts it. **Main** is the
 page the panel opens on: notices, status, the Sync button, the download summary and the menu. A **wide page** is a page
-that widens the panel from 348 px to 854 px for as long as it is mounted — the width belongs to the page, not to a view
-inside it, and it collapses again when the page unmounts, the QAM tab changes, the panel closes or the plugin is
-dismounted. Main and Downloads are narrow; every other page is wide. _Avoid_: sub-page, screen, route (a **route** is a
-Steam page outside the QAM, such as the game detail page).
+that widens the panel from 348 px to 854 px for as long as it is mounted — the full screen width on the Deck, whose Big
+Picture viewport is 854 CSS px across. The width belongs to the page, not to a view inside it, and it collapses again
+when the page unmounts, the QAM tab changes, the panel closes or the plugin is dismounted. Main and Downloads are
+narrow; every other page is wide. _Avoid_: sub-page, screen, route (a **route** is a Steam page outside the QAM, such as
+the game detail page).
 
 ### List and detail
 

--- a/docs/adr/0029-wide-qam-pages-drive-steams-friends-expansion.md
+++ b/docs/adr/0029-wide-qam-pages-drive-steams-friends-expansion.md
@@ -13,11 +13,13 @@ was built inside that number: six pages behind a router, each a full-screen repl
 narrow column cannot show a list and its detail at once; sections without titles; rows that fold two facts into a label
 and a description because a third column has nowhere to go.
 
-Steam's own Friends tab runs at 854 px. The main window's `.ViewPlaceholder` is always 854 px wide, anchored right and
-pushed off-screen by `transform: translateX(506px)`; Steam's `Expanded` class sets `translateX(0)`. That class follows
-one MobX observable, `qamFriendsExpanded`, on the FriendsUI store, which registers a `message` listener on the
-SharedJSContext window — the window plugin code runs in — and flips on `QamFriendsExpanded` / `QamFriendsHidden`. The
-per-tab 300 px cap is a second, independent rule; only `.TabGroupPanel.tab_Friends` lifts it.
+Steam's own Friends tab runs at 854 px. The QAM lives in a sliding container in the main window — an absolutely
+positioned element the width of the viewport, anchored right and pushed off-screen by `transform: translateX(506px)`, so
+348 px stay visible; Steam's `Expanded` class sets `translateX(0)`. Its class names are hashed, so it is identified by
+geometry rather than by a selector. That class follows one MobX observable, `qamFriendsExpanded`, on the FriendsUI
+store, which registers a `message` listener on the SharedJSContext window — the window plugin code runs in — and flips
+on `QamFriendsExpanded` / `QamFriendsHidden`. The per-tab 300 px cap is a second, independent rule; only
+`.TabGroupPanel.tab_Friends` lifts it.
 
 Measured on the device (Big Picture, CEF Chrome 126), not read from documentation: posting the message widens the
 visible panel from 348 px to 854 px; lifting the cap widens the plugin's tab panel from 300 px to 806 px (854 minus the
@@ -53,14 +55,22 @@ change, no unmount), when the QAM closes (`useQuickAccessVisible`), and from the
 
 ## Consequences
 
-- **The wide state rests on undocumented Steam internals** — the message name, the placeholder, the `Expanded` class,
-  the per-tab cap. A Steam update can silently stop the expansion; the plugin's own rule would still lift the cap, so a
-  wide page would render 806 px of content inside a 348 px panel and clip. No fallback switch is built for that case:
-  the rebuild proceeds, and a switch or a width-dependent navigation is reconsidered only if updates keep breaking it.
-  The expansion is measurable in the dev loop through the placeholder's geometry (`findSP()`); the QAM browser view
-  itself is 855 px wide in both states and proves nothing.
+- **The wide state rests on undocumented Steam internals** — the message name, the sliding container, the `Expanded`
+  class, the per-tab cap. A Steam update can silently stop the expansion; the plugin's own rule would still lift the
+  cap, so a wide page would render 806 px of content inside a 348 px panel and clip. No fallback switch is built for
+  that case: the rebuild proceeds, and a switch or a width-dependent navigation is reconsidered only if updates keep
+  breaking it. The expansion is measurable in the dev loop through the sliding container's geometry (`findSP()`); the
+  QAM browser view itself is 855 px wide in both states and proves nothing.
+- **On the Deck a wide page covers the whole screen.** The Big Picture viewport is 854 × 534 CSS px at
+  `devicePixelRatio` 1.5 (1280 × 800 physical), so 854 px is not a wider panel over a visible library — it is the
+  library gone. On a desktop Big Picture window, which is wider, the same page is a panel with the library beside it, so
+  every width judgement has to be made under `mise run dev:ui-scale deck` or it is made against a layout no Deck ever
+  shows.
 - **The flag is Steam's and global.** A page that leaks it leaves Steam's own QAM expanded until the Friends tab toggles
-  it back. The four clearing paths above are the whole discipline.
+  it back. The four clearing paths above are the whole discipline — with two of Steam's own behaviours behind them:
+  `OpenQuickAccessMenu` calls `SetQAMFriendsChatExpanded(false)` on every QAM tab change away from Friends, and the
+  Friends tab re-expands itself from its list's `onFocusWithin`. So the flag is never ours alone to hold, and a Friends
+  panel that widens after our page closed is Steam doing that, not a leak of ours.
 - **`window.origin`, never a literal origin.** It addresses the message to the one window meant to receive it and always
   matches it. A well-formed target origin that does not match is checked at delivery and the message is discarded in
   silence, so a literal is a failure with no symptom but a panel that never widens; `"*"` is always delivered, but to

--- a/docs/adr/0029-wide-qam-pages-drive-steams-friends-expansion.md
+++ b/docs/adr/0029-wide-qam-pages-drive-steams-friends-expansion.md
@@ -60,7 +60,7 @@ change, no unmount), when the QAM closes (`useQuickAccessVisible`), and from the
   cap, so a wide page would render 806 px of content inside a 348 px panel and clip. No fallback switch is built for
   that case: the rebuild proceeds, and a switch or a width-dependent navigation is reconsidered only if updates keep
   breaking it. The expansion is measurable in the dev loop through the sliding container's geometry (`findSP()`); the
-  QAM browser view itself is 855 px wide in both states and proves nothing.
+  QAM browser view itself is 854 px wide in both states and proves nothing.
 - **On the Deck a wide page covers the whole screen.** The Big Picture viewport is 854 × 534 CSS px at
   `devicePixelRatio` 1.5 (1280 × 800 physical), so 854 px is not a wider panel over a visible library — it is the
   library gone. On a desktop Big Picture window, which is wider, the same page is a panel with the library beside it, so

--- a/docs/architecture/qam-panel.md
+++ b/docs/architecture/qam-panel.md
@@ -115,6 +115,11 @@ QAM remount, so reopening the QAM lands on the page that was open, and a wide pa
 Steam's tabbed page, switched with L1/R1, for two to four peer views of one page. Wide pages only: at 300 px the bumper
 glyphs overlap the labels, which is why the Library page's tab bar is hand-rolled today. Only Library has tabs.
 
+Entry focus lands in the content — the active tab's, so the list of a list-and-detail page — and the bumper glyphs
+follow, because Steam draws them only while gamepad focus is within the tabbed page. Back stays reachable by moving up
+and with B. A tabbed page therefore marks itself as placing its own entry focus, and the panel's router leaves it alone
+instead of focusing the page's first button, which is the Back row above the tabs.
+
 ### List and detail
 
 The list takes about a third of the width (264 px in the prototype), the detail the rest. Focus selects: moving through

--- a/docs/architecture/qam-panel.md
+++ b/docs/architecture/qam-panel.md
@@ -16,20 +16,20 @@ without restating it. The width mechanism's decision record is
 
 ## Where the code lives
 
-| Module                                                        | Responsibility                                                                                                       |
-| ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `src/index.tsx` (`QAMPanel`)                                  | The router: one `Page` value, one mounted page, a module-level `currentPage` that survives a QAM remount             |
-| `src/types/navigation.ts`                                     | The `Page` union — every page the router can land on                                                                 |
-| `src/components/MainPage.tsx`                                 | Main                                                                                                                 |
-| `src/components/LibraryPage.tsx`                              | Library — Platforms and Collections                                                                                  |
-| `src/components/SettingsPage.tsx`, `src/components/settings/` | Settings and its sections                                                                                            |
-| `src/components/DangerZone.tsx`, `RemovedGamesCleanup.tsx`    | Data Management                                                                                                      |
-| `src/components/DownloadQueue.tsx`                            | Downloads                                                                                                            |
-| `src/components/SystemPage.tsx`                               | System — retires into Library › Platforms                                                                            |
-| `src/utils/deckyUiInternals.ts`                               | Honest typing for `@decky/ui` values that come from a webpack probe; the wide frame's class names and `Tabs` go here |
-| `src/utils/qamExpansion.ts`                                   | The panel's width: the expand and hide messages, the injected `max-width` rule, and the four paths that clear both   |
-| `src/components/qam/`                                         | The wide-page frame: `WidePage` (Back row, title, tabs, measured height) and `ListDetail`                            |
-| `src/utils/` module stores                                    | State that must outlive a page: sync progress, pending preview, downloads, prune, notices                            |
+| Module                                                        | Responsibility                                                                                                      |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `src/index.tsx` (`QAMPanel`)                                  | The router: one `Page` value, one mounted page, a module-level `currentPage` that survives a QAM remount            |
+| `src/types/navigation.ts`                                     | The `Page` union — every page the router can land on                                                                |
+| `src/components/MainPage.tsx`                                 | Main                                                                                                                |
+| `src/components/LibraryPage.tsx`                              | Library — Platforms and Collections                                                                                 |
+| `src/components/SettingsPage.tsx`, `src/components/settings/` | Settings and its sections                                                                                           |
+| `src/components/DangerZone.tsx`, `RemovedGamesCleanup.tsx`    | Data Management                                                                                                     |
+| `src/components/DownloadQueue.tsx`                            | Downloads                                                                                                           |
+| `src/components/SystemPage.tsx`                               | System — retires into Library › Platforms                                                                           |
+| `src/utils/deckyUiInternals.ts`                               | Honest typing for `@decky/ui` values that come from a webpack probe: the frame's class names, `Tabs`, scroll panels |
+| `src/utils/qamExpansion.ts`                                   | The panel's width: the expand and hide messages, the injected `max-width` rule, and the four paths that clear both  |
+| `src/components/qam/`                                         | The wide-page frame: `WidePage` (Back row, title, tabs, measured height), `ListDetail` and `ScrollRegion`           |
+| `src/utils/` module stores                                    | State that must outlive a page: sync progress, pending preview, downloads, prune, notices                           |
 
 ## Two widths
 
@@ -37,30 +37,56 @@ Every page is either narrow (348 px, 300 px of content) or wide (854 px, 806 px 
 page: a page is wide or it is not, and no view inside a page changes it. Main and Downloads are narrow; Sync, Library,
 Settings and Data Management are wide.
 
-How a page gets wide, measured on the device (Big Picture, CEF Chrome 126) rather than read from documentation:
+**On the Deck, wide means full screen.** The Big Picture viewport is 854 × 534 CSS px at `devicePixelRatio` 1.5 (1280 ×
+800 physical), so the narrow panel covers 41 % of the width and the wide one covers all of it — there is no library left
+beside a wide page. A desktop Big Picture window is wider and shows one, which is why width judgements are made under
+`mise run dev:ui-scale deck` and nowhere else.
 
-- Steam's main window holds the QAM in `.ViewPlaceholder`, always 854 px wide, anchored right and pushed off-screen by
-  `transform: translateX(506px)`, so 348 px stay visible. Steam's `Expanded` class sets `translateX(0)`. The class
-  follows one MobX observable on the FriendsUI store, which listens for `message` events on the SharedJSContext window —
-  the window plugin code runs in. A wide page posts `{ message: "QamFriendsExpanded" }` to `window` on mount and
-  `{ message: "QamFriendsHidden" }` when it lets go. The target origin is always `window.origin`, which addresses the
-  message to that window and always matches it. A well-formed target origin that does not match is checked at delivery
-  and the message is discarded in silence, so a literal one would leave the panel simply never widening.
+How a page gets wide, measured on the device rather than read from documentation:
+
+- Steam's main window holds the QAM in a sliding container: an absolutely positioned element as wide as the viewport and
+  854 × 454 CSS px on the Deck — the 80 px above it is Steam's top bar — anchored right and pushed off-screen by
+  `transform: translateX(506px)`, so 348 px stay visible. Steam's `Expanded` class sets `translateX(0)`. Its class names
+  are hashed and there is no `ViewPlaceholder` to match on any more, so the container is found by geometry: absolutely
+  positioned, a transform set, at least 800 × 400. The class follows one MobX observable on the FriendsUI store, which
+  listens for `message` events on the SharedJSContext window — the window plugin code runs in. A wide page posts
+  `{ message: "QamFriendsExpanded" }` to `window` on mount and `{ message: "QamFriendsHidden" }` when it lets go. The
+  target origin is always `window.origin`, which addresses the message to that window and always matches it. A
+  well-formed target origin that does not match is checked at delivery and the message is discarded in silence, so a
+  literal one would leave the panel simply never widening.
 - Every tab's content panel carries `max-width: 300px`; only Steam's Friends panel lifts it. A wide page injects one
   stylesheet whose `:has()` rule lifts the cap for a marker class on the plugin's own subtree. Class names come from
   `quickAccessMenuClasses`, which can be `undefined`; `[id^="quickaccess_content_"]` is the fallback selector. Decky
-  registers one QAM tab (`QuickAccessTab.Decky = 999`), so the plugin's panel is `#quickaccess_content_999`.
+  registers one QAM tab (`QuickAccessTab.Decky = 999`), so the plugin's panel is `#quickaccess_content_999` — and
+  `TabGroupPanel` sits on that same element, measured, which is why walking the DOM by id and writing the CSS against
+  the class reach the same panel.
 - Result: the visible panel goes from 348 px to 854 px and the tab panel from 300 px to 806 px (854 minus the 48 px tab
-  rail). The QAM browser view itself is 855 px wide in both states, so only the placeholder's geometry, read through
-  `findSP()`, proves an expansion.
+  rail). The QAM browser view itself is 855 px wide in both states, so only the sliding container's geometry, read
+  through `findSP()`, proves an expansion.
 
 The flag is Steam's and global, so the page that set it clears it: on unmount (navigation away, plugin closed), when the
 Decky tab stops being the active QAM tab (the `ActiveTab` class on the panel's parent — a tab switch is a class change,
 not an unmount), when the QAM closes (`useQuickAccessVisible`), and from `onDismount`.
 
+Steam moves the same flag on its own, in both directions, and neither is a bug in the plugin. `OpenQuickAccessMenu`
+clears it (`SetQAMFriendsChatExpanded(false)`) on every QAM tab change away from Friends, which is a second net under
+the plugin's own `ActiveTab` observer; and the Friends tab's list expands it from `onFocusWithin`, so Friends goes wide
+the moment gamepad focus enters it. A Friends panel that widens after a wide page closed is Steam doing that. Both are
+in `chunk~2dcc5aaf7.js` in Steam's own bundle, where the receiver is also visible: `OnMessage` on the FriendsUI store
+sets `m_bQamFriendsExpanded` from exactly the two messages the plugin sends, and Steam's own senders post with the
+literal `"https://steamloopback.host"` — which is what `window.origin` is in the SharedJSContext.
+
 Steam's tabbed page fills its parent instead of growing, and nothing in the QAM chain provides a height. A wide page
 therefore measures the viewport left below its header and takes that as its height; its regions scroll inside it. A
-`min-height` is not enough — it clips.
+`min-height` is not enough — it clips. Under Decky's title bar, the frame's Back row, its title and a tab bar, that
+leaves a body of roughly 260 px inside the 454 px view.
+
+A region's own scrolling is Steam's, not CSS. Steam's gamepad navigation scrolls by moving focus, so an `overflow: auto`
+box holding content nobody can focus — a detail pane of text — cannot be scrolled with a controller at all. Every
+scrolling region therefore goes through `ScrollRegion`, which renders Steam's scroll panel: the same component the QAM's
+own tab panel is built from, with gamepad direction bound to scrolling. Both of a list-and-detail page's regions are
+ones, and so is the frame's body when the page has no tabs; a tabbed page's body is not, because Steam's tabbed page
+brings a scroll panel per tab.
 
 ## Pages
 

--- a/docs/architecture/qam-panel.md
+++ b/docs/architecture/qam-panel.md
@@ -16,20 +16,20 @@ without restating it. The width mechanism's decision record is
 
 ## Where the code lives
 
-| Module                                                        | Responsibility                                                                                                      |
-| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `src/index.tsx` (`QAMPanel`)                                  | The router: one `Page` value, one mounted page, a module-level `currentPage` that survives a QAM remount            |
-| `src/types/navigation.ts`                                     | The `Page` union — every page the router can land on                                                                |
-| `src/components/MainPage.tsx`                                 | Main                                                                                                                |
-| `src/components/LibraryPage.tsx`                              | Library — Platforms and Collections                                                                                 |
-| `src/components/SettingsPage.tsx`, `src/components/settings/` | Settings and its sections                                                                                           |
-| `src/components/DangerZone.tsx`, `RemovedGamesCleanup.tsx`    | Data Management                                                                                                     |
-| `src/components/DownloadQueue.tsx`                            | Downloads                                                                                                           |
-| `src/components/SystemPage.tsx`                               | System — retires into Library › Platforms                                                                           |
-| `src/utils/deckyUiInternals.ts`                               | Honest typing for `@decky/ui` values that come from a webpack probe: the frame's class names, `Tabs`, scroll panels |
-| `src/utils/qamExpansion.ts`                                   | The panel's width: the expand and hide messages, the injected `max-width` rule, and the four paths that clear both  |
-| `src/components/qam/`                                         | The wide-page frame: `WidePage` (Back row, title, tabs, measured height), `ListDetail` and `ScrollRegion`           |
-| `src/utils/` module stores                                    | State that must outlive a page: sync progress, pending preview, downloads, prune, notices                           |
+| Module                                                        | Responsibility                                                                                                           |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `src/index.tsx` (`QAMPanel`)                                  | The router: one `Page` value, one mounted page, a module-level `currentPage` that survives a QAM remount                 |
+| `src/types/navigation.ts`                                     | The `Page` union — every page the router can land on                                                                     |
+| `src/components/MainPage.tsx`                                 | Main                                                                                                                     |
+| `src/components/LibraryPage.tsx`                              | Library — Platforms and Collections                                                                                      |
+| `src/components/SettingsPage.tsx`, `src/components/settings/` | Settings and its sections                                                                                                |
+| `src/components/DangerZone.tsx`, `RemovedGamesCleanup.tsx`    | Data Management                                                                                                          |
+| `src/components/DownloadQueue.tsx`                            | Downloads                                                                                                                |
+| `src/components/SystemPage.tsx`                               | System — retires into Library › Platforms                                                                                |
+| `src/utils/deckyUiInternals.ts`                               | Honest typing for `@decky/ui` values that come from a webpack probe: the frame's class names, `Tabs`, `ScrollPanelGroup` |
+| `src/utils/qamExpansion.ts`                                   | The panel's width: the expand and hide messages, the injected `max-width` rule, and the four paths that clear both       |
+| `src/components/qam/`                                         | The wide-page frame: `WidePage` (Back row, title, tabs, measured height), `ListDetail` and `ScrollRegion`                |
+| `src/utils/` module stores                                    | State that must outlive a page: sync progress, pending preview, downloads, prune, notices                                |
 
 ## Two widths
 
@@ -61,7 +61,7 @@ How a page gets wide, measured on the device rather than read from documentation
   `TabGroupPanel` sits on that same element, measured, which is why walking the DOM by id and writing the CSS against
   the class reach the same panel.
 - Result: the visible panel goes from 348 px to 854 px and the tab panel from 300 px to 806 px (854 minus the 48 px tab
-  rail). The QAM browser view itself is 855 px wide in both states, so only the sliding container's geometry, read
+  rail). The QAM browser view itself is 854 px wide in both states, so only the sliding container's geometry, read
   through `findSP()`, proves an expansion.
 
 The flag is Steam's and global, so the page that set it clears it: on unmount (navigation away, plugin closed), when the
@@ -83,10 +83,12 @@ leaves a body of roughly 260 px inside the 454 px view.
 
 A region's own scrolling is Steam's, not CSS. Steam's gamepad navigation scrolls by moving focus, so an `overflow: auto`
 box holding content nobody can focus — a detail pane of text — cannot be scrolled with a controller at all. Every
-scrolling region therefore goes through `ScrollRegion`, which renders Steam's scroll panel: the same component the QAM's
-own tab panel is built from, with gamepad direction bound to scrolling. Both of a list-and-detail page's regions are
-ones, and so is the frame's body when the page has no tabs; a tabbed page's body is not, because Steam's tabbed page
-brings a scroll panel per tab.
+scrolling region therefore goes through `ScrollRegion`, which renders `ScrollPanelGroup`, the one Steam scroll panel
+that binds gamepad direction to scrolling. Its plain sibling `ScrollPanel` does not, and that is the kind Steam uses for
+the QAM's own tab panel and for each tab's content — so neither of those solves this for us.
+
+Both of a list-and-detail page's regions are `ScrollRegion`s, and so is the frame's body when the page has no tabs. A
+tabbed body gets none from the frame: see "Building blocks → Tabs" for whose job it is instead.
 
 ## Pages
 
@@ -116,9 +118,15 @@ Steam's tabbed page, switched with L1/R1, for two to four peer views of one page
 glyphs overlap the labels, which is why the Library page's tab bar is hand-rolled today. Only Library has tabs.
 
 Entry focus lands in the content — the active tab's, so the list of a list-and-detail page — and the bumper glyphs
-follow, because Steam draws them only while gamepad focus is within the tabbed page. Back stays reachable by moving up
-and with B. A tabbed page therefore marks itself as placing its own entry focus, and the panel's router leaves it alone
-instead of focusing the page's first button, which is the Back row above the tabs.
+follow, because Steam draws them only while gamepad focus is within the tabbed page. Back stays reachable by moving up.
+A tabbed page therefore marks itself as placing its own entry focus, and the panel's router leaves it alone instead of
+focusing the page's first button, which is the Back row above the tabs.
+
+**A tab's content is the page's business, not the frame's.** The frame wraps an untabbed body in a `ScrollRegion` and a
+tabbed one in nothing, because it cannot know what a tab holds. Steam's per-tab scroller does not close the gap: it is
+the plain `ScrollPanel`, which binds no gamepad direction, so a tab holding content nobody can focus is as unscrollable
+as a bare div. A page with such a tab wraps that content in `ScrollRegion` itself. Library's tabs hold list-and-detail
+layouts, which carry their own regions, so nothing there needs it today.
 
 ### List and detail
 

--- a/docs/architecture/qam-panel.md
+++ b/docs/architecture/qam-panel.md
@@ -86,10 +86,12 @@ A region scrolls the way the rest of the QAM scrolls: by moving focus. Every scr
 one Steam's tabbed page wraps each tab's content in. It is an `overflow-y: auto` box that takes no focus of its own, so
 the rows inside it take focus directly and Steam scrolls the focused row into view.
 
-**Every row a reader must be able to reach is a focusable row.** A toggle, a button, a `Focusable`-wrapped table row —
-including a table row that carries no action, so the reader can walk the table. Plain text that only accompanies a row,
-a hint under a group, scrolls with its neighbours and need not be reachable itself. This is what focus-driven scrolling
-costs: content nobody can focus cannot be scrolled to.
+**Every row a reader must be able to reach is a focusable row.** A toggle, a button, or — where a table row carries no
+action of its own, so the reader can still walk the table — a `Focusable` with an `onActivate` handler. The handler is
+what makes it a stop: `FocusableProps` exposes no `focusable` prop, an activate handler is what sets one, and a bare
+`Focusable` is a container that passes focus on to its children rather than taking it. Plain text that only accompanies
+a row, a hint under a group, scrolls with its neighbours and need not be reachable itself. This is what focus-driven
+scrolling costs: content nobody can focus cannot be scrolled to.
 
 `ScrollPanelGroup` — the sibling that binds gamepad direction to scrolling, and would carry unfocusable content — was
 tried on the device and rejected. It is focusable and its OK button focuses its first visible child, so each region

--- a/docs/architecture/qam-panel.md
+++ b/docs/architecture/qam-panel.md
@@ -16,20 +16,20 @@ without restating it. The width mechanism's decision record is
 
 ## Where the code lives
 
-| Module                                                        | Responsibility                                                                                                           |
-| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `src/index.tsx` (`QAMPanel`)                                  | The router: one `Page` value, one mounted page, a module-level `currentPage` that survives a QAM remount                 |
-| `src/types/navigation.ts`                                     | The `Page` union — every page the router can land on                                                                     |
-| `src/components/MainPage.tsx`                                 | Main                                                                                                                     |
-| `src/components/LibraryPage.tsx`                              | Library — Platforms and Collections                                                                                      |
-| `src/components/SettingsPage.tsx`, `src/components/settings/` | Settings and its sections                                                                                                |
-| `src/components/DangerZone.tsx`, `RemovedGamesCleanup.tsx`    | Data Management                                                                                                          |
-| `src/components/DownloadQueue.tsx`                            | Downloads                                                                                                                |
-| `src/components/SystemPage.tsx`                               | System — retires into Library › Platforms                                                                                |
-| `src/utils/deckyUiInternals.ts`                               | Honest typing for `@decky/ui` values that come from a webpack probe: the frame's class names, `Tabs`, `ScrollPanelGroup` |
-| `src/utils/qamExpansion.ts`                                   | The panel's width: the expand and hide messages, the injected `max-width` rule, and the four paths that clear both       |
-| `src/components/qam/`                                         | The wide-page frame: `WidePage` (Back row, title, tabs, measured height), `ListDetail` and `ScrollRegion`                |
-| `src/utils/` module stores                                    | State that must outlive a page: sync progress, pending preview, downloads, prune, notices                                |
+| Module                                                        | Responsibility                                                                                                      |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `src/index.tsx` (`QAMPanel`)                                  | The router: one `Page` value, one mounted page, a module-level `currentPage` that survives a QAM remount            |
+| `src/types/navigation.ts`                                     | The `Page` union — every page the router can land on                                                                |
+| `src/components/MainPage.tsx`                                 | Main                                                                                                                |
+| `src/components/LibraryPage.tsx`                              | Library — Platforms and Collections                                                                                 |
+| `src/components/SettingsPage.tsx`, `src/components/settings/` | Settings and its sections                                                                                           |
+| `src/components/DangerZone.tsx`, `RemovedGamesCleanup.tsx`    | Data Management                                                                                                     |
+| `src/components/DownloadQueue.tsx`                            | Downloads                                                                                                           |
+| `src/components/SystemPage.tsx`                               | System — retires into Library › Platforms                                                                           |
+| `src/utils/deckyUiInternals.ts`                               | Honest typing for `@decky/ui` values that come from a webpack probe: the frame's class names, `Tabs`, `ScrollPanel` |
+| `src/utils/qamExpansion.ts`                                   | The panel's width: the expand and hide messages, the injected `max-width` rule, and the four paths that clear both  |
+| `src/components/qam/`                                         | The wide-page frame: `WidePage` (Back row, title, tabs, measured height), `ListDetail` and `ScrollRegion`           |
+| `src/utils/` module stores                                    | State that must outlive a page: sync progress, pending preview, downloads, prune, notices                           |
 
 ## Two widths
 
@@ -81,11 +81,20 @@ therefore measures the viewport left below its header and takes that as its heig
 `min-height` is not enough — it clips. Under Decky's title bar, the frame's Back row, its title and a tab bar, that
 leaves a body of roughly 260 px inside the 454 px view.
 
-A region's own scrolling is Steam's, not CSS. Steam's gamepad navigation scrolls by moving focus, so an `overflow: auto`
-box holding content nobody can focus — a detail pane of text — cannot be scrolled with a controller at all. Every
-scrolling region therefore goes through `ScrollRegion`, which renders `ScrollPanelGroup`, the one Steam scroll panel
-that binds gamepad direction to scrolling. Its plain sibling `ScrollPanel` does not, and that is the kind Steam uses for
-the QAM's own tab panel and for each tab's content — so neither of those solves this for us.
+A region scrolls the way the rest of the QAM scrolls: by moving focus. Every scrolling region goes through
+`ScrollRegion`, which renders Steam's plain `ScrollPanel` — the container the QAM's own tab panel is built from, and the
+one Steam's tabbed page wraps each tab's content in. It is an `overflow-y: auto` box that takes no focus of its own, so
+the rows inside it take focus directly and Steam scrolls the focused row into view.
+
+**Every row a reader must be able to reach is a focusable row.** A toggle, a button, a `Focusable`-wrapped table row —
+including a table row that carries no action, so the reader can walk the table. Plain text that only accompanies a row,
+a hint under a group, scrolls with its neighbours and need not be reachable itself. This is what focus-driven scrolling
+costs: content nobody can focus cannot be scrolled to.
+
+`ScrollPanelGroup` — the sibling that binds gamepad direction to scrolling, and would carry unfocusable content — was
+tried on the device and rejected. It is focusable and its OK button focuses its first visible child, so each region
+became a focus stop of its own: the whole list outlined as one block, A to step into it, and only then rows taking
+focus. Steam's own QAM does not behave that way.
 
 Both of a list-and-detail page's regions are `ScrollRegion`s, and so is the frame's body when the page has no tabs. A
 tabbed body gets none from the frame: see "Building blocks → Tabs" for whose job it is instead.
@@ -123,16 +132,17 @@ A tabbed page therefore marks itself as placing its own entry focus, and the pan
 focusing the page's first button, which is the Back row above the tabs.
 
 **A tab's content is the page's business, not the frame's.** The frame wraps an untabbed body in a `ScrollRegion` and a
-tabbed one in nothing, because it cannot know what a tab holds. Steam's per-tab scroller does not close the gap: it is
-the plain `ScrollPanel`, which binds no gamepad direction, so a tab holding content nobody can focus is as unscrollable
-as a bare div. A page with such a tab wraps that content in `ScrollRegion` itself. Library's tabs hold list-and-detail
-layouts, which carry their own regions, so nothing there needs it today.
+tabbed one in nothing: Steam's tabbed page already wraps each tab's content in this same plain scroll panel, so a region
+from the frame would only nest a second scroller around it. Rows of one column therefore scroll in a tab with nothing
+added. A page that needs more than that one scroller — a list and a detail scrolling independently side by side — builds
+its regions with `ScrollRegion` itself, which is what Library's tabs do.
 
 ### List and detail
 
 The list takes about a third of the width (264 px in the prototype), the detail the rest. Focus selects: moving through
 the list changes the detail at once, as Steam's own settings do. A list row may carry a toggle; A operates it, never the
-selection. Both regions scroll independently inside the page's measured height.
+selection. Both regions scroll independently inside the page's measured height, and both scroll by moving focus — so a
+detail pane is built from focusable rows, not from paragraphs.
 
 A list that is grouped or sorted by state computes its order when the page mounts and keeps it while the page is open,
 so toggling a row does not move it out from under the focus. The next mount shows the new order.

--- a/docs/architecture/qam-panel.md
+++ b/docs/architecture/qam-panel.md
@@ -315,6 +315,7 @@ store screenshots (#830) are taken after.
 - [#1809](https://github.com/danielcopper/romm-tender/issues/1809) — the design issue this page answers.
 - The static prototype the decisions were made on: [qam-prototype.html](../assets/qam-prototype.html), a single
   self-contained page kept in `docs/assets/`. Every page at device size with numbered notes; its example data is
-  invented, and it reflects the decisions as of this page's first version.
+  invented, and it reflects the decisions as of this page's first version. Redrawn to the Deck's real 854 × 534 CSS px —
+  Steam's 80 px top bar over a 454 px panel — once the device round had measured them.
 - [ADR-0029](../adr/0029-wide-qam-pages-drive-steams-friends-expansion.md) — why the panel widens through Steam's
   Friends expansion and not a full-screen route, and what that rests on.

--- a/docs/assets/qam-prototype.html
+++ b/docs/assets/qam-prototype.html
@@ -82,7 +82,7 @@
   .subtabs { display: flex; gap: 8px; margin: 0 0 12px; }
 
   .stage { position: relative; overflow: hidden; border: 1px solid var(--line); border-radius: 4px; background: #0e1116; }
-  .deck { position: absolute; top: 0; left: 0; width: 1280px; height: 800px; transform-origin: 0 0; overflow: hidden;
+  .deck { position: absolute; top: 0; left: 0; width: 854px; height: 534px; transform-origin: 0 0; overflow: hidden;
           background: radial-gradient(1100px 620px at 28% 18%, #262c39, #0e1116 70%); }
   .caption { display: flex; gap: 18px; margin: 8px 0 22px; font-family: var(--font-mono); font-size: 12px; color: var(--muted); }
 
@@ -115,7 +115,10 @@
           --blue: #1a9fff; --ok: #59bf40; --warn: #f0a030; --dng: #e8686a; --fill: rgba(255,255,255,.08); --fill2: rgba(255,255,255,.14);
           font-family: var(--font-mock); color: var(--t); font-size: 14px; line-height: 1.35; }
   .bgtile { position: absolute; border-radius: 6px; background: rgba(255,255,255,.035); }
-  .qam { position: absolute; top: 0; right: 0; bottom: 0; width: 348px; display: flex; box-shadow: -12px 0 40px rgba(0,0,0,.45); }
+  /* Steam's top bar takes the first 80 of the 534 CSS px; the QuickAccess view is the 454 px below it. */
+  .deck::before { content: ""; position: absolute; top: 0; left: 0; right: 0; height: 80px; background: #0b0d11; }
+  .deck::after { content: "95 %   13:28"; position: absolute; top: 28px; right: 24px; font: 600 15px/1 var(--font-mock); color: #dcdedf; letter-spacing: .02em; }
+  .qam { position: absolute; top: 80px; right: 0; bottom: 0; width: 348px; display: flex; box-shadow: -12px 0 40px rgba(0,0,0,.45); }
   .qam.wide { width: 854px; }
   .rail { width: 48px; background: var(--p2); display: flex; flex-direction: column; align-items: center; padding-top: 14px; gap: 16px; flex: none; }
   .rail i { width: 18px; height: 18px; border: 2px solid #5a6270; border-radius: 4px; display: block; }
@@ -198,11 +201,10 @@
 
   @media (prefers-reduced-motion: no-preference) { .chip, .index button { transition: background .12s; } }
 </style>
-
 </head>
 <body>
 <header class="top">
-  <h1>Tender QAM Prototype <small>static · 1280×800 · panel 348 / 854 px</small></h1>
+  <h1>Tender QAM Prototype <small>static · 854×534 CSS px, the Deck at 1.5× · panel 348 / 854 px</small></h1>
   <div class="switch">
     <span class="lab">DECIDED 2026-09-02</span>
     <span class="chip" aria-pressed="true" style="cursor:default">everything about one platform in one place</span>
@@ -229,7 +231,7 @@
     <!-- ================= STRUKTUR ================= -->
     <section class="screen on" id="s-struktur">
       <h2>Structure</h2>
-      <p class="sub">Main stays narrow and is the entry point. Behind it are pages that are wide, where list and detail sit next to each other. Everything about one platform is in one place, Sync gets its own page.</p>
+      <p class="sub">Main stays narrow and is the entry point. Behind it are pages that are wide, where list and detail sit next to each other. Everything about one platform is in one place, Sync gets its own page. Drawn at the Deck's real metrics, measured on the device: 854 × 534 CSS px at 1.5× scale, so a wide page is the full screen, and the panel below Steam's top bar is 454 px tall.</p>
 
       <div class="trees">
         <div class="tree">
@@ -337,7 +339,7 @@
           </div>
         </div>
       </div></div>
-      <div class="caption"><span>Panel 348 px · content 300 px</span><span>Unchanged: status rows, download summary</span></div>
+      <div class="caption"><span>Panel 348 px, 41 % of the screen · content 300 px · 454 px tall</span><span>Unchanged: status rows, download summary</span></div>
 
       <div class="notes">
         <div><h3>Notes</h3>
@@ -412,7 +414,7 @@
           </div>
         </div>
       </div></div>
-      <div class="caption"><span>Panel 854 px · content 806 px</span><span>Left column flexible, right column 270 px</span></div>
+      <div class="caption"><span>Panel 854 px, the full screen width · content 806 px · 454 px tall</span><span>Left column flexible, right column 270 px</span></div>
       <div class="notes">
         <div><h3>Notes</h3>
           <ol>
@@ -518,7 +520,7 @@
           </div>
         </div>
       </div></div>
-      <div class="caption"><span>Panel 854 px · content 806 px</span><span>List 264 px · detail 524 px</span></div>
+      <div class="caption"><span>Panel 854 px, the full screen width · content 806 px · 454 px tall</span><span>List 264 px · detail 524 px</span></div>
 
       <div class="notes">
         <div><h3>Notes</h3>
@@ -586,7 +588,7 @@
           </div>
         </div>
       </div></div>
-      <div class="caption"><span>Panel 854 px · content 806 px</span><span>Sections 220 px · content 568 px</span></div>
+      <div class="caption"><span>Panel 854 px, the full screen width · content 806 px · 454 px tall</span><span>Sections 220 px · content 568 px</span></div>
       <div class="notes">
         <div><h3>Notes</h3>
           <ol>
@@ -646,7 +648,7 @@
           </div>
         </div>
       </div></div>
-      <div class="caption"><span>Panel 854 px · content 806 px</span><span>Operations 240 px · content 548 px</span></div>
+      <div class="caption"><span>Panel 854 px, the full screen width · content 806 px · 454 px tall</span><span>Operations 240 px · content 548 px</span></div>
       <div class="notes">
         <div><h3>Notes</h3>
           <ol>
@@ -690,7 +692,7 @@
           </div>
         </div>
       </div></div>
-      <div class="caption"><span>Panel 348 px · content 300 px</span></div>
+      <div class="caption"><span>Panel 348 px, 41 % of the screen · content 300 px · 454 px tall</span></div>
       <div class="notes">
         <div><h3>Notes</h3>
           <ul>
@@ -718,9 +720,9 @@
     function fit() {
       document.querySelectorAll('.screen.on .stage').forEach(function (s) {
         var w = s.clientWidth; if (!w) return;
-        var sc = Math.min(1, w / 1280);
+        var sc = Math.min(1, w / 854);
         s.querySelector('.deck').style.transform = 'scale(' + sc + ')';
-        s.style.height = Math.round(800 * sc) + 'px';
+        s.style.height = Math.round(534 * sc) + 'px';
       });
     }
 

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -171,7 +171,6 @@ vi.mock("@decky/ui", async () => {
     playSectionClasses: undefined,
     quickAccessMenuClasses: undefined,
     Tabs: undefined,
-    ScrollPanel: undefined,
     ScrollPanelGroup: undefined,
     findSP: vi.fn(() => undefined),
     ConfirmModal: (p: AnyProps) => ce("div", { "data-testid": "confirm-modal" }, p.children as never),

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -171,7 +171,7 @@ vi.mock("@decky/ui", async () => {
     playSectionClasses: undefined,
     quickAccessMenuClasses: undefined,
     Tabs: undefined,
-    ScrollPanelGroup: undefined,
+    ScrollPanel: undefined,
     findSP: vi.fn(() => undefined),
     ConfirmModal: (p: AnyProps) => ce("div", { "data-testid": "confirm-modal" }, p.children as never),
     DialogButton: ({

--- a/src/components/RomMPlaySection.test.tsx
+++ b/src/components/RomMPlaySection.test.tsx
@@ -171,6 +171,8 @@ vi.mock("@decky/ui", async () => {
     playSectionClasses: undefined,
     quickAccessMenuClasses: undefined,
     Tabs: undefined,
+    ScrollPanel: undefined,
+    ScrollPanelGroup: undefined,
     findSP: vi.fn(() => undefined),
     ConfirmModal: (p: AnyProps) => ce("div", { "data-testid": "confirm-modal" }, p.children as never),
     DialogButton: ({

--- a/src/components/qam/ListDetail.test.tsx
+++ b/src/components/qam/ListDetail.test.tsx
@@ -6,7 +6,7 @@
  * focusin event rather than Steam's gamepad engine.
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { useState, type CSSProperties, type FC, type ReactNode } from "react";
 import { ListDetail, type ListDetailItem, type ListDetailProps } from "./ListDetail";
@@ -48,6 +48,14 @@ const ControlledHost: FC<{ onSelect?: (id: string) => void; onToggle?: (id: stri
 };
 
 describe("ListDetail", () => {
+  // The scroll-panel test swaps deckyUiInternals for a stub in the module
+  // registry, where a `vi.doMock` otherwise stands for the rest of the file and
+  // would reach any later test that imports dynamically.
+  afterEach(() => {
+    vi.doUnmock("../../utils/deckyUiInternals");
+    vi.resetModules();
+  });
+
   it("selects the row that takes focus and swaps the detail with it", () => {
     const onSelect = vi.fn();
     render(<ControlledHost onSelect={onSelect} />);

--- a/src/components/qam/ListDetail.test.tsx
+++ b/src/components/qam/ListDetail.test.tsx
@@ -8,8 +8,8 @@
 
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { useState, type FC } from "react";
-import { ListDetail, type ListDetailItem } from "./ListDetail";
+import { useState, type CSSProperties, type FC, type ReactNode } from "react";
+import { ListDetail, type ListDetailItem, type ListDetailProps } from "./ListDetail";
 
 const PLATFORMS = [
   { id: "n64", name: "Nintendo 64" },
@@ -108,6 +108,35 @@ describe("ListDetail", () => {
     expect(detail).toContainElement(screen.getByText("detail for n64"));
     expect(list?.style.overflow).toBe("auto");
     expect(detail?.style.overflow).toBe("auto");
+  });
+
+  it("gives each region Steam's scroll panel, so unfocusable detail content scrolls", async () => {
+    vi.resetModules();
+    vi.doMock("../../utils/deckyUiInternals", () => ({
+      ScrollPanelGroup: ({ style, children }: { style?: CSSProperties; children?: ReactNode }) => (
+        <div data-testid="scroll-panel" style={style}>
+          {children}
+        </div>
+      ),
+    }));
+    const Scrolling = (await import("./ListDetail")).ListDetail as FC<ListDetailProps>;
+
+    render(
+      <Scrolling
+        items={platformItems(() => {})}
+        selectedId="n64"
+        onSelect={vi.fn()}
+        renderDetail={() => <div>plain text nobody can focus</div>}
+      />,
+    );
+    const [list, detail] = screen.getAllByTestId("scroll-panel");
+
+    // The detail pane is the case that forced this: Steam scrolls by moving
+    // focus, so rows that take no focus scroll only from inside the panel.
+    expect(list).toContainElement(screen.getByRole("button", { name: /Nintendo 64/ }));
+    expect(detail).toContainElement(screen.getByText("plain text nobody can focus"));
+    expect(list?.style.width).toBe("264px");
+    expect(detail?.style.height).toBe("100%");
   });
 
   it("renders a detail for an empty selection", () => {

--- a/src/components/qam/ListDetail.test.tsx
+++ b/src/components/qam/ListDetail.test.tsx
@@ -118,10 +118,10 @@ describe("ListDetail", () => {
     expect(detail?.style.overflow).toBe("auto");
   });
 
-  it("gives each region Steam's scroll panel, so unfocusable detail content scrolls", async () => {
+  it("gives each pane Steam's scroll panel, so the two scroll independently", async () => {
     vi.resetModules();
     vi.doMock("../../utils/deckyUiInternals", () => ({
-      ScrollPanelGroup: ({ style, children }: { style?: CSSProperties; children?: ReactNode }) => (
+      ScrollPanel: ({ style, children }: { style?: CSSProperties; children?: ReactNode }) => (
         <div data-testid="scroll-panel" style={style}>
           {children}
         </div>
@@ -134,15 +134,15 @@ describe("ListDetail", () => {
         items={platformItems(() => {})}
         selectedId="n64"
         onSelect={vi.fn()}
-        renderDetail={() => <div>plain text nobody can focus</div>}
+        renderDetail={() => <button>a detail row</button>}
       />,
     );
     const [list, detail] = screen.getAllByTestId("scroll-panel");
 
-    // The detail pane is the case that forced this: Steam scrolls by moving
-    // focus, so rows that take no focus scroll only from inside the panel.
+    // Two panels rather than one around both: the panes scroll independently, so
+    // a long detail must not carry the list up with it.
     expect(list).toContainElement(screen.getByRole("button", { name: /Nintendo 64/ }));
-    expect(detail).toContainElement(screen.getByText("plain text nobody can focus"));
+    expect(detail).toContainElement(screen.getByRole("button", { name: "a detail row" }));
     expect(list?.style.width).toBe("264px");
     expect(detail?.style.height).toBe("100%");
   });

--- a/src/components/qam/ListDetail.tsx
+++ b/src/components/qam/ListDetail.tsx
@@ -3,6 +3,10 @@
  * focused entry's detail on the right, each scrolling on its own inside the
  * frame's measured height.
  *
+ * A region scrolls by moving focus, so what a reader must be able to reach in
+ * either pane — a detail's table rows included — has to be focusable; plain
+ * text scrolls along with the row it accompanies but cannot be scrolled to.
+ *
  * Focus selects — moving through the list changes the detail at once, as Steam's
  * own settings do. The row's own control keeps A, so this component never
  * intercepts it; a row that carries a toggle still toggles on press.

--- a/src/components/qam/ListDetail.tsx
+++ b/src/components/qam/ListDetail.tsx
@@ -13,6 +13,7 @@
 
 import type { FC, ReactNode } from "react";
 import { Focusable } from "@decky/ui";
+import { ScrollRegion } from "./ScrollRegion";
 
 export interface ListDetailItem {
   id: string;
@@ -29,29 +30,29 @@ export interface ListDetailProps {
 // The list takes about a third of the 806 px a wide tab panel offers.
 const LIST_WIDTH = "264px";
 
-const regionStyle = { height: "100%", overflow: "auto", minHeight: 0 } as const;
-
 export const ListDetail: FC<ListDetailProps> = ({ items, selectedId, onSelect, renderDetail }) => (
   <Focusable flow-children="horizontal" style={{ display: "flex", gap: "12px", height: "100%", minHeight: 0 }}>
-    <Focusable flow-children="vertical" style={{ ...regionStyle, flex: `0 0 ${LIST_WIDTH}`, width: LIST_WIDTH }}>
-      {items.map((item) => (
-        // React delivers onFocus through focusin, so this fires for focus
-        // landing on whatever control the row itself renders — and again for
-        // every move between controls inside the same row, or on the way back
-        // from the detail pane. Only a real change is reported, so a page may
-        // treat onSelect as an event and do work on it.
-        <Focusable
-          key={item.id}
-          onFocus={() => {
-            if (item.id !== selectedId) onSelect(item.id);
-          }}
-        >
-          {item.render(item.id === selectedId)}
-        </Focusable>
-      ))}
-    </Focusable>
-    <Focusable flow-children="vertical" style={{ ...regionStyle, flex: "1 1 auto", minWidth: 0 }}>
-      {renderDetail(selectedId)}
-    </Focusable>
+    <ScrollRegion style={{ flex: `0 0 ${LIST_WIDTH}`, width: LIST_WIDTH }}>
+      <Focusable flow-children="vertical">
+        {items.map((item) => (
+          // React delivers onFocus through focusin, so this fires for focus
+          // landing on whatever control the row itself renders — and again for
+          // every move between controls inside the same row, or on the way back
+          // from the detail pane. Only a real change is reported, so a page may
+          // treat onSelect as an event and do work on it.
+          <Focusable
+            key={item.id}
+            onFocus={() => {
+              if (item.id !== selectedId) onSelect(item.id);
+            }}
+          >
+            {item.render(item.id === selectedId)}
+          </Focusable>
+        ))}
+      </Focusable>
+    </ScrollRegion>
+    <ScrollRegion style={{ flex: "1 1 auto", minWidth: 0 }}>
+      <Focusable flow-children="vertical">{renderDetail(selectedId)}</Focusable>
+    </ScrollRegion>
   </Focusable>
 );

--- a/src/components/qam/ScrollRegion.test.tsx
+++ b/src/components/qam/ScrollRegion.test.tsx
@@ -82,7 +82,7 @@ describe("ScrollRegion", () => {
   it("lets the caller place the region without losing its bounds", async () => {
     const ScrollRegion = await loadScrollRegion(StubScrollPanelGroup);
 
-    render(<ScrollRegion style={{ flex: "0 0 264px", width: "264px" }}>{null}</ScrollRegion>);
+    render(<ScrollRegion style={{ flex: "0 0 264px", width: "264px" }} />);
 
     const panel = screen.getByTestId("scroll-panel");
     expect(panel.style.flex).toBe("0 0 264px");

--- a/src/components/qam/ScrollRegion.test.tsx
+++ b/src/components/qam/ScrollRegion.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * ScrollRegion tests — that the region reaches Steam's scroll panel when the
+ * probe found one, that it still is a bounded region of the focus tree when the
+ * probe missed, and that a caller can place it without losing its bounds.
+ *
+ * What the panel then does with a gamepad is Steam's, and happy-dom has neither
+ * the panel nor a gamepad; the device round covers the scrolling itself.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { CSSProperties, FC, ReactNode } from "react";
+import type { ScrollRegionProps } from "./ScrollRegion";
+
+interface StubPanelProps {
+  style?: CSSProperties;
+  children?: ReactNode;
+}
+
+/** Stand-in for Steam's scroll panel: it keeps the style so bounds stay assertable. */
+const StubScrollPanelGroup: FC<StubPanelProps> = ({ style, children }) => (
+  <div data-testid="scroll-panel" style={style}>
+    {children}
+  </div>
+);
+
+/**
+ * A fresh copy of the component with `panel` as the webpack probe's answer.
+ * The probe is read at module scope, so both outcomes need their own load.
+ */
+async function loadScrollRegion(panel: FC<StubPanelProps> | undefined): Promise<FC<ScrollRegionProps>> {
+  vi.resetModules();
+  vi.doMock("../../utils/deckyUiInternals", () => ({ ScrollPanelGroup: panel }));
+  return (await import("./ScrollRegion")).ScrollRegion;
+}
+
+/** The bounds every region carries, whichever element ends up carrying them. */
+function expectBounds(el: HTMLElement): void {
+  expect(el.style.height).toBe("100%");
+  expect(el.style.overflow).toBe("auto");
+  // Without the floor reset a flex child's min-height is its content, so the
+  // region would grow past its parent instead of scrolling inside it. happy-dom
+  // keeps the "0" verbatim where a browser would normalise it to "0px".
+  expect(el.style.minHeight).toBe("0");
+}
+
+describe("ScrollRegion", () => {
+  it("puts its content in Steam's scroll panel when the probe found one", async () => {
+    const ScrollRegion = await loadScrollRegion(StubScrollPanelGroup);
+
+    render(
+      <ScrollRegion>
+        <div>region content</div>
+      </ScrollRegion>,
+    );
+
+    // Steam's gamepad navigation scrolls by moving focus, so content nobody can
+    // focus scrolls only from inside the panel. A bare div here would leave a
+    // detail pane of text rows reachable with a mouse and nothing else.
+    const panel = screen.getByTestId("scroll-panel");
+    expect(panel).toContainElement(screen.getByText("region content"));
+    expectBounds(panel);
+  });
+
+  it("keeps the region, its bounds and its place in the focus tree when the probe missed", async () => {
+    const ScrollRegion = await loadScrollRegion(undefined);
+
+    render(
+      <ScrollRegion>
+        <div>region content</div>
+      </ScrollRegion>,
+    );
+
+    expect(screen.queryByTestId("scroll-panel")).not.toBeInTheDocument();
+    // A Focusable rather than a div: the region is a level of the focus tree
+    // either way, so a missed probe costs the scrolling and nothing else.
+    const region = screen.getByTestId("focusable");
+    expect(region).toContainElement(screen.getByText("region content"));
+    expectBounds(region);
+  });
+
+  it("lets the caller place the region without losing its bounds", async () => {
+    const ScrollRegion = await loadScrollRegion(StubScrollPanelGroup);
+
+    render(<ScrollRegion style={{ flex: "0 0 264px", width: "264px" }}>{null}</ScrollRegion>);
+
+    const panel = screen.getByTestId("scroll-panel");
+    expect(panel.style.flex).toBe("0 0 264px");
+    expect(panel.style.width).toBe("264px");
+    expectBounds(panel);
+  });
+});

--- a/src/components/qam/ScrollRegion.test.tsx
+++ b/src/components/qam/ScrollRegion.test.tsx
@@ -3,8 +3,10 @@
  * probe found one, that it still is a bounded region of the focus tree when the
  * probe missed, and that a caller can place it without losing its bounds.
  *
- * What the panel then does with a gamepad is Steam's, and happy-dom has neither
- * the panel nor a gamepad; the device round covers the scrolling itself.
+ * What the panel then does with focus is Steam's: it takes none of its own, and
+ * the focused row is what scrolls into view. happy-dom has neither the panel nor
+ * a gamepad, so nothing here can pin that the region is not a focus stop — the
+ * device round is what pins it.
  */
 
 import { describe, it, expect, vi } from "vitest";
@@ -18,7 +20,7 @@ interface StubPanelProps {
 }
 
 /** Stand-in for Steam's scroll panel: it keeps the style so bounds stay assertable. */
-const StubScrollPanelGroup: FC<StubPanelProps> = ({ style, children }) => (
+const StubScrollPanel: FC<StubPanelProps> = ({ style, children }) => (
   <div data-testid="scroll-panel" style={style}>
     {children}
   </div>
@@ -30,7 +32,7 @@ const StubScrollPanelGroup: FC<StubPanelProps> = ({ style, children }) => (
  */
 async function loadScrollRegion(panel: FC<StubPanelProps> | undefined): Promise<FC<ScrollRegionProps>> {
   vi.resetModules();
-  vi.doMock("../../utils/deckyUiInternals", () => ({ ScrollPanelGroup: panel }));
+  vi.doMock("../../utils/deckyUiInternals", () => ({ ScrollPanel: panel }));
   return (await import("./ScrollRegion")).ScrollRegion;
 }
 
@@ -45,7 +47,7 @@ function expectBounds(el: HTMLElement): void {
 
 describe("ScrollRegion", () => {
   it("puts its content in Steam's scroll panel when the probe found one", async () => {
-    const ScrollRegion = await loadScrollRegion(StubScrollPanelGroup);
+    const ScrollRegion = await loadScrollRegion(StubScrollPanel);
 
     render(
       <ScrollRegion>
@@ -53,16 +55,15 @@ describe("ScrollRegion", () => {
       </ScrollRegion>,
     );
 
-    // Steam's gamepad navigation scrolls by moving focus, so content nobody can
-    // focus scrolls only from inside the panel. A bare div here would leave a
-    // detail pane of text rows reachable with a mouse and nothing else.
+    // The panel is the container the QAM's own tab panel is built from: rows
+    // inside it take focus directly and the focused one is scrolled into view.
     const panel = screen.getByTestId("scroll-panel");
     expect(panel).toContainElement(screen.getByText("region content"));
     expectBounds(panel);
   });
 
   it("leaves the panel's overflow to Steam, which clips it sideways", async () => {
-    const ScrollRegion = await loadScrollRegion(StubScrollPanelGroup);
+    const ScrollRegion = await loadScrollRegion(StubScrollPanel);
 
     render(
       <ScrollRegion>
@@ -71,9 +72,9 @@ describe("ScrollRegion", () => {
     );
 
     // Steam's ScrollY class is `overflow-y: auto` with `overflow-x: hidden`, and
-    // an inline shorthand beats both. The horizontal room it would restore is
-    // what the panel's gamepad-direction handler consumes left and right for,
-    // and left↔right is how focus crosses from a list to its detail.
+    // an inline shorthand beats both axes. The sideways scroll it would restore
+    // is one Steam clips on purpose: one over-wide row and every focus step
+    // would drag the pane left and right under the reader.
     expect(screen.getByTestId("scroll-panel").style.overflow).toBe("");
   });
 
@@ -87,8 +88,9 @@ describe("ScrollRegion", () => {
     );
 
     expect(screen.queryByTestId("scroll-panel")).not.toBeInTheDocument();
-    // A Focusable rather than a div: the region is a level of the focus tree
-    // either way, so a missed probe costs the scrolling and nothing else.
+    // A Focusable rather than a div: it is the base panel Steam's scroll panel
+    // itself renders, so the region stays one level of the focus tree and a
+    // missed probe costs Steam's scroll padding, not the structure.
     const region = screen.getByTestId("focusable");
     expect(region).toContainElement(screen.getByText("region content"));
     expectBounds(region);
@@ -97,7 +99,7 @@ describe("ScrollRegion", () => {
   });
 
   it("lets the caller place the region without losing its bounds", async () => {
-    const ScrollRegion = await loadScrollRegion(StubScrollPanelGroup);
+    const ScrollRegion = await loadScrollRegion(StubScrollPanel);
 
     render(<ScrollRegion style={{ flex: "0 0 264px", width: "264px" }} />);
 

--- a/src/components/qam/ScrollRegion.test.tsx
+++ b/src/components/qam/ScrollRegion.test.tsx
@@ -89,8 +89,10 @@ describe("ScrollRegion", () => {
 
     expect(screen.queryByTestId("scroll-panel")).not.toBeInTheDocument();
     // A Focusable rather than a div: it is the base panel Steam's scroll panel
-    // itself renders, so the region stays one level of the focus tree and a
-    // missed probe costs Steam's scroll padding, not the structure.
+    // itself renders, so the region stays one level of the focus tree. What a
+    // missed probe costs is what the panel adds on top — its scroll padding, its
+    // own focus-ring root, and the ref that scrolls the focused element back
+    // into view after a resize — not the structure.
     const region = screen.getByTestId("focusable");
     expect(region).toContainElement(screen.getByText("region content"));
     expectBounds(region);

--- a/src/components/qam/ScrollRegion.test.tsx
+++ b/src/components/qam/ScrollRegion.test.tsx
@@ -37,7 +37,6 @@ async function loadScrollRegion(panel: FC<StubPanelProps> | undefined): Promise<
 /** The bounds every region carries, whichever element ends up carrying them. */
 function expectBounds(el: HTMLElement): void {
   expect(el.style.height).toBe("100%");
-  expect(el.style.overflow).toBe("auto");
   // Without the floor reset a flex child's min-height is its content, so the
   // region would grow past its parent instead of scrolling inside it. happy-dom
   // keeps the "0" verbatim where a browser would normalise it to "0px".
@@ -62,6 +61,22 @@ describe("ScrollRegion", () => {
     expectBounds(panel);
   });
 
+  it("leaves the panel's overflow to Steam, which clips it sideways", async () => {
+    const ScrollRegion = await loadScrollRegion(StubScrollPanelGroup);
+
+    render(
+      <ScrollRegion>
+        <div>region content</div>
+      </ScrollRegion>,
+    );
+
+    // Steam's ScrollY class is `overflow-y: auto` with `overflow-x: hidden`, and
+    // an inline shorthand beats both. The horizontal room it would restore is
+    // what the panel's gamepad-direction handler consumes left and right for,
+    // and left↔right is how focus crosses from a list to its detail.
+    expect(screen.getByTestId("scroll-panel").style.overflow).toBe("");
+  });
+
   it("keeps the region, its bounds and its place in the focus tree when the probe missed", async () => {
     const ScrollRegion = await loadScrollRegion(undefined);
 
@@ -77,6 +92,8 @@ describe("ScrollRegion", () => {
     const region = screen.getByTestId("focusable");
     expect(region).toContainElement(screen.getByText("region content"));
     expectBounds(region);
+    // Nothing here carries a Steam class, so this branch owns its own overflow.
+    expect(region.style.overflow).toBe("auto");
   });
 
   it("lets the caller place the region without losing its bounds", async () => {

--- a/src/components/qam/ScrollRegion.tsx
+++ b/src/components/qam/ScrollRegion.tsx
@@ -9,9 +9,10 @@
  * only accompanies one scrolls along with it.
  *
  * The panel comes from a webpack probe that can miss, and a page whose regions
- * silently vanish would be worse than one whose regions scroll without Steam's
- * own scroll padding — so the fallback keeps the region, its bounds and its
- * place in the focus tree.
+ * silently vanish would be worse than one that scrolls without what the panel
+ * adds on top — so the fallback keeps the region, its bounds and its place in
+ * the focus tree, and gives up Steam's scroll padding, its own focus-ring root
+ * and the ref that scrolls the focused element back into view after a resize.
  *
  * Structure and vocabulary: `docs/architecture/qam-panel.md`.
  */

--- a/src/components/qam/ScrollRegion.tsx
+++ b/src/components/qam/ScrollRegion.tsx
@@ -1,0 +1,43 @@
+/**
+ * One scrolling region of a wide page, bounded by the height its parent gives it.
+ *
+ * Steam's gamepad navigation scrolls by moving focus, so a plain `overflow: auto`
+ * box holding content nobody can focus — a detail pane of text rows — cannot be
+ * scrolled with the controller at all, only with a mouse. Steam's scroll panel is
+ * what closes that: it binds gamepad direction to scrolling, which is why the
+ * QAM's own tab panel scrolls such content and a bare div does not.
+ *
+ * The panel comes from a webpack probe that can miss, and a page whose regions
+ * silently vanish would be worse than one that scrolls only under a mouse — so
+ * the fallback keeps the region, its bounds and its place in the focus tree.
+ *
+ * Structure and vocabulary: `docs/architecture/qam-panel.md`.
+ */
+
+import type { CSSProperties, FC, ReactNode } from "react";
+import { Focusable } from "@decky/ui";
+import { ScrollPanelGroup } from "../../utils/deckyUiInternals";
+
+export interface ScrollRegionProps {
+  /** Merged over the region's own bounds — the caller places it, not sizes it. */
+  style?: CSSProperties;
+  children?: ReactNode;
+}
+
+// `height: 100%` and `minHeight: 0` together are what let a flex child scroll
+// rather than grow: without the floor reset a flex item's min-height is its
+// content, so the region expands past its parent and the page clips instead.
+const BOUNDS: CSSProperties = { height: "100%", minHeight: 0, overflow: "auto" };
+
+export const ScrollRegion: FC<ScrollRegionProps> = ({ style, children }) => {
+  const regionStyle = { ...BOUNDS, ...style };
+
+  // Focusable, not a div, when the probe misses: the region is a level of the
+  // focus tree either way, and a plain div would silently restructure gamepad
+  // navigation around it.
+  return ScrollPanelGroup ? (
+    <ScrollPanelGroup style={regionStyle}>{children}</ScrollPanelGroup>
+  ) : (
+    <Focusable style={regionStyle}>{children}</Focusable>
+  );
+};

--- a/src/components/qam/ScrollRegion.tsx
+++ b/src/components/qam/ScrollRegion.tsx
@@ -1,23 +1,24 @@
 /**
  * One scrolling region of a wide page, bounded by the height its parent gives it.
  *
- * Steam's gamepad navigation scrolls by moving focus, so a plain `overflow: auto`
- * box holding content nobody can focus — a detail pane of text rows — cannot be
- * scrolled with the controller at all, only with a mouse. `ScrollPanelGroup`
- * closes that by binding gamepad direction to scrolling. Its plain sibling
- * `ScrollPanel` does not, which is why reaching for the panel Steam's own QAM tab
- * uses would not have fixed anything: that one is the plain kind.
+ * The region is Steam's plain `ScrollPanel`, the container the QAM's own tab
+ * panel is built from. It is not a focus stop of its own: the rows inside take
+ * focus directly and Steam scrolls the focused row into view, which is how the
+ * rest of the QAM scrolls. Reaching content is therefore the caller's side of
+ * the bargain — every row a reader must reach is a focusable row, and text that
+ * only accompanies one scrolls along with it.
  *
  * The panel comes from a webpack probe that can miss, and a page whose regions
- * silently vanish would be worse than one that scrolls only under a mouse — so
- * the fallback keeps the region, its bounds and its place in the focus tree.
+ * silently vanish would be worse than one whose regions scroll without Steam's
+ * own scroll padding — so the fallback keeps the region, its bounds and its
+ * place in the focus tree.
  *
  * Structure and vocabulary: `docs/architecture/qam-panel.md`.
  */
 
 import type { CSSProperties, FC, ReactNode } from "react";
 import { Focusable } from "@decky/ui";
-import { ScrollPanelGroup } from "../../utils/deckyUiInternals";
+import { ScrollPanel } from "../../utils/deckyUiInternals";
 
 export interface ScrollRegionProps {
   /** Merged over the region's own bounds — the caller places it, not sizes it. */
@@ -30,21 +31,20 @@ export interface ScrollRegionProps {
 // content, so the region expands past its parent and the page clips instead.
 //
 // No overflow here — the panel branch must not set one. Steam's own `ScrollY`
-// class carries `overflow-y: auto` with `overflow-x: hidden`
-// (`._29WypCpglgRKsR_fMPsoFX`, `css/chunk~2dcc5aaf7.css`), and an inline
-// `overflow` shorthand beats both. Restoring horizontal room is not cosmetic: the
-// gamepad-direction handler this panel binds consumes left and right whenever
-// there is room to scroll sideways, and left↔right is how a reader crosses from
-// the list to the detail — one over-wide row would strand focus in the list.
+// class carries `overflow-y: auto` with `overflow-x: hidden` and a 20 px scroll
+// padding (`._29WypCpglgRKsR_fMPsoFX`, `css/chunk~2dcc5aaf7.css`), and an inline
+// `overflow` shorthand beats both of those axes. The sideways scroll it would
+// restore is one Steam clips on purpose: one over-wide row and every focus step
+// inside the region would drag the whole pane left and right under the reader.
 const BOUNDS: CSSProperties = { height: "100%", minHeight: 0 };
 
 export const ScrollRegion: FC<ScrollRegionProps> = ({ style, children }) =>
-  // Focusable, not a div, when the probe misses: the region is a level of the
-  // focus tree either way, and a plain div would silently restructure gamepad
-  // navigation around it. That branch has no Steam class behind it, which makes
-  // it the one place the overflow is ours to set.
-  ScrollPanelGroup ? (
-    <ScrollPanelGroup style={{ ...BOUNDS, ...style }}>{children}</ScrollPanelGroup>
+  // Focusable, not a div, when the probe misses: it is the very base panel
+  // Steam's scroll panel renders, so the region keeps the same place in the
+  // focus tree and takes focus no more than the panel does. That branch has no
+  // Steam class behind it, which makes it the one place the overflow is ours.
+  ScrollPanel ? (
+    <ScrollPanel style={{ ...BOUNDS, ...style }}>{children}</ScrollPanel>
   ) : (
     <Focusable style={{ ...BOUNDS, overflow: "auto", ...style }}>{children}</Focusable>
   );

--- a/src/components/qam/ScrollRegion.tsx
+++ b/src/components/qam/ScrollRegion.tsx
@@ -3,9 +3,10 @@
  *
  * Steam's gamepad navigation scrolls by moving focus, so a plain `overflow: auto`
  * box holding content nobody can focus — a detail pane of text rows — cannot be
- * scrolled with the controller at all, only with a mouse. Steam's scroll panel is
- * what closes that: it binds gamepad direction to scrolling, which is why the
- * QAM's own tab panel scrolls such content and a bare div does not.
+ * scrolled with the controller at all, only with a mouse. `ScrollPanelGroup`
+ * closes that by binding gamepad direction to scrolling. Its plain sibling
+ * `ScrollPanel` does not, which is why reaching for the panel Steam's own QAM tab
+ * uses would not have fixed anything: that one is the plain kind.
  *
  * The panel comes from a webpack probe that can miss, and a page whose regions
  * silently vanish would be worse than one that scrolls only under a mouse — so
@@ -27,17 +28,23 @@ export interface ScrollRegionProps {
 // `height: 100%` and `minHeight: 0` together are what let a flex child scroll
 // rather than grow: without the floor reset a flex item's min-height is its
 // content, so the region expands past its parent and the page clips instead.
-const BOUNDS: CSSProperties = { height: "100%", minHeight: 0, overflow: "auto" };
+//
+// No overflow here — the panel branch must not set one. Steam's own `ScrollY`
+// class carries `overflow-y: auto` with `overflow-x: hidden`
+// (`._29WypCpglgRKsR_fMPsoFX`, `css/chunk~2dcc5aaf7.css`), and an inline
+// `overflow` shorthand beats both. Restoring horizontal room is not cosmetic: the
+// gamepad-direction handler this panel binds consumes left and right whenever
+// there is room to scroll sideways, and left↔right is how a reader crosses from
+// the list to the detail — one over-wide row would strand focus in the list.
+const BOUNDS: CSSProperties = { height: "100%", minHeight: 0 };
 
-export const ScrollRegion: FC<ScrollRegionProps> = ({ style, children }) => {
-  const regionStyle = { ...BOUNDS, ...style };
-
+export const ScrollRegion: FC<ScrollRegionProps> = ({ style, children }) =>
   // Focusable, not a div, when the probe misses: the region is a level of the
   // focus tree either way, and a plain div would silently restructure gamepad
-  // navigation around it.
-  return ScrollPanelGroup ? (
-    <ScrollPanelGroup style={regionStyle}>{children}</ScrollPanelGroup>
+  // navigation around it. That branch has no Steam class behind it, which makes
+  // it the one place the overflow is ours to set.
+  ScrollPanelGroup ? (
+    <ScrollPanelGroup style={{ ...BOUNDS, ...style }}>{children}</ScrollPanelGroup>
   ) : (
-    <Focusable style={regionStyle}>{children}</Focusable>
+    <Focusable style={{ ...BOUNDS, overflow: "auto", ...style }}>{children}</Focusable>
   );
-};

--- a/src/components/qam/WidePage.test.tsx
+++ b/src/components/qam/WidePage.test.tsx
@@ -14,17 +14,22 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import type { FC, ReactNode } from "react";
 import { WIDE_ROOT_CLASS } from "../../utils/qamExpansion";
-import type { WidePageProps, WidePageTab } from "./WidePage";
+import { OWNS_ENTRY_FOCUS_ATTR, type WidePageProps, type WidePageTab } from "./WidePage";
 
 interface StubTabsProps {
   tabs: WidePageTab[];
   activeTab: string;
   onShowTab: (tabId: string) => void;
+  autoFocusContents?: boolean;
 }
 
-/** Stand-in for Steam's tabbed page: a bar of titles plus the active content. */
-const StubTabs: FC<StubTabsProps> = ({ tabs, activeTab, onShowTab }) => (
-  <div data-testid="steam-tabs">
+/**
+ * Stand-in for Steam's tabbed page: a bar of titles plus the active content.
+ * `autoFocusContents` is surfaced as an attribute — the real page consumes it to
+ * place focus, which happy-dom's gamepad-free DOM cannot show happening.
+ */
+const StubTabs: FC<StubTabsProps> = ({ tabs, activeTab, onShowTab, autoFocusContents }) => (
+  <div data-testid="steam-tabs" data-auto-focus-contents={String(Boolean(autoFocusContents))}>
     {tabs.map((tab) => (
       <button key={tab.id} onClick={() => onShowTab(tab.id)}>
         {tab.title}
@@ -193,6 +198,45 @@ describe("WidePage", () => {
     // around it would nest two scrollers on the same content.
     expect(screen.queryByTestId("scroll-panel")).not.toBeInTheDocument();
     expect(screen.getByTestId("steam-tabs")).toBeInTheDocument();
+  });
+
+  it("has Steam's tabbed page place entry focus, and says so on its root", async () => {
+    const WidePage = await loadWidePage(StubTabs);
+
+    const { container } = render(
+      <WidePage title="Library" onBack={vi.fn()} tabs={TAB_SET} activeTab="platforms" onShowTab={vi.fn()} />,
+    );
+
+    // Focus in the content is also what draws the L1/R1 glyphs: Steam's tab row
+    // shows them only while focus is within the tabbed page, and the Back row
+    // is above the tabs. The marker is what keeps the router's own focus —
+    // which would land on that Back row — away from the page.
+    expect(screen.getByTestId("steam-tabs")).toHaveAttribute("data-auto-focus-contents", "true");
+    expect(container.firstElementChild).toHaveAttribute(OWNS_ENTRY_FOCUS_ATTR);
+  });
+
+  it("claims no entry focus without tabs, where nothing here places any", async () => {
+    const WidePage = await loadWidePage(StubTabs);
+
+    const { container } = render(
+      <WidePage title="Settings" onBack={vi.fn()}>
+        <div>page body</div>
+      </WidePage>,
+    );
+
+    expect(container.firstElementChild).not.toHaveAttribute(OWNS_ENTRY_FOCUS_ATTR);
+  });
+
+  it("claims no entry focus when the Tabs probe missed, so the router still covers the page", async () => {
+    const WidePage = await loadWidePage(undefined);
+
+    const { container } = render(
+      <WidePage title="Library" onBack={vi.fn()} tabs={TAB_SET} activeTab="platforms" onShowTab={vi.fn()} />,
+    );
+
+    // The fallback renders the tab's content raw, with nothing to autofocus. A
+    // marker here would opt the page out of the only focus it would get.
+    expect(container.firstElementChild).not.toHaveAttribute(OWNS_ENTRY_FOCUS_ATTR);
   });
 
   it("takes no children beside tabs, whose body is the active tab's content", async () => {

--- a/src/components/qam/WidePage.test.tsx
+++ b/src/components/qam/WidePage.test.tsx
@@ -34,9 +34,24 @@ const StubTabs: FC<StubTabsProps> = ({ tabs, activeTab, onShowTab }) => (
   </div>
 );
 
-async function loadWidePage(tabs: FC<StubTabsProps> | undefined): Promise<FC<WidePageProps>> {
+/** Stand-in for Steam's scroll panel, which the frame reaches via `ScrollRegion`. */
+const StubScrollPanelGroup: FC<{ children?: ReactNode }> = ({ children }) => (
+  <div data-testid="scroll-panel">{children}</div>
+);
+
+async function loadWidePage(
+  tabs: FC<StubTabsProps> | undefined,
+  scrollPanelGroup?: FC<{ children?: ReactNode }>,
+): Promise<FC<WidePageProps>> {
   vi.resetModules();
-  vi.doMock("../../utils/deckyUiInternals", () => ({ quickAccessMenuClasses: undefined, Tabs: tabs }));
+  // Every export the graph under test imports has to be named here — Vitest
+  // throws on an import of a name the factory left out, which is how the scroll
+  // panel reaches this file at all: `ScrollRegion` asks for it, `WidePage` does not.
+  vi.doMock("../../utils/deckyUiInternals", () => ({
+    quickAccessMenuClasses: undefined,
+    Tabs: tabs,
+    ScrollPanelGroup: scrollPanelGroup,
+  }));
   return (await import("./WidePage")).WidePage;
 }
 
@@ -155,6 +170,29 @@ describe("WidePage", () => {
     // Dropping the hook while the module stays imported elsewhere leaves the
     // rest of this file green.
     expect(post).toHaveBeenCalledWith({ message: "QamFriendsExpanded" }, window.origin);
+  });
+
+  it("gives an untabbed body a scroll panel of its own", async () => {
+    const WidePage = await loadWidePage(StubTabs, StubScrollPanelGroup);
+
+    render(
+      <WidePage title="Settings" onBack={vi.fn()}>
+        <div>page body</div>
+      </WidePage>,
+    );
+
+    expect(screen.getByTestId("scroll-panel")).toContainElement(screen.getByText("page body"));
+  });
+
+  it("leaves a tabbed body's scrolling to Steam's tabbed page", async () => {
+    const WidePage = await loadWidePage(StubTabs, StubScrollPanelGroup);
+
+    render(<WidePage title="Library" onBack={vi.fn()} tabs={TAB_SET} activeTab="platforms" onShowTab={vi.fn()} />);
+
+    // Steam's tabbed page brings a scroll panel per tab. A second one wrapped
+    // around it would nest two scrollers on the same content.
+    expect(screen.queryByTestId("scroll-panel")).not.toBeInTheDocument();
+    expect(screen.getByTestId("steam-tabs")).toBeInTheDocument();
   });
 
   it("takes no children beside tabs, whose body is the active tab's content", async () => {

--- a/src/components/qam/WidePage.test.tsx
+++ b/src/components/qam/WidePage.test.tsx
@@ -189,13 +189,14 @@ describe("WidePage", () => {
     expect(screen.getByTestId("scroll-panel")).toContainElement(screen.getByText("page body"));
   });
 
-  it("leaves a tabbed body's scrolling to Steam's tabbed page", async () => {
+  it("gives a tabbed body no region, leaving its tabs' content to the page", async () => {
     const WidePage = await loadWidePage(StubTabs, StubScrollPanelGroup);
 
     render(<WidePage title="Library" onBack={vi.fn()} tabs={TAB_SET} activeTab="platforms" onShowTab={vi.fn()} />);
 
-    // Steam's tabbed page brings a scroll panel per tab. A second one wrapped
-    // around it would nest two scrollers on the same content.
+    // A tab's content is the page's business — a page whose tab holds
+    // unfocusable content wraps it in `ScrollRegion` itself, which it could not
+    // do if the frame had already wrapped the whole tabbed page in one.
     expect(screen.queryByTestId("scroll-panel")).not.toBeInTheDocument();
     expect(screen.getByTestId("steam-tabs")).toBeInTheDocument();
   });

--- a/src/components/qam/WidePage.test.tsx
+++ b/src/components/qam/WidePage.test.tsx
@@ -40,13 +40,13 @@ const StubTabs: FC<StubTabsProps> = ({ tabs, activeTab, onShowTab, autoFocusCont
 );
 
 /** Stand-in for Steam's scroll panel, which the frame reaches via `ScrollRegion`. */
-const StubScrollPanelGroup: FC<{ children?: ReactNode }> = ({ children }) => (
+const StubScrollPanel: FC<{ children?: ReactNode }> = ({ children }) => (
   <div data-testid="scroll-panel">{children}</div>
 );
 
 async function loadWidePage(
   tabs: FC<StubTabsProps> | undefined,
-  scrollPanelGroup?: FC<{ children?: ReactNode }>,
+  scrollPanel?: FC<{ children?: ReactNode }>,
 ): Promise<FC<WidePageProps>> {
   vi.resetModules();
   // Every export the graph under test imports has to be named here — Vitest
@@ -55,7 +55,7 @@ async function loadWidePage(
   vi.doMock("../../utils/deckyUiInternals", () => ({
     quickAccessMenuClasses: undefined,
     Tabs: tabs,
-    ScrollPanelGroup: scrollPanelGroup,
+    ScrollPanel: scrollPanel,
   }));
   return (await import("./WidePage")).WidePage;
 }
@@ -178,7 +178,7 @@ describe("WidePage", () => {
   });
 
   it("gives an untabbed body a scroll panel of its own", async () => {
-    const WidePage = await loadWidePage(StubTabs, StubScrollPanelGroup);
+    const WidePage = await loadWidePage(StubTabs, StubScrollPanel);
 
     render(
       <WidePage title="Settings" onBack={vi.fn()}>
@@ -190,13 +190,13 @@ describe("WidePage", () => {
   });
 
   it("gives a tabbed body no region, leaving its tabs' content to the page", async () => {
-    const WidePage = await loadWidePage(StubTabs, StubScrollPanelGroup);
+    const WidePage = await loadWidePage(StubTabs, StubScrollPanel);
 
     render(<WidePage title="Library" onBack={vi.fn()} tabs={TAB_SET} activeTab="platforms" onShowTab={vi.fn()} />);
 
-    // A tab's content is the page's business — a page whose tab holds
-    // unfocusable content wraps it in `ScrollRegion` itself, which it could not
-    // do if the frame had already wrapped the whole tabbed page in one.
+    // Steam's tabbed page already scrolls each tab's content in this same panel,
+    // so a region here would nest a second scroller around all of them — and a
+    // tab that needs regions of its own could no longer place them.
     expect(screen.queryByTestId("scroll-panel")).not.toBeInTheDocument();
     expect(screen.getByTestId("steam-tabs")).toBeInTheDocument();
   });

--- a/src/components/qam/WidePage.tsx
+++ b/src/components/qam/WidePage.tsx
@@ -85,9 +85,11 @@ export const WidePage: FC<WidePageProps> = ({ title, onBack, tabs, activeTab, on
   // clips instead of growing, so the body needs a definite height.
   const bodyStyle = { height: bodyHeight === null ? undefined : `${bodyHeight}px`, overflow: "hidden" };
 
-  // Only the untabbed body gets a scroll region of its own. Steam's tabbed page
-  // brings one per tab, and the branch below it is the probe-missed fallback,
-  // which renders the tab's content exactly as Steam's own page would have.
+  // Only the untabbed body gets a region from the frame. A tab's content is the
+  // page's own business, and the frame cannot know whether it needs one — so a
+  // page whose tab holds content nobody can focus wraps that in `ScrollRegion`
+  // itself. Steam's per-tab scroller does not cover it: like the QAM's own tab
+  // panel it is the plain `ScrollPanel`, which binds no gamepad direction.
   let body: ReactNode = <ScrollRegion>{children}</ScrollRegion>;
   if (tabs) {
     // `autoFocusContents` lands entry focus in the active tab's content — the

--- a/src/components/qam/WidePage.tsx
+++ b/src/components/qam/WidePage.tsx
@@ -13,6 +13,7 @@ import { useLayoutEffect, useRef, useState, type FC, type ReactNode } from "reac
 import { ButtonItem, PanelSection, PanelSectionRow } from "@decky/ui";
 import { Tabs } from "../../utils/deckyUiInternals";
 import { WIDE_ROOT_CLASS, useWideQamPanel } from "../../utils/qamExpansion";
+import { ScrollRegion } from "./ScrollRegion";
 
 export interface WidePageTab {
   id: string;
@@ -74,7 +75,10 @@ export const WidePage: FC<WidePageProps> = ({ title, onBack, tabs, activeTab, on
   // clips instead of growing, so the body needs a definite height.
   const bodyStyle = { height: bodyHeight === null ? undefined : `${bodyHeight}px`, overflow: "hidden" };
 
-  let body: ReactNode = children;
+  // Only the untabbed body gets a scroll region of its own. Steam's tabbed page
+  // brings one per tab, and the branch below it is the probe-missed fallback,
+  // which renders the tab's content exactly as Steam's own page would have.
+  let body: ReactNode = <ScrollRegion>{children}</ScrollRegion>;
   if (tabs) {
     body = Tabs ? (
       <Tabs tabs={tabs} activeTab={activeTab} onShowTab={onShowTab} />

--- a/src/components/qam/WidePage.tsx
+++ b/src/components/qam/WidePage.tsx
@@ -4,7 +4,8 @@
  * optional L1/R1 tab bar, and a body of a definite, measured height.
  *
  * The page's own content is `children`, or — when the page has tabs — the
- * `content` of each tab, which Steam's `Tabs` renders itself.
+ * `content` of each tab, which Steam's `Tabs` renders itself. A tabbed page
+ * also opens with focus in that content rather than on the Back row.
  *
  * Structure and vocabulary: `docs/architecture/qam-panel.md`.
  */
@@ -34,6 +35,15 @@ export type WidePageProps = {
   title: string;
   onBack: () => void;
 } & TabProps;
+
+/**
+ * Marks a page that places its own entry focus, which the panel's router reads
+ * to keep its first-button focus away. A tabbed page sets it, because the
+ * `autoFocusContents` it hands Steam's tabbed page is what puts focus in the
+ * content; a page that cannot place focus itself never sets it, so the router
+ * still covers it.
+ */
+export const OWNS_ENTRY_FOCUS_ATTR = "data-romm-owns-entry-focus";
 
 // Floor under the measured body, so a viewport read taken before Steam has laid
 // the panel out cannot collapse the page to nothing.
@@ -80,15 +90,24 @@ export const WidePage: FC<WidePageProps> = ({ title, onBack, tabs, activeTab, on
   // which renders the tab's content exactly as Steam's own page would have.
   let body: ReactNode = <ScrollRegion>{children}</ScrollRegion>;
   if (tabs) {
+    // `autoFocusContents` lands entry focus in the active tab's content — the
+    // list of a list-and-detail page — which is also what makes Steam draw the
+    // L1/R1 glyphs: its tab row shows them only while gamepad focus is within
+    // the tabbed page, and the Back row above the tabs is outside it
+    // (`chunk~2dcc5aaf7.js`, the tab row's `showGlyphs`).
     body = Tabs ? (
-      <Tabs tabs={tabs} activeTab={activeTab} onShowTab={onShowTab} />
+      <Tabs tabs={tabs} activeTab={activeTab} onShowTab={onShowTab} autoFocusContents />
     ) : (
       tabs.find((tab) => tab.id === activeTab)?.content
     );
   }
 
+  // Claimed only where the claim is true: without Steam's tabbed page nothing
+  // here places focus, so the router's own must still run.
+  const ownsEntryFocus = Boolean(tabs && Tabs);
+
   return (
-    <div className={WIDE_ROOT_CLASS} ref={rootRef}>
+    <div className={WIDE_ROOT_CLASS} ref={rootRef} {...(ownsEntryFocus ? { [OWNS_ENTRY_FOCUS_ATTR]: "" } : {})}>
       <PanelSection>
         <PanelSectionRow>
           <ButtonItem layout="below" onClick={onBack}>

--- a/src/components/qam/WidePage.tsx
+++ b/src/components/qam/WidePage.tsx
@@ -85,11 +85,12 @@ export const WidePage: FC<WidePageProps> = ({ title, onBack, tabs, activeTab, on
   // clips instead of growing, so the body needs a definite height.
   const bodyStyle = { height: bodyHeight === null ? undefined : `${bodyHeight}px`, overflow: "hidden" };
 
-  // Only the untabbed body gets a region from the frame. A tab's content is the
-  // page's own business, and the frame cannot know whether it needs one — so a
-  // page whose tab holds content nobody can focus wraps that in `ScrollRegion`
-  // itself. Steam's per-tab scroller does not cover it: like the QAM's own tab
-  // panel it is the plain `ScrollPanel`, which binds no gamepad direction.
+  // Only the untabbed body gets a region from the frame. Steam's tabbed page
+  // already wraps each tab's content in this same plain scroll panel
+  // (`ScrollingTab<id>`, `scrollDirection: "y"`, in `chunk~2dcc5aaf7.js`), so
+  // one from the frame would nest a second scroller inside it. A tab that needs
+  // more than that one — a list and a detail scrolling side by side — builds its
+  // regions with `ScrollRegion` itself.
   let body: ReactNode = <ScrollRegion>{children}</ScrollRegion>;
   if (tabs) {
     // `autoFocusContents` lands entry focus in the active tab's content — the

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -12,7 +12,8 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { act, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
 import { toaster } from "@decky/api";
 import { emitDeckyEvent, deckyEventListenerCount } from "./test-utils/decky-api-mock";
 import {
@@ -111,14 +112,29 @@ vi.mock("./api/backend", async () => {
   };
 });
 
+// Main stands in for whichever page the router has mounted. `ownsEntryFocus`
+// makes it carry the marker a page sets when it places entry focus itself,
+// which is the one thing the router's focus effect branches on.
+let mainPageOwnsEntryFocus = false;
+vi.mock("./components/MainPage", () => ({
+  MainPage: () =>
+    // React drops an attribute whose value is undefined, so this renders the
+    // marker only in the owns-focus case.
+    createElement(
+      "div",
+      { "data-romm-owns-entry-focus": mainPageOwnsEntryFocus ? "" : undefined },
+      createElement("button", null, "first button"),
+    ),
+}));
+
 import { applyAllPlaytime, registerMetadataPatches, applyAllMetadata } from "./patches/metadataPatches";
 import { registerRomMAppId, unregisterRomMAppId } from "./patches/gameDetailPatch";
 import definePluginResult from "./index";
 
 // `definePlugin` is stubbed in test-setup to return its factory unchanged, so
 // the default export IS the factory. Calling it registers the listeners and
-// returns the plugin descriptor (with onDismount).
-const pluginFactory = definePluginResult as unknown as () => { onDismount: () => void };
+// returns the plugin descriptor (with onDismount and the panel itself).
+const pluginFactory = definePluginResult as unknown as () => { onDismount: () => void; content: ReactNode };
 
 function flush(): Promise<void> {
   return new Promise((r) => setTimeout(r, 0));
@@ -2047,5 +2063,55 @@ describe("index.tsx — sync_plan seeds the applying-phase ETA (always-on estima
     expect(weightedCoarseFraction(1, 0.5, 2)).toBeCloseTo(70 / 80, 10);
     resetEta();
     plugin.onDismount();
+  });
+});
+
+describe("index.tsx — where entry focus lands on a page swap", () => {
+  beforeEach(() => {
+    mainPageOwnsEntryFocus = false;
+  });
+
+  it("focuses the mounted page's first button", async () => {
+    vi.useFakeTimers();
+    try {
+      const plugin = pluginFactory();
+      render(plugin.content);
+
+      // Steam's gamepad nav keeps a focus pointer across page swaps and would
+      // otherwise resolve it onto whatever sits at the old page's position.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(50);
+      });
+      const btn = screen.getByRole("button", { name: "first button" });
+
+      expect(btn).toHaveFocus();
+      expect(btn).toHaveClass("gpfocus");
+      plugin.onDismount();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("leaves focus alone for a page that places its own", async () => {
+    vi.useFakeTimers();
+    try {
+      mainPageOwnsEntryFocus = true;
+      const plugin = pluginFactory();
+      render(plugin.content);
+
+      // A wide page's first button is its Back row, which sits above the tabs
+      // and so outside Steam's tabbed page — landing there would hide the L1/R1
+      // glyphs the page needs to be switchable at all.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(50);
+      });
+      const btn = screen.getByRole("button", { name: "first button" });
+
+      expect(btn).not.toHaveFocus();
+      expect(btn).not.toHaveClass("gpfocus");
+      plugin.onDismount();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ import { LibraryPage } from "./components/LibraryPage";
 import { SystemPage } from "./components/SystemPage";
 import { DangerZone } from "./components/DangerZone";
 import { DownloadQueue } from "./components/DownloadQueue";
+import { OWNS_ENTRY_FOCUS_ATTR } from "./components/qam/WidePage";
 import { initUnitSyncManager, resetSyncCancel } from "./utils/syncManager";
 import { setSyncProgress, getSyncProgress, updateSyncProgress } from "./utils/syncProgress";
 import { estimatePlanSeconds } from "./utils/syncEstimate";
@@ -115,13 +116,23 @@ const QAMPanel: FC = () => {
     // resolves it on the next input — landing on a button at the old page's
     // position. Force focus to the first button so navigation starts at the
     // top. Same querySelector + .focus() + gpfocus pattern as CustomPlayButton.
-    const focusTimer = setTimeout(() => {
-      const btn = el.querySelector("button");
-      if (btn) {
-        btn.focus();
-        btn.classList.add("gpfocus");
-      }
-    }, 50);
+    //
+    // A page carrying the opt-out marker places entry focus itself, and this
+    // focus would undo it: the first button of a wide page is the Back row,
+    // which sits above the tabs and therefore outside Steam's tabbed page —
+    // and Steam draws the L1/R1 glyphs only while gamepad focus is within it
+    // (`chunk~2dcc5aaf7.js`, the tab row's `showGlyphs`). Landing here would
+    // leave a tabbed page with no visible way to switch tabs.
+    const ownsFocus = el.querySelector(`[${OWNS_ENTRY_FOCUS_ATTR}]`) !== null;
+    const focusTimer = ownsFocus
+      ? undefined
+      : setTimeout(() => {
+          const btn = el.querySelector("button");
+          if (btn) {
+            btn.focus();
+            btn.classList.add("gpfocus");
+          }
+        }, 50);
     return () => {
       cancelAnimationFrame(rafHandle);
       clearTimeout(focusTimer);

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -282,7 +282,7 @@ vi.mock("@decky/ui", () => {
     // every file that reaches @decky/ui through deckyUiInternals.
     quickAccessMenuClasses: undefined,
     Tabs: undefined,
-    ScrollPanelGroup: undefined,
+    ScrollPanel: undefined,
     // The QAM is open for any test that renders a wide page; the hook's
     // clear-on-close path is exercised in src/utils/qamExpansion.test.tsx.
     useQuickAccessVisible: () => true,

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -275,10 +275,15 @@ vi.mock("@decky/ui", () => {
     appDetailsClasses: undefined,
     playSectionClasses: undefined,
     // The wide-QAM probes. Undefined is the honest default here: happy-dom has
-    // no Steam webpack modules, so a test that wants the class names or the
-    // tabbed page mocks `src/utils/deckyUiInternals` with its own values.
+    // no Steam webpack modules, so a test that wants the class names, the tabbed
+    // page or a scroll panel mocks `src/utils/deckyUiInternals` with its own
+    // values. Named explicitly rather than left off: Vitest throws on an import
+    // of a name the mock factory does not define, so an omission would break
+    // every file that reaches @decky/ui through deckyUiInternals.
     quickAccessMenuClasses: undefined,
     Tabs: undefined,
+    ScrollPanel: undefined,
+    ScrollPanelGroup: undefined,
     // The QAM is open for any test that renders a wide page; the hook's
     // clear-on-close path is exercised in src/utils/qamExpansion.test.tsx.
     useQuickAccessVisible: () => true,

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -282,7 +282,6 @@ vi.mock("@decky/ui", () => {
     // every file that reaches @decky/ui through deckyUiInternals.
     quickAccessMenuClasses: undefined,
     Tabs: undefined,
-    ScrollPanel: undefined,
     ScrollPanelGroup: undefined,
     // The QAM is open for any test that renders a wide page; the hook's
     // clear-on-close path is exercised in src/utils/qamExpansion.test.tsx.

--- a/src/utils/deckyUiInternals.ts
+++ b/src/utils/deckyUiInternals.ts
@@ -22,7 +22,7 @@ import {
   appDetailsClasses as _appDetailsClasses,
   playSectionClasses as _playSectionClasses,
   quickAccessMenuClasses as _quickAccessMenuClasses,
-  ScrollPanelGroup as _ScrollPanelGroup,
+  ScrollPanel as _ScrollPanel,
   Tabs as _Tabs,
   findSP as _findSP,
   type TabsProps,
@@ -45,9 +45,9 @@ export const Tabs: FC<TabsProps> | undefined = _Tabs;
 
 /**
  * What the scroll panel accepts beyond its children. Upstream types it
- * `FC<{ children?: ReactNode }>`, which is narrower than it is: it spreads
- * everything it does not consume into Steam's `ScrollPanel`, which destructures
- * `className` and `style` and merges the style with its own scroll padding.
+ * `FC<{ children?: ReactNode }>`, which is narrower than it is: it destructures
+ * `className` and `style`, merges the style with its own scroll padding, and
+ * spreads the rest into the same base panel `Focusable` renders.
  */
 export interface ScrollPanelProps {
   children?: ReactNode;
@@ -56,18 +56,22 @@ export interface ScrollPanelProps {
 }
 
 /**
- * The scroll container that also scrolls on gamepad direction, which is the one
- * a region of unfocusable content needs: Steam's gamepad navigation scrolls by
- * moving focus, so a plain overflow box holding text nobody can focus never
- * scrolls at all.
+ * Steam's plain scroll container: an `overflow-y: auto` box that takes no focus
+ * of its own, so the rows inside it take focus directly and Steam's navigation
+ * scrolls the focused row into view. It is what the QAM's own tab panel is built
+ * from — the element carrying `#quickaccess_content_999` IS one of these — and
+ * what Steam's tabbed page wraps each tab's content in.
  *
- * Despite the name it is not a wrapper around several scroll panels — it renders
- * one itself, with `onGamepadDirection` bound and its OK button focusing its
- * first visible child. Steam's plain `ScrollPanel` binds no direction and is not
- * re-exported here, because a region built on it would not scroll; it is what
- * the QAM's own tab panel and each tab's content are built from. Also a probe,
- * so also possibly `undefined`.
+ * Its sibling `ScrollPanelGroup` binds gamepad direction to scrolling, which is
+ * what a region of content nobody can focus would need; it was tried on the
+ * device and rejected, because it is focusable and its OK button focuses its
+ * first visible child, making every region a stop the reader has to enter with A
+ * before reaching a row. Reachability is bought the other way instead: every row
+ * a reader must reach is a focusable row (`docs/architecture/qam-panel.md`).
+ *
+ * Reached through a `findModuleByExport` probe on its render function, so it is
+ * `undefined` whenever that probe misses.
  */
-export const ScrollPanelGroup: FC<ScrollPanelProps> | undefined = _ScrollPanelGroup;
+export const ScrollPanel: FC<ScrollPanelProps> | undefined = _ScrollPanel;
 
 export const findSP = (): Window | undefined => _findSP();

--- a/src/utils/deckyUiInternals.ts
+++ b/src/utils/deckyUiInternals.ts
@@ -22,7 +22,6 @@ import {
   appDetailsClasses as _appDetailsClasses,
   playSectionClasses as _playSectionClasses,
   quickAccessMenuClasses as _quickAccessMenuClasses,
-  ScrollPanel as _ScrollPanel,
   ScrollPanelGroup as _ScrollPanelGroup,
   Tabs as _Tabs,
   findSP as _findSP,
@@ -45,11 +44,10 @@ export const quickAccessMenuClasses: typeof _quickAccessMenuClasses | undefined 
 export const Tabs: FC<TabsProps> | undefined = _Tabs;
 
 /**
- * What a scroll panel accepts beyond its children. Upstream types both panels
- * as `FC<{ children?: ReactNode }>`, which is narrower than they are: Steam's
- * `ScrollPanel` destructures `className` and `style` and merges the style with
- * its own scroll padding, and `ScrollPanelGroup` spreads everything it does not
- * consume down into it.
+ * What the scroll panel accepts beyond its children. Upstream types it
+ * `FC<{ children?: ReactNode }>`, which is narrower than it is: it spreads
+ * everything it does not consume into Steam's `ScrollPanel`, which destructures
+ * `className` and `style` and merges the style with its own scroll padding.
  */
 export interface ScrollPanelProps {
   children?: ReactNode;
@@ -58,24 +56,17 @@ export interface ScrollPanelProps {
 }
 
 /**
- * Steam's plain scroll container: it carries the overflow and the scrollbar, and
- * it is the element the QAM's own tab panel is built from — the panel that holds
- * `#quickaccess_content_999` IS one of these.
- *
- * Reached through a `findModuleByExport` probe on its render function, so it is
- * `undefined` whenever that probe misses.
- */
-export const ScrollPanel: FC<ScrollPanelProps> | undefined = _ScrollPanel;
-
-/**
  * The scroll container that also scrolls on gamepad direction, which is the one
  * a region of unfocusable content needs: Steam's gamepad navigation scrolls by
  * moving focus, so a plain overflow box holding text nobody can focus never
  * scrolls at all.
  *
- * Despite the name it is not a wrapper around several `ScrollPanel`s — it
- * renders one itself, with `onGamepadDirection` bound and its OK button focusing
- * its first visible child. Also a probe, so also possibly `undefined`.
+ * Despite the name it is not a wrapper around several scroll panels — it renders
+ * one itself, with `onGamepadDirection` bound and its OK button focusing its
+ * first visible child. Steam's plain `ScrollPanel` binds no direction and is not
+ * re-exported here, because a region built on it would not scroll; it is what
+ * the QAM's own tab panel and each tab's content are built from. Also a probe,
+ * so also possibly `undefined`.
  */
 export const ScrollPanelGroup: FC<ScrollPanelProps> | undefined = _ScrollPanelGroup;
 

--- a/src/utils/deckyUiInternals.ts
+++ b/src/utils/deckyUiInternals.ts
@@ -15,13 +15,15 @@
  * here, typed honestly.
  */
 
-import type { FC } from "react";
+import type { CSSProperties, FC, ReactNode } from "react";
 import {
   appActionButtonClasses as _appActionButtonClasses,
   basicAppDetailsSectionStylerClasses as _basicAppDetailsSectionStylerClasses,
   appDetailsClasses as _appDetailsClasses,
   playSectionClasses as _playSectionClasses,
   quickAccessMenuClasses as _quickAccessMenuClasses,
+  ScrollPanel as _ScrollPanel,
+  ScrollPanelGroup as _ScrollPanelGroup,
   Tabs as _Tabs,
   findSP as _findSP,
   type TabsProps,
@@ -41,5 +43,40 @@ export const quickAccessMenuClasses: typeof _quickAccessMenuClasses | undefined 
  * component type states what the frame actually passes it.
  */
 export const Tabs: FC<TabsProps> | undefined = _Tabs;
+
+/**
+ * What a scroll panel accepts beyond its children. Upstream types both panels
+ * as `FC<{ children?: ReactNode }>`, which is narrower than they are: Steam's
+ * `ScrollPanel` destructures `className` and `style` and merges the style with
+ * its own scroll padding, and `ScrollPanelGroup` spreads everything it does not
+ * consume down into it.
+ */
+export interface ScrollPanelProps {
+  children?: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}
+
+/**
+ * Steam's plain scroll container: it carries the overflow and the scrollbar, and
+ * it is the element the QAM's own tab panel is built from — the panel that holds
+ * `#quickaccess_content_999` IS one of these.
+ *
+ * Reached through a `findModuleByExport` probe on its render function, so it is
+ * `undefined` whenever that probe misses.
+ */
+export const ScrollPanel: FC<ScrollPanelProps> | undefined = _ScrollPanel;
+
+/**
+ * The scroll container that also scrolls on gamepad direction, which is the one
+ * a region of unfocusable content needs: Steam's gamepad navigation scrolls by
+ * moving focus, so a plain overflow box holding text nobody can focus never
+ * scrolls at all.
+ *
+ * Despite the name it is not a wrapper around several `ScrollPanel`s — it
+ * renders one itself, with `onGamepadDirection` bound and its OK button focusing
+ * its first visible child. Also a probe, so also possibly `undefined`.
+ */
+export const ScrollPanelGroup: FC<ScrollPanelProps> | undefined = _ScrollPanelGroup;
 
 export const findSP = (): Window | undefined => _findSP();

--- a/src/utils/qamExpansion.test.tsx
+++ b/src/utils/qamExpansion.test.tsx
@@ -59,9 +59,10 @@ interface QamFixture {
  * The QAM shape the hook walks up through: the panel Decky's tab renders into,
  * inside the parent Steam marks with `ActiveTab`.
  *
- * `tabPanelClassOn` says which element carries `TabGroupPanel` — the panel
- * itself, or an ancestor. The spike could not tell the two apart, because
- * `:has()` matches from any ancestor, so both shapes have to work.
+ * `tabPanelClassOn` says which element carries `TabGroupPanel`. On the device it
+ * is the panel itself, measured — but `:has()` matches from any ancestor, so a
+ * Steam build that moves the class up would leave the CSS working and the DOM
+ * walk broken. Both shapes are mounted so the walk is pinned either way.
  */
 function mountQamDom(tabPanelClassOn: "panel" | "ancestor" = "panel", doc: Document = document): QamFixture {
   const ancestor = doc.createElement("div");

--- a/src/utils/qamExpansion.ts
+++ b/src/utils/qamExpansion.ts
@@ -23,10 +23,9 @@ export const WIDE_ROOT_CLASS = "romm-wide-qam-root";
 const WIDE_PANEL_STYLE_ID = "romm-wide-qam-styles";
 
 // Decky registers a single QAM tab (`QuickAccessTab.Decky = 999`), so the
-// plugin's panel is `#quickaccess_content_999`. This is the handle for walking
-// the DOM: the id is on the panel itself, whereas `TabGroupPanel` is a class
-// whose element the spike never isolated — `:has()` matches from any ancestor,
-// so a rule that works proves nothing about which element carries it.
+// plugin's panel is `#quickaccess_content_999`. Measured on the device: the id
+// and the `TabGroupPanel` class are on that same element, so walking the DOM by
+// id lands where the CSS below matches by class.
 const PANEL_ID_SELECTOR = '[id^="quickaccess_content_"]';
 
 const TAB_PANEL_SELECTOR = quickAccessMenuClasses?.TabGroupPanel
@@ -34,11 +33,11 @@ const TAB_PANEL_SELECTOR = quickAccessMenuClasses?.TabGroupPanel
   : PANEL_ID_SELECTOR;
 
 // Steam caps every tab's content panel at 300 px and lifts it only for its own
-// Friends panel, through the compound selector `.TabGroupPanel.tab_Friends`
-// (ADR-0029) — one element carrying both classes, which is evidence the cap
-// sits on the panel element itself. The `> *` line is cheap insurance against
-// it sitting one level in, kept until a device check settles which it is.
-// `:has()` scopes the lift to a panel holding a wide page of ours.
+// Friends panel (ADR-0029). The cap is on the panel element itself: with these
+// rules up, the device measured `#quickaccess_content_999` at 806 px. The `> *`
+// line covers a child carrying a cap of its own, which was never separately
+// measured and costs one selector to keep. `:has()` scopes the lift to a panel
+// holding a wide page of ours.
 const WIDE_PANEL_CSS = `
 ${TAB_PANEL_SELECTOR}:has(.${WIDE_ROOT_CLASS}) { max-width: none; }
 ${TAB_PANEL_SELECTOR}:has(.${WIDE_ROOT_CLASS}) > * { max-width: none; }


### PR DESCRIPTION
Closes #1813.

#1823 merged the frame before its device rounds. This carries what those rounds changed and measured.

- Measured at the Deck's metrics (854 × 534 CSS px at 1.5×): the expanded panel is the full screen width, the QuickAccess view is 454 px tall, and the frame's body gets about 260 px under Decky's title bar, Back, title and tabs. `.ViewPlaceholder` no longer exists as a class; the sliding container is found by geometry. Steam clears the width flag itself on any QAM tab change away from Friends, and the Friends tab expands on focus-within — both read from Steam's bundle and recorded in the docs.
- Scroll regions: `ScrollRegion` renders Steam's plain `ScrollPanel`, the panel the QAM's own tab panel is built from — not a focus stop; scrolling is focus-driven, and the rule that every reachable row is a focusable row is recorded. `ScrollPanelGroup` was tried on the device and rejected: it makes each region a focus stop the reader has to enter with A.
- Entry focus lands in the content of a wide page: `WidePage` passes `autoFocusContents` to Steam's `Tabs` and marks itself, and the router skips its first-button focus for a page that carries the marker. Steam's L1/R1 glyphs then show on entry.
- The prototype in `docs/assets/` is redrawn at the measured viewport; the postMessage target-origin reason is corrected in the ADR, the page and the source (a mismatched origin drops the message in a browser; the throw the spike saw was happy-dom's).

Device rounds: 348 → 854 px on mount with the tab panel at 806 px, 348 px again after Back and after closing the QAM, 854 px again on re-entry; rows take focus directly and scroll into view in both regions; L1/R1 switch the tabs and their glyphs show on entry.
