### PR TITLE
docs: give the authorship note a callout set off by a rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,11 @@ _Named after the railway car behind a steam locomotive, or the boat that shuttle
 > [support matrix](https://danielcopper.github.io/romm-tender/user-guide/save-sync-support-matrix/) has the per-system
 > detail. The [Decky Store](https://plugins.deckbrew.xyz/) listing comes with v1.0; until then it's a manual install.
 
-**How this is built.** The code is written by an AI coding agent working under my direction. The architecture, the
-design decisions and the review are mine, and changes are smoke-tested on real hardware before they ship.
+---
+
+> [!NOTE]
+> **How this is built.** The code is written by an AI coding agent working under my direction. The architecture, the
+> design decisions and the review are mine, and changes are smoke-tested on real hardware before they ship.
 
 ## Features
 


### PR DESCRIPTION
As a bare paragraph the note read as body text and disappeared into the
page — the pre-1.0 caveat right above it has a quote bar, so the eye
takes that one as the notice and this one as prose. It is a note, and it
should look like one.

A GitHub note callout gives it a blue bar. It cannot simply follow the
pre-1.0 quote, though: two blockquotes separated by a blank line parse as
one quote with a blank line inside it, which markdownlint rejects
(MD028). A horizontal rule between them is what keeps them two blocks,
and it earns its place on its own — the note is about the project, not
about the release state, and the rule says so.

