### PR TITLE
fix(library): refused writes revert and say why, and two Platforms detail defects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -442,14 +442,15 @@ Format: **invariant** — tier — enforced by.
   from today's placement, so for a file fetched before an emu-atlas bump moved it the name still matches our record
   while the path names whatever now occupies the new destination — RetroDECK's own `codehandler.bin`, in the case that
   motivated this. The count the UI offers is bound to the same set: `deletable_count` on the `get_firmware_status`
-  payload is records-still-on-disk, because `local_count` is the library's progress ratio and is wrong in both
-  directions — it hid the button entirely for a platform whose downloads had all left the library. **Since #1815 the
-  same field is stamped per ROW** (`_stamp_deletable`), and the frontend authorises a destructive action on it: a row's
-  Delete is offered where `deletable_count` is non-zero and nowhere else, and a folder row's counts the records written
-  underneath it, because a folder is never a download but what we put inside one is still ours. That is a wire field a
-  page reads to decide whether to offer a delete, so deriving it from `downloaded` — the same substitution as below, one
-  layer out — puts the button on `codehandler.bin`; `TestGetFirmwareStatusDeletableCount` pins the row's answer for a
-  file the plugin did not place. **Three buttons now reach one removal loop**
+  payload is records-still-on-disk, counted as distinct paths, because `local_count` is the library's progress ratio and
+  is wrong in both directions — it hid the button entirely for a platform whose downloads had all left the library.
+  **Since #1815 the same field is stamped per ROW** (`_stamp_deletable`), and the frontend authorises a destructive
+  action on it: a row's Delete is offered where `deletable_count` is non-zero and nowhere else, and a folder row's
+  counts the distinct files our records name underneath it, because a folder is never a download but what we put inside
+  one is still ours — and two records naming one path are one unlink, the platform count's own rule read one layer in.
+  That is a wire field a page reads to decide whether to offer a delete, so deriving it from `downloaded` — the same
+  substitution as below, one layer out — puts the button on `codehandler.bin`; `TestGetFirmwareStatusDeletableCount`
+  pins the row's answer for a file the plugin did not place. **Three buttons now reach one removal loop**
   (`PlatformBiosDeleter._delete_recorded_io`, under a record predicate per button): a second copy of that loop is the
   shape this rule is about, because the copies would drift silently. **Nothing mechanical stands behind any of this.** A
   delete path looping a status list on `downloaded` alone would go green — which is exactly the shape this one had when

--- a/docs/architecture/qam-panel.md
+++ b/docs/architecture/qam-panel.md
@@ -494,7 +494,12 @@ it, for the focused platform:
   are checked in that order: an empty menu is the case where RetroDECK's own fallback fails too, so it is answered
   before the not-bakeable one, and the surviving count branch then speaks only for a menu that really does hold one
   bakeable option. The frontend half of #1016 lands in the same place: a switch the backend refuses is reported there,
-  and the header keeps naming the core that is actually active.
+  and the header keeps naming the core that is actually active. A switch takes the page's busy hold from the moment it
+  is picked until it is over; an accepted one re-bakes the launch command of every bound shortcut, which is why the hold
+  has to cover the whole of it. The chip and the pane's buttons disable, another platform's pane says `Working on X`,
+  and the acting pane says `Switching to <emulator>…` in the same status line the outcome lands in — a success takes
+  that line back, a refusal replaces it, and a continuation cancelled by leaving the page takes it back too, because
+  such a switch either committed or never ran and there is no pane left to report to either way.
 - **BIOS files** — the summary (required, or files, and the two unknown states), then a table: File, On disk, Contents,
   and a **Download** button on every row that is missing and in the RomM library (#164) — never on a folder declaration,
   whatever its state, because the emulator opens that name as a directory — and a **Delete** button on every row a

--- a/docs/architecture/qam-panel.md
+++ b/docs/architecture/qam-panel.md
@@ -656,6 +656,13 @@ search with its 50-row render cap, Enable all / Disable all with today's semanti
 marker (the payload carries `is_own`, not an owner name), ROM count and the toggle. The collections tab's permanent
 brick on one transient failure (#1020) is fixed as part of the rewrite.
 
+**Already shipped on the tab as it stands, and unchanged by that rewrite:** its four writes — a row's toggle, the
+whole-kind Enable all / Disable all, the batch write a search or filter narrows them to, and the Mine / All owner scope
+— are optimistic in the way the Platforms list is, and answer a refusal the same way. The control goes back where it was
+and a line under Enable all / Disable all says why, taken back by the next collection write that succeeds and by leaving
+the view it is about: entering the tab and switching sub-tab both reset the search and the filter, so the line resets
+with them.
+
 ## Settings
 
 Wide, list and detail: the sections on the left, the focused section on the right. Five sections instead of today's

--- a/docs/architecture/qam-panel.md
+++ b/docs/architecture/qam-panel.md
@@ -504,12 +504,12 @@ it, for the focused platform:
   and a **Download** button on every row that is missing and in the RomM library (#164) — never on a folder declaration,
   whatever its state, because the emulator opens that name as a directory — and a **Delete** button on every row a
   download record of ours still holds. That covers a declared **folder** too, where no record carries the row's name and
-  the button counts the records written underneath it (`Delete (N)`): a folder is never a download, which says nothing
-  about the files already inside one. Same authority as `Delete BIOS`, described below. Below the table one row of
-  buttons: Download required (_N_), Download all, Delete BIOS behind a `ConfirmModal`. **All three are always rendered
-  and disable when there is nothing to do**, the ruling the Remove group already had: on PS2 all three vanished at once,
-  and a button that disappears is a state the reader has to work out. A disabled `DialogButton` is still a focus stop,
-  so the row stays walkable.
+  the button counts the distinct files our records name underneath it (`Delete (N)`): a folder is never a download,
+  which says nothing about the files already inside one. Same authority as `Delete BIOS`, described below. Below the
+  table one row of buttons: Download required (_N_), Download all, Delete BIOS behind a `ConfirmModal`. **All three are
+  always rendered and disable when there is nothing to do**, the ruling the Remove group already had: on PS2 all three
+  vanished at once, and a button that disappears is a state the reader has to work out. A disabled `DialogButton` is
+  still a focus stop, so the row stays walkable.
 
   **A running download is said by the button that started it.** The pressed button — bulk or per-row — becomes a
   spinner, every other download button on the pane disables, and when it finishes the rows re-read. There is no

--- a/docs/architecture/qam-panel.md
+++ b/docs/architecture/qam-panel.md
@@ -391,9 +391,16 @@ is made of. The layout study still draws it; on this point the study is supersed
 finding. Do not restore it as a regression. Enable all and Disable all sit above the groups, in the list column and
 outside every row, so reaching them reports no selection. The order freezes while the page is open.
 
-The row is the page's only sync control — focus is already there and A works the toggle — so the detail opens with one
-header line instead of a Sync section: the platform's name, `N on RomM · M in Steam · <core name>`, and the core
-picker's icon button, right-aligned.
+**Every sync write is optimistic, and a write that does not take says so.** The row flips before the backend answers, so
+a write that is refused or never lands puts the row — or, for Enable all and Disable all, the whole list — back where it
+was, and states why in a line under those two buttons: in the list column, scrolling with the rows, plain text rather
+than a focus stop. It carries the backend's own message, or a short fixed sentence where there is none, and the next
+write that succeeds takes it back. A refusal resolves rather than throwing (the migration gate answers one, and so does
+the RomM listing Enable all needs), so without the line a revert is indistinguishable from a toggle that never moved.
+
+The detail offers no sync control of its own — the row already is one, focus is already there and A works the toggle,
+and the list's two header buttons act on every row at once — so it opens with one header line instead of a Sync section:
+the platform's name, `N on RomM · M in Steam · <core name>`, and the core picker's icon button, right-aligned.
 
 **Both counts on that line are ROM files.** `N` is RomM's own `rom_count` for the platform; `M` is `reachable_count` —
 how many of the platform's ROMs a reader can get to through a shortcut, which is every member of a sibling group that

--- a/py_modules/services/firmware/status.py
+++ b/py_modules/services/firmware/status.py
@@ -259,27 +259,29 @@ class FirmwareStatusReader:
 
         One pass over the download records and one probe each, so every answer
         on the pane comes from the same set. The platform count and the rows are
-        not the same NUMBER, and are not meant to be: the count is over records,
-        while a row exists only where something declares the file or the library
-        offers it — a download RomM has since dropped and no core declares
-        raises the count with no row to show it, and only the platform-wide
-        button can reach it.
+        not the same NUMBER, and are not meant to be: the count is drawn from
+        the download records, while a row exists only where something declares
+        the file or the library offers it — a download RomM has since dropped
+        and no core declares raises the count with no row to show it, and only
+        the platform-wide button can reach it.
 
         The delete is authorised by the record and unlinks the path that record
         holds, so this is exactly that set: recorded paths under one of the
-        platform's firmware slugs that are still on disk. The platform count is
-        of distinct paths, because two records naming one file are one unlink.
+        platform's firmware slugs that are still on disk, counted as distinct
+        PATHS because two records naming one file are one unlink.
 
         **A row's count is answered two ways, because a row is one of two
         things.** A declared FILE matches a record by name — the row knows its
         file name and not our record. A declared FOLDER has no name a record
-        could carry, so it matches the records written *underneath* it: the
-        emulator lists that folder and whatever we downloaded into it is ours to
-        remove, which is a rule about files and is independent of the separate
-        rule that a folder is never offered as a download. The folder path is
-        used to NARROW the record set and never to widen it, so a destination
-        that has since moved can only offer fewer files, never something the
-        plugin did not place.
+        could carry, so it counts the distinct files our records name
+        *underneath* it: the emulator lists that folder and whatever we
+        downloaded into it is ours to remove, which is a rule about files and is
+        independent of the separate rule that a folder is never offered as a
+        download. Distinct for the reason the platform count is — a row's number
+        is what its button promises to unlink. The folder path is used to NARROW
+        the record set and never to widen it, so a destination that has since
+        moved can only offer fewer files, never something the plugin did not
+        place.
 
         None of this is ``downloaded``, and none of it may be replaced by that:
         it is ``os.path.exists`` at the row's own destination, equally true of
@@ -298,7 +300,9 @@ class FirmwareStatusReader:
             if f.get("declared_kind") == DECLARED_DIRECTORY:
                 root = (f.get("local_path") or "").rstrip("/")
                 f["deletable_count"] = (
-                    sum(1 for record in present if record.file_path.startswith(f"{root}/")) if root else 0
+                    len({record.file_path for record in present if record.file_path.startswith(f"{root}/")})
+                    if root
+                    else 0
                 )
             else:
                 f["deletable_count"] = 1 if f["file_name"] in names else 0

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -353,10 +353,14 @@ export const probeReachability = callable<[], { online: boolean }>("probe_reacha
 export const refreshSaveStatus = callable<[number], { success: boolean }>("refresh_save_status");
 export const removeRom = callable<[number], BackendResult>("remove_rom");
 export const getPlatforms = callable<[], { success: boolean; platforms: PlatformSyncSetting[] }>("get_platforms");
-export const savePlatformSync = callable<[number, boolean], { success: boolean; message: string }>(
+// `message` only comes with a refusal: both answer a bare `{success: true}`,
+// so a caller reading it on the success shape reads `undefined`.
+export const savePlatformSync = callable<[number, boolean], { success: boolean; message?: string }>(
   "save_platform_sync",
 );
-export const setAllPlatformsSync = callable<[boolean], { success: boolean; message: string }>("set_all_platforms_sync");
+export const setAllPlatformsSync = callable<[boolean], { success: boolean; message?: string }>(
+  "set_all_platforms_sync",
+);
 export const getCollections = callable<
   [],
   { success: boolean; collections: CollectionSyncSetting[]; message?: string; reason?: RommErrorCode }

--- a/src/components/LibraryPage.test.tsx
+++ b/src/components/LibraryPage.test.tsx
@@ -5,9 +5,15 @@
 // happens after the call returns so the test would pass with or without the
 // .catch.
 //
+// The same rule covers a REFUSAL, which resolves rather than throwing: all four
+// Collections writes revert on `success: false` too, and each revert is asserted
+// through the reverted control and the line that says why.
+//
 // LibraryPage catch sites (all asserted below):
-//   - handleCollectionToggle catch → rollback setCollections
-//   - handleSetAllCollections catch → restore previous collections snapshot
+//   - handleCollectionToggle catch → rollback setCollections + collections line
+//   - handleSetAllCollections catch → restore previous snapshot + collections line
+//   - handleBatchCollectionsSync catch → restore previous snapshot + collections line
+//   - handleOwnerScopeChange catch → restore previous scope + collections line
 //   - platform-groups inline catch → setPlatformGroups(!value) rollback
 //   - getCollections .catch → setCollectionsError(true) (the list-driving fetch)
 //   - getSettings .catch → owner-scope stays at its "all" default; the two
@@ -24,7 +30,7 @@
 //      would be called twice instead of once.
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, fireEvent, act } from "@testing-library/react";
+import { render, fireEvent, act, waitFor } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { LibraryPage } from "./LibraryPage";
 import * as backend from "../api/backend";
@@ -578,6 +584,126 @@ describe("LibraryPage", () => {
       const reverted = container.querySelector<HTMLInputElement>('[data-label="MyColl"] input')!;
       // CATCH-REJECTION assert: rolled back to original false
       expect(reverted.checked).toBe(false);
+      expect(container.querySelector('[data-testid="collections-status"]')?.textContent).toBe(
+        "Could not save that; the change was undone.",
+      );
+    });
+
+    it("reverts and says why when saveCollectionSync is refused", async () => {
+      // The callable is `@migration_blocked`, so a refusal resolves rather than
+      // throwing: without reading `success` the toggle stays where the reader
+      // put it over a write that never landed.
+      vi.mocked(backend.getCollections).mockResolvedValue({
+        success: true,
+        collections: [
+          makeCollection({ id: "abc", name: "MyColl", kind: "standard", is_favorite: false, sync_enabled: false }),
+        ],
+      });
+      vi.mocked(backend.saveCollectionSync).mockResolvedValue({
+        success: false,
+        message: "Pending RetroDECK migration. Open the plugin QAM to migrate or dismiss.",
+      });
+      const { getByText, container } = render(<LibraryPage onBack={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(getByText("Collections"));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      fireEvent.click(container.querySelector<HTMLInputElement>('[data-label="MyColl"] input')!);
+
+      await waitFor(() =>
+        expect(container.querySelector('[data-testid="collections-status"]')?.textContent).toBe(
+          "Pending RetroDECK migration. Open the plugin QAM to migrate or dismiss.",
+        ),
+      );
+      expect(container.querySelector<HTMLInputElement>('[data-label="MyColl"] input')!.checked).toBe(false);
+    });
+
+    it("takes the line back on the next collection write that succeeds", async () => {
+      vi.mocked(backend.getCollections).mockResolvedValue({
+        success: true,
+        collections: [
+          makeCollection({ id: "abc", name: "MyColl", kind: "standard", is_favorite: false, sync_enabled: false }),
+        ],
+      });
+      vi.mocked(backend.saveCollectionSync).mockResolvedValueOnce({ success: false, message: "Cannot reach RomM" });
+      const { getByText, container } = render(<LibraryPage onBack={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(getByText("Collections"));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      fireEvent.click(container.querySelector<HTMLInputElement>('[data-label="MyColl"] input')!);
+      await waitFor(() =>
+        expect(container.querySelector('[data-testid="collections-status"]')?.textContent).toBe("Cannot reach RomM"),
+      );
+
+      fireEvent.click(container.querySelector<HTMLInputElement>('[data-label="MyColl"] input')!);
+
+      await waitFor(() => expect(container.querySelector('[data-testid="collections-status"]')).toBeNull());
+      expect(container.querySelector<HTMLInputElement>('[data-label="MyColl"] input')!.checked).toBe(true);
+    });
+
+    it("takes the line back when the tab is left and re-entered", async () => {
+      // The line is about a write on the view it was made in. Re-entering the
+      // tab resets the sub-tab, the search and the filter, so keeping the line
+      // would stand a refusal over a list the reader has not written to yet.
+      vi.mocked(backend.getCollections).mockResolvedValue({
+        success: true,
+        collections: [
+          makeCollection({ id: "abc", name: "MyColl", kind: "standard", is_favorite: false, sync_enabled: false }),
+        ],
+      });
+      vi.mocked(backend.saveCollectionSync).mockResolvedValue({ success: false, message: "Cannot reach RomM" });
+      const { getByText, container } = render(<LibraryPage onBack={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(getByText("Collections"));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      fireEvent.click(container.querySelector<HTMLInputElement>('[data-label="MyColl"] input')!);
+      await waitFor(() =>
+        expect(container.querySelector('[data-testid="collections-status"]')?.textContent).toBe("Cannot reach RomM"),
+      );
+
+      fireEvent.click(getByText("Platforms"));
+      fireEvent.click(getByText("Collections"));
+
+      await waitFor(() => expect(container.querySelector('[data-testid="collections-status"]')).toBeNull());
+    });
+
+    it("takes the line back when the sub-tab changes", async () => {
+      // The other half of the same rule, and the one a re-entry test cannot
+      // reach: the sub-tab switch resets the search and the filter without
+      // leaving the tab, so a Standard refusal would otherwise stand over the
+      // Smart list.
+      vi.mocked(backend.getCollections).mockResolvedValue({
+        success: true,
+        collections: [
+          makeCollection({ id: "abc", name: "MyColl", kind: "standard", is_favorite: false, sync_enabled: false }),
+          makeCollection({ id: "sc1", name: "Filter A", kind: "smart", is_favorite: false, sync_enabled: false }),
+        ],
+      });
+      vi.mocked(backend.saveCollectionSync).mockResolvedValue({ success: false, message: "Cannot reach RomM" });
+      const { getByText, container } = render(<LibraryPage onBack={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(getByText("Collections"));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      fireEvent.click(container.querySelector<HTMLInputElement>('[data-label="MyColl"] input')!);
+      await waitFor(() =>
+        expect(container.querySelector('[data-testid="collections-status"]')?.textContent).toBe("Cannot reach RomM"),
+      );
+
+      fireEvent.click(getByText("Smart"));
+
+      await waitFor(() => expect(container.querySelector('[data-testid="collections-status"]')).toBeNull());
+      expect(container.querySelector('[data-label="Filter A"]')).not.toBeNull();
     });
   });
 
@@ -675,6 +801,49 @@ describe("LibraryPage", () => {
       const b = container.querySelector<HTMLInputElement>('[data-label="B"] input');
       expect(a?.checked).toBe(true);
       expect(b?.checked).toBe(false);
+      expect(container.querySelector('[data-testid="collections-status"]')?.textContent).toBe(
+        "Could not save that; the change was undone.",
+      );
+    });
+
+    it("restores the snapshot and says why when setAllCollectionsSync is refused", async () => {
+      // The collection listings behind the whole-kind write can fail on their
+      // own, and then the callable answers `{success: false, …}` rather than
+      // throwing — which left every collection in the sub-tab flipped over a
+      // write that never landed.
+      vi.mocked(backend.getCollections).mockResolvedValue({
+        success: true,
+        collections: [
+          makeCollection({ id: "a", name: "A", kind: "standard", is_favorite: false, sync_enabled: true }),
+          makeCollection({ id: "b", name: "B", kind: "standard", is_favorite: false, sync_enabled: false }),
+        ],
+      });
+      vi.mocked(backend.setAllCollectionsSync).mockResolvedValue({
+        success: false,
+        message: "Cannot reach RomM. Check the server address.",
+      });
+      const { container, getByText } = render(<LibraryPage onBack={vi.fn()} />);
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(getByText("Collections"));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      await act(async () => {
+        fireEvent.click(getByText("Enable All"));
+        await Promise.resolve();
+      });
+      const props = lastConfirmModalProps<{ onOK?: () => void }>();
+      await act(async () => {
+        props?.onOK?.();
+        for (let i = 0; i < 4; i++) await Promise.resolve();
+      });
+
+      expect(container.querySelector<HTMLInputElement>('[data-label="A"] input')?.checked).toBe(true);
+      expect(container.querySelector<HTMLInputElement>('[data-label="B"] input')?.checked).toBe(false);
+      expect(container.querySelector('[data-testid="collections-status"]')?.textContent).toBe(
+        "Cannot reach RomM. Check the server address.",
+      );
     });
 
     it("does not render the platform-groups toggle on the Collections tab (moved to Settings)", async () => {
@@ -1202,6 +1371,34 @@ describe("LibraryPage", () => {
       // back to "all", so the foreign collection is visible again.
       expect(vi.mocked(backend.setCollectionOwnerScope)).toHaveBeenCalledWith("own");
       expect(container.querySelector('[data-label="TheirColl"]')).not.toBeNull();
+      expect(container.querySelector('[data-testid="collections-status"]')?.textContent).toBe(
+        "Could not save that; the change was undone.",
+      );
+    });
+
+    it("rolls the scope back and says why when setCollectionOwnerScope is refused", async () => {
+      // The fourth optimistic write on this tab, and the same shape as the
+      // three sync ones: a refusal resolves, so without reading `success` the
+      // list would keep filtering by a scope the backend never stored. The
+      // message is a stand-in — the one refusal the backend has today is for a
+      // scope outside `own` / `all`, which this control cannot send — so what is
+      // pinned is the shape, not that answer.
+      vi.mocked(backend.getCollections).mockResolvedValue({ success: true, collections: ownAndForeign() });
+      vi.mocked(backend.setCollectionOwnerScope).mockResolvedValue({
+        success: false,
+        reason: "config_error",
+        message: "Could not save the collection scope",
+      });
+      const { getByText, container } = render(<LibraryPage onBack={vi.fn()} />);
+      await openCollections(getByText);
+      fireEvent.click(getByText("Mine"));
+
+      await waitFor(() =>
+        expect(container.querySelector('[data-testid="collections-status"]')?.textContent).toBe(
+          "Could not save the collection scope",
+        ),
+      );
+      expect(container.querySelector('[data-label="TheirColl"]')).not.toBeNull();
     });
 
     it("the section-header count is scope-aware (Mine drops the foreign collection)", async () => {
@@ -1563,6 +1760,41 @@ describe("LibraryPage", () => {
       await typeSearch(getByTestId, "");
       const a = container.querySelector<HTMLInputElement>('[data-label="Action Heroes"] input');
       expect(a?.checked).toBe(false);
+      expect(container.querySelector('[data-testid="collections-status"]')?.textContent).toBe(
+        "Could not save that; the change was undone.",
+      );
+    });
+
+    it("rolls back the batch flip and says why when saveCollectionsSync is refused", async () => {
+      vi.mocked(backend.getCollections).mockResolvedValue({
+        success: true,
+        collections: [
+          makeCollection({
+            id: "u1",
+            name: "Action Heroes",
+            kind: "standard",
+            is_favorite: false,
+            sync_enabled: false,
+          }),
+          makeCollection({ id: "u2", name: "Puzzle Box", kind: "standard", is_favorite: false, sync_enabled: false }),
+        ],
+      });
+      vi.mocked(backend.saveCollectionsSync).mockResolvedValue({
+        success: false,
+        message: "Pending RetroDECK migration. Open the plugin QAM to migrate or dismiss.",
+      });
+      const { getByText, getByTestId, container } = render(<LibraryPage onBack={vi.fn()} />);
+      await openCollections(getByText);
+      await typeSearch(getByTestId, "action");
+      fireEvent.click(getByText("Enable All"));
+
+      await waitFor(() =>
+        expect(container.querySelector('[data-testid="collections-status"]')?.textContent).toBe(
+          "Pending RetroDECK migration. Open the plugin QAM to migrate or dismiss.",
+        ),
+      );
+      await typeSearch(getByTestId, "");
+      expect(container.querySelector<HTMLInputElement>('[data-label="Action Heroes"] input')?.checked).toBe(false);
     });
   });
 

--- a/src/components/LibraryPage.tsx
+++ b/src/components/LibraryPage.tsx
@@ -45,7 +45,7 @@ import { fuzzyMatch } from "../utils/fuzzyMatch";
 import { LoadingRow } from "./LoadingRow";
 import { WidePage, type WidePageTab } from "./qam/WidePage";
 import { PlatformsTab } from "./library/PlatformsTab";
-import { usePlatformsPage } from "./library/usePlatformsPage";
+import { SYNC_WRITE_FAILED, usePlatformsPage } from "./library/usePlatformsPage";
 
 type CollectionSubTab = "standard" | "smart" | "virtual";
 
@@ -158,6 +158,11 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
   // the sub-tab changes so each sub-tab is entered unfiltered.
   const [search, setSearch] = useState("");
   const [virtualTypeFilter, setVirtualTypeFilter] = useState<VirtualTypeFilter>("all");
+  // Why the last collection write did not take, or `null`. Every one of them is
+  // optimistic, so a refusal puts the rows — or the scope — back, and a revert
+  // with nothing said is what a control that never moved looks like. Cleared by
+  // the next write that succeeds, and by leaving the view it is about.
+  const [collectionsStatus, setCollectionsStatus] = useState<string | null>(null);
   // Wraps the search field's label + input so it can be lifted to the top of
   // the scroll view when the on-screen keyboard opens over the lower half of
   // the screen (#1539).
@@ -224,31 +229,51 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
 
   // Reset the collections sub-tab (and its search + per-type filter) on every
   // entry into the Collections tab so the user lands on a predictable view (no
-  // persistence).
+  // persistence). The status line goes with them: it is about a write on the
+  // view being left, so keeping it would stand a Virtual refusal over the
+  // Standard list the reader comes back to.
   const handleCollectionsTabClick = () => {
     setActiveSubTab("standard");
     setSearch("");
     setVirtualTypeFilter("all");
+    setCollectionsStatus(null);
     setActiveTab("collections");
   };
 
   // Switch sub-tabs and reset the per-sub-tab filters so a query typed in one
-  // sub-tab never silently hides another sub-tab's list.
+  // sub-tab never silently hides another sub-tab's list. The status line is
+  // per-view for the same reason.
   const handleSubTabChange = (sub: CollectionSubTab) => {
     setActiveSubTab(sub);
     setSearch("");
     setVirtualTypeFilter("all");
+    setCollectionsStatus(null);
   };
 
   // --- Collections tab handlers ---
+  // All four writes on this tab treat a refusal and a rejection as one outcome:
+  // the write did not take, the optimistic flip goes back, and the reader is
+  // told. None of these callables throws to refuse. The three sync writes are
+  // `@migration_blocked`, and the whole-kind one also answers a failure when the
+  // collection listings behind it cannot be fetched; the owner-scope write is
+  // not gated and refuses a scope it does not recognise.
   const handleCollectionToggle = async (id: string, kind: CollectionKind, enabled: boolean) => {
-    setCollections((prev) => prev.map((c) => (c.id === id && c.kind === kind ? { ...c, sync_enabled: enabled } : c)));
-    try {
-      await saveCollectionSync(id, kind, enabled);
-    } catch {
+    const revert = () =>
       setCollections((prev) =>
         prev.map((c) => (c.id === id && c.kind === kind ? { ...c, sync_enabled: !enabled } : c)),
       );
+    setCollections((prev) => prev.map((c) => (c.id === id && c.kind === kind ? { ...c, sync_enabled: enabled } : c)));
+    try {
+      const result = await saveCollectionSync(id, kind, enabled);
+      if (!result.success) {
+        revert();
+        setCollectionsStatus(result.message || SYNC_WRITE_FAILED);
+        return;
+      }
+      setCollectionsStatus(null);
+    } catch {
+      revert();
+      setCollectionsStatus(SYNC_WRITE_FAILED);
     }
   };
 
@@ -262,9 +287,16 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
       prev.map((c) => (filterCollectionsBySubTab([c], scope).length > 0 ? { ...c, sync_enabled: enabled } : c)),
     );
     try {
-      await setAllCollectionsSync(enabled, scope);
+      const result = await setAllCollectionsSync(enabled, scope);
+      if (!result.success) {
+        setCollections(previous);
+        setCollectionsStatus(result.message || SYNC_WRITE_FAILED);
+        return;
+      }
+      setCollectionsStatus(null);
     } catch {
       setCollections(previous);
+      setCollectionsStatus(SYNC_WRITE_FAILED);
     }
   };
 
@@ -279,9 +311,16 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
       prev.map((c) => (c.kind === kind && idSet.has(c.id) ? { ...c, sync_enabled: enabled } : c)),
     );
     try {
-      await saveCollectionsSync(ids, kind, enabled);
+      const result = await saveCollectionsSync(ids, kind, enabled);
+      if (!result.success) {
+        setCollections(previous);
+        setCollectionsStatus(result.message || SYNC_WRITE_FAILED);
+        return;
+      }
+      setCollectionsStatus(null);
     } catch {
       setCollections(previous);
+      setCollectionsStatus(SYNC_WRITE_FAILED);
     }
   };
 
@@ -318,9 +357,16 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
     const previous = ownerScope;
     setOwnerScope(scope);
     try {
-      await setCollectionOwnerScope(scope);
+      const result = await setCollectionOwnerScope(scope);
+      if (!result.success) {
+        setOwnerScope(previous);
+        setCollectionsStatus(result.message || SYNC_WRITE_FAILED);
+        return;
+      }
+      setCollectionsStatus(null);
     } catch {
       setOwnerScope(previous);
+      setCollectionsStatus(SYNC_WRITE_FAILED);
     }
   };
 
@@ -528,6 +574,16 @@ export const LibraryPage: FC<LibraryPageProps> = ({ onBack }) => {
               </DialogButton>
             </Focusable>
           </PanelSectionRow>
+          {/* Why a write did not take, under the two buttons and above the list
+              it is about. Plain text, so it accompanies the rows rather than
+              adding a focus stop between the buttons and the first of them. */}
+          {collectionsStatus && (
+            <PanelSectionRow>
+              <div data-testid="collections-status" style={{ fontSize: "12px", color: "#dcdedf" }}>
+                {collectionsStatus}
+              </div>
+            </PanelSectionRow>
+          )}
           {renderCollectionListBody(matched, rendered, overflow, activeLabel)}
         </PanelSection>
       </>

--- a/src/components/library/PlatformsTab.test.tsx
+++ b/src/components/library/PlatformsTab.test.tsx
@@ -365,7 +365,7 @@ describe("Library › Platforms", () => {
       expect(toggle.checked).toBe(false);
     });
 
-    it("puts the toggle back when the write is refused", async () => {
+    it("puts the toggle back when the write is rejected, and says so", async () => {
       vi.mocked(backend.savePlatformSync).mockRejectedValue(new Error("offline"));
       const { container } = render(<LibraryPage onBack={vi.fn()} />);
       await flushAsync();
@@ -377,6 +377,54 @@ describe("Library › Platforms", () => {
       });
 
       expect(toggle.checked).toBe(true);
+      expect(within(container).getByTestId("status-list").textContent).toBe(
+        "Could not save that; the change was undone.",
+      );
+    });
+
+    it("puts the toggle back and carries the backend's words when the write is refused", async () => {
+      // A refusal resolves — the migration gate answers `{success: false, …}`
+      // without throwing — so the reverted row is the only thing the reader
+      // would otherwise see, and it is what a toggle that never moved looks
+      // like.
+      vi.mocked(backend.savePlatformSync).mockResolvedValue({
+        success: false,
+        message: "Pending RetroDECK migration. Open the plugin QAM to migrate or dismiss.",
+      });
+      const { container } = render(<LibraryPage onBack={vi.fn()} />);
+      await flushAsync();
+
+      const toggle = container.querySelector<HTMLInputElement>('[data-testid="toggle-input"]')!;
+      await act(async () => {
+        fireEvent.click(toggle);
+        for (let i = 0; i < 4; i++) await Promise.resolve();
+      });
+
+      expect(toggle.checked).toBe(true);
+      expect(within(container).getByTestId("status-list").textContent).toBe(
+        "Pending RetroDECK migration. Open the plugin QAM to migrate or dismiss.",
+      );
+    });
+
+    it("takes the line back on the next write that succeeds", async () => {
+      vi.mocked(backend.savePlatformSync).mockResolvedValueOnce({ success: false, message: "RomM is unreachable" });
+      const { container } = render(<LibraryPage onBack={vi.fn()} />);
+      await flushAsync();
+
+      const toggle = container.querySelector<HTMLInputElement>('[data-testid="toggle-input"]')!;
+      await act(async () => {
+        fireEvent.click(toggle);
+        for (let i = 0; i < 4; i++) await Promise.resolve();
+      });
+      expect(within(container).getByTestId("status-list").textContent).toBe("RomM is unreachable");
+
+      await act(async () => {
+        fireEvent.click(toggle);
+        for (let i = 0; i < 4; i++) await Promise.resolve();
+      });
+
+      expect(container.querySelector('[data-testid="status-list"]')).toBeNull();
+      expect(toggle.checked).toBe(false);
     });
 
     it("enables and disables every platform from above the groups", async () => {
@@ -394,7 +442,7 @@ describe("Library › Platforms", () => {
       }
     });
 
-    it("restores the previous set when Enable all is refused", async () => {
+    it("restores the previous set when Enable all is rejected, and says so", async () => {
       vi.mocked(backend.getPlatforms).mockResolvedValue({ success: true, platforms: threePlatforms });
       vi.mocked(backend.setAllPlatformsSync).mockRejectedValue(new Error("offline"));
       const { container } = render(<LibraryPage onBack={vi.fn()} />);
@@ -410,6 +458,36 @@ describe("Library › Platforms", () => {
       );
       // Dreamcast, GBA on; Nintendo 64 off — exactly the pre-press set.
       expect(checked).toEqual([true, true, false]);
+      expect(within(container).getByTestId("status-list").textContent).toBe(
+        "Could not save that; the change was undone.",
+      );
+    });
+
+    it("restores the previous set and says why when Enable all is refused", async () => {
+      // The RomM listing behind this write can fail on its own, and then the
+      // callable answers `{success: false, …}` rather than throwing — which
+      // left every toggle flipped on over a write that never landed. Reverting
+      // without the line only trades that for a silent flip back.
+      vi.mocked(backend.getPlatforms).mockResolvedValue({ success: true, platforms: threePlatforms });
+      vi.mocked(backend.setAllPlatformsSync).mockResolvedValue({
+        success: false,
+        message: "Cannot reach RomM. Check the server address.",
+      });
+      const { container } = render(<LibraryPage onBack={vi.fn()} />);
+      await flushAsync();
+
+      await act(async () => {
+        fireEvent.click(buttonByText(container, "Enable all")!);
+        for (let i = 0; i < 4; i++) await Promise.resolve();
+      });
+
+      const checked = [...container.querySelectorAll<HTMLInputElement>('[data-testid="toggle-input"]')].map(
+        (t) => t.checked,
+      );
+      expect(checked).toEqual([true, true, false]);
+      expect(within(container).getByTestId("status-list").textContent).toBe(
+        "Cannot reach RomM. Check the server address.",
+      );
     });
 
     it("says so when the platform list itself cannot be read", async () => {

--- a/src/components/library/PlatformsTab.test.tsx
+++ b/src/components/library/PlatformsTab.test.tsx
@@ -1157,6 +1157,167 @@ describe("Library › Platforms", () => {
 
       expect(within(container).getByTestId("status-core").textContent).toBe("Could not change the core");
     });
+
+    it("holds the page busy while the switch runs, and gives it back afterwards", async () => {
+      // The re-bake walks every bound shortcut, so a second pick would start a
+      // second continuation over the same set — the page's own busy state is
+      // what forbids it, and this action used to skip it.
+      vi.mocked(backend.getPlatforms).mockResolvedValue({
+        success: true,
+        platforms: [
+          platform({ id: 1, slug: "gba", name: "Game Boy Advance" }),
+          platform({ id: 2, slug: "n64", name: "Nintendo 64" }),
+        ],
+      });
+      vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
+        success: true,
+        platforms: [firmwarePlatform(), firmwarePlatform({ platform_slug: "n64" })],
+      });
+      // Both panes need a synced platform's own buttons: the chip is disabled
+      // on a platform with nothing in Steam for a reason of its own.
+      vi.mocked(backend.getRegistryPlatforms).mockResolvedValue({
+        platforms: [
+          { slug: "gba", name: "GBA", count: 9 },
+          { slug: "n64", name: "N64", count: 4 },
+        ],
+      });
+      let finish: (v: { success: boolean; rebake_items: never[] }) => void = () => {};
+      vi.mocked(backend.setSystemCore).mockReturnValue(
+        new Promise((resolve) => {
+          finish = resolve;
+        }),
+      );
+      const { container } = render(<LibraryPage onBack={vi.fn()} />);
+      await flushAsync();
+      await openCoreMenu(container);
+      await pickFromCoreMenu("VBA Next");
+
+      expect(coreButton(container)).toBeDisabled();
+      expect(buttonByText(container, "Download required (1)")?.disabled).toBe(true);
+      // The acting pane says what it is doing, in the register the removal and
+      // the save delete use — a disabled pane with nothing said is what the
+      // other two already avoid.
+      expect(within(container).getByTestId("status-core").textContent).toBe("Switching to VBA Next…");
+      await focusRow(container, "Nintendo 64");
+      expect(container.textContent).toContain("Working on Game Boy Advance");
+
+      await act(async () => {
+        finish({ success: true, rebake_items: [] });
+        for (let i = 0; i < 10; i++) await Promise.resolve();
+      });
+
+      expect(container.textContent).not.toContain("Working on Game Boy Advance");
+      expect(coreButton(container)).not.toBeDisabled();
+      expect(buttonByText(container, "Download required (1)")?.disabled).toBe(false);
+      await focusRow(container, "Game Boy Advance");
+      expect(container.querySelector('[data-testid="status-core"]')).toBeNull();
+    });
+
+    it("takes back a failed switch's line when the next one succeeds", async () => {
+      // The clearing half of the scoped clear. Without it the pick's own
+      // "Switching to …" line stands under a switch that is over.
+      vi.mocked(backend.setSystemCore).mockResolvedValueOnce({ success: false, message: "RetroDECK is not installed" });
+      const { container } = render(<LibraryPage onBack={vi.fn()} />);
+      await flushAsync();
+      await openCoreMenu(container);
+      await pickFromCoreMenu("VBA Next");
+      expect(within(container).getByTestId("status-core").textContent).toBe("RetroDECK is not installed");
+
+      vi.mocked(backend.setSystemCore).mockResolvedValue({ success: true, rebake_items: [] });
+      await openCoreMenu(container);
+      await pickFromCoreMenu("VBA Next");
+      await flushAsync();
+
+      expect(container.querySelector('[data-testid="status-core"]')).toBeNull();
+    });
+
+    it("stays silent when leaving the page cancels the switch's continuation", async () => {
+      // Teardown, not a failure: the callable rejects because the page went
+      // away, and "Could not change the core" would claim the core did not
+      // change on a screen that can no longer show whether it did.
+      const logWarnSpy = vi.spyOn(backend, "logWarn").mockImplementation(() => {});
+      try {
+        let rejectSwitch!: (error: unknown) => void;
+        vi.mocked(backend.setSystemCore).mockImplementation(
+          () =>
+            new Promise((_resolve, reject) => {
+              rejectSwitch = reject;
+            }),
+        );
+        const r = render(<LibraryPage onBack={vi.fn()} />);
+        await flushAsync();
+        await openCoreMenu(r.container);
+        await pickFromCoreMenu("VBA Next");
+        r.unmount();
+
+        await act(async () => {
+          rejectSwitch(new Error("teardown cancelled the callable"));
+          for (let i = 0; i < 6; i++) await Promise.resolve();
+        });
+
+        expect(logWarnSpy).toHaveBeenCalledWith(expect.stringContaining("Core switch continuation was cancelled"));
+        // And the failure leg did not also run: it is what would have written
+        // the line, and its own log is the only trace left once the page is
+        // gone.
+        const logged = vi.mocked(backend.debugLog).mock.calls.map((c) => c[0]);
+        expect(logged.some((m) => m.includes("setSystemCore: error"))).toBe(false);
+      } finally {
+        logWarnSpy.mockRestore();
+      }
+    });
+
+    it("gives the page back when the switch is refused", async () => {
+      vi.mocked(backend.setSystemCore).mockResolvedValue({ success: false, message: "RetroDECK is not installed" });
+      const { container } = render(<LibraryPage onBack={vi.fn()} />);
+      await flushAsync();
+      await openCoreMenu(container);
+      await pickFromCoreMenu("VBA Next");
+
+      // The early return out of the refusal is inside the same `finally`, so
+      // the pane comes back rather than staying dead behind a line that says
+      // the switch is over.
+      expect(within(container).getByTestId("status-core").textContent).toBe("RetroDECK is not installed");
+      expect(coreButton(container)).not.toBeDisabled();
+    });
+
+    it("keeps the switch's line on the platform it was picked on", async () => {
+      // One status for the whole page, so the line has to carry its slug: an
+      // unbound one would report this switch on every pane the reader walks to,
+      // where `Working on X` is what belongs.
+      vi.mocked(backend.getPlatforms).mockResolvedValue({
+        success: true,
+        platforms: [
+          platform({ id: 1, slug: "gba", name: "Game Boy Advance" }),
+          platform({ id: 2, slug: "n64", name: "Nintendo 64" }),
+        ],
+      });
+      vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
+        success: true,
+        platforms: [firmwarePlatform(), firmwarePlatform({ platform_slug: "n64" })],
+      });
+      let finish: (v: { success: boolean; rebake_items: never[] }) => void = () => {};
+      vi.mocked(backend.setSystemCore).mockReturnValue(
+        new Promise((resolve) => {
+          finish = resolve;
+        }),
+      );
+      const { container } = render(<LibraryPage onBack={vi.fn()} />);
+      await flushAsync();
+      await openCoreMenu(container);
+      await pickFromCoreMenu("VBA Next");
+      expect(within(container).getByTestId("status-core").textContent).toBe("Switching to VBA Next…");
+
+      await focusRow(container, "Nintendo 64");
+      expect(container.querySelector('[data-testid="status-core"]')).toBeNull();
+      expect(container.textContent).toContain("Working on Game Boy Advance");
+
+      await act(async () => {
+        finish({ success: true, rebake_items: [] });
+        for (let i = 0; i < 10; i++) await Promise.resolve();
+      });
+      await focusRow(container, "Game Boy Advance");
+      expect(container.querySelector('[data-testid="status-core"]')).toBeNull();
+    });
   });
 
   // ------------------------------------------------------------------

--- a/src/components/library/PlatformsTab.tsx
+++ b/src/components/library/PlatformsTab.tsx
@@ -156,25 +156,42 @@ export const PlatformsTab: FC<{ state: PlatformsPageState }> = ({ state }) => {
   pushGroup(groups.available, "Available");
 
   const listHeader: ReactNode = (
-    // The pair spans exactly what a row below it spans, which is NOT symmetric:
-    // a row is inset on the left by its own marker bar and the gap after it, and
-    // runs flush to the column's right edge. Steam's `Field` contributes nothing
-    // horizontally to that — inside the QAM it renders in its `Classic` mode,
-    // whose only padding is 10px top and bottom — so there is no Field inset to
-    // match, and a right padding here would be that much of the rows' width the
-    // buttons do not have. Measured on the device through CEF: rows 79.6 →
-    // 335.9, buttons 79.9 → 335.9.
-    <Focusable
-      flow-children="horizontal"
-      style={{ display: "flex", gap: "8px", padding: `4px 0 8px ${ROW_CONTENT_INSET}px` }}
-    >
-      <DialogButton style={{ flex: 1, minWidth: 0, padding: "8px 0" }} onClick={() => state.setAllSync(true)}>
-        Enable all
-      </DialogButton>
-      <DialogButton style={{ flex: 1, minWidth: 0, padding: "8px 0" }} onClick={() => state.setAllSync(false)}>
-        Disable all
-      </DialogButton>
-    </Focusable>
+    <>
+      {/* The pair spans exactly what a row below it spans, which is NOT
+          symmetric: a row is inset on the left by its own marker bar and the gap
+          after it, and runs flush to the column's right edge. Steam's `Field`
+          contributes nothing horizontally to that — inside the QAM it renders in
+          its `Classic` mode, whose only padding is 10px top and bottom — so
+          there is no Field inset to match, and a right padding here would be
+          that much of the rows' width the buttons do not have. Measured on the
+          device through CEF: rows 79.6 → 335.9, buttons 79.9 → 335.9. */}
+      <Focusable
+        flow-children="horizontal"
+        style={{ display: "flex", gap: "8px", padding: `4px 0 8px ${ROW_CONTENT_INSET}px` }}
+      >
+        <DialogButton style={{ flex: 1, minWidth: 0, padding: "8px 0" }} onClick={() => state.setAllSync(true)}>
+          Enable all
+        </DialogButton>
+        <DialogButton style={{ flex: 1, minWidth: 0, padding: "8px 0" }} onClick={() => state.setAllSync(false)}>
+          Disable all
+        </DialogButton>
+      </Focusable>
+      {/* Why a sync write did not take, under the buttons and inset with them:
+          the writes are optimistic, so a refusal puts the row back, and a revert
+          with nothing said is what a toggle that never moved looks like. Plain
+          text for the reason the group headings are plain text — a focus stop
+          here would sit between the buttons and the first row and lead nowhere —
+          and it belongs to the list rather than to a platform's pane, because
+          Enable all is about every row at once. */}
+      {state.listStatus && (
+        <div
+          data-testid="status-list"
+          style={{ fontSize: "12px", color: "#dcdedf", padding: `0 0 8px ${ROW_CONTENT_INSET}px` }}
+        >
+          {state.listStatus}
+        </div>
+      )}
+    </>
   );
 
   return (

--- a/src/components/library/usePlatformsPage.ts
+++ b/src/components/library/usePlatformsPage.ts
@@ -183,9 +183,10 @@ export interface PlatformsPageState {
    */
   listStatus: string | null;
   /**
-   * The platform whose action is in flight, or `null`. Every action on every
-   * platform disables while one is running, and the slug is what lets a pane
-   * that is not the one acting say why its buttons are dead.
+   * The platform whose action is in flight, or `null`. Every action the detail
+   * offers disables on every platform while one is running; the list's own sync
+   * writes are outside the hold. The slug is what lets a pane that is not the
+   * one acting say why its buttons are dead.
    *
    * **What forbids running two at once is this page's own state, not a lock
    * anywhere else.** `status`, `removalProgress` and `busySlug` are each
@@ -517,6 +518,14 @@ export function usePlatformsPage(): PlatformsPageState {
     );
   }, []);
 
+  /** Take back the core line this pick wrote, and only that one. The page holds
+   *  a single status, and the clear runs after an await: naming the line means a
+   *  line that landed in the meantime is left where it is rather than taken by
+   *  a clear that was about something else. */
+  const clearCoreLine = useCallback((slug: string) => {
+    setStatus((prev) => (prev?.slug === slug && prev.scope === "core" ? null : prev));
+  }, []);
+
   const changeCore = useCallback(
     (slug: string, pickedLabel: string) => {
       const answer = cores[slug];
@@ -524,11 +533,15 @@ export function usePlatformsPage(): PlatformsPageState {
       // (empty label → follow the es_systems default); any other pins it.
       const defaultLabel = answer?.emulators.find((e) => e.is_default)?.label;
       const label = pickedLabel === defaultLabel ? "" : pickedLabel;
+      setBusySlug(slug);
+      setStatus({ slug, scope: "core", text: `Switching to ${pickedLabel}…` });
+      // Captured before the continuation starts, so the catch can tell a
+      // cancelled continuation from a failed switch.
+      const admission = capturePruneLeaseAdmission(LEASE_OWNER);
       detach(debugLog(`setSystemCore: slug=${slug} label=${label} (selected=${pickedLabel})`));
       detach(
         (async () => {
           try {
-            const admission = capturePruneLeaseAdmission(LEASE_OWNER);
             const result = await setSystemCore(slug, label);
             detach(debugLog(`setSystemCore: result success=${result.success}`));
             if (!result.success) {
@@ -551,7 +564,7 @@ export function usePlatformsPage(): PlatformsPageState {
               LEASE_OWNER,
               admission,
             );
-            setStatus(null);
+            clearCoreLine(slug);
             reloadCore(slug);
             // A different core wants different BIOS files, so the table below
             // the picker is stale until the overview is read again.
@@ -560,13 +573,24 @@ export function usePlatformsPage(): PlatformsPageState {
               new CustomEvent("romm_data_changed", { detail: { type: "core_changed", platform_slug: slug } }),
             );
           } catch (e) {
+            // Leaving the page cancels the continuation, which is teardown
+            // rather than a failure: the switch either committed or never ran
+            // (`isPruneLeaseCancellation`), and either way there is no pane
+            // left to report to. The line the pick put up goes with it.
+            if (isPruneLeaseCancellation(e, admission)) {
+              logWarn(`Core switch continuation was cancelled: ${e}`);
+              clearCoreLine(slug);
+              return;
+            }
             detach(debugLog(`setSystemCore: error: ${e}`));
             setStatus({ slug, scope: "core", text: "Could not change the core" });
+          } finally {
+            setBusySlug(null);
           }
         })(),
       );
     },
-    [cores, refreshFirmware, reloadCore],
+    [clearCoreLine, cores, refreshFirmware, reloadCore],
   );
 
   /** Hold the pressed button on a red `Failed` for a moment before everything

--- a/src/components/library/usePlatformsPage.ts
+++ b/src/components/library/usePlatformsPage.ts
@@ -65,6 +65,12 @@ const FAILED_NOTICE_MS = 2000;
 const LEASE_OWNER = "library-platforms";
 const REMOVAL_REPORT_TIMEOUT_MS = 15000;
 
+/** What a sync write that did not take says when there is no answer to quote.
+ *  A refusal always carries a message (`.claude/rules/callables.md`) and that
+ *  message is what the reader gets. A REJECTION has no answer at all — the call
+ *  never returned one — and the revert would otherwise happen in silence. */
+export const SYNC_WRITE_FAILED = "Could not save that; the change was undone.";
+
 /** Which group of the detail a status line belongs under, so a failed core
  *  switch is not reported below the removal buttons. */
 export type StatusScope = "core" | "bios" | "remove";
@@ -166,6 +172,16 @@ export interface PlatformsPageState {
   coreFor: (slug: string) => CoreAnswer;
   saveCountFor: (slug: string) => SaveCountAnswer;
   status: DetailStatus | null;
+  /**
+   * Why the last sync write did not take, or `null`. The list's own line, not a
+   * platform pane's: Enable all is about the whole list, and a row's toggle is
+   * about a row the reader is already looking at, so neither belongs in
+   * {@link DetailStatus}, which is bound to one platform's pane.
+   *
+   * Cleared by the next sync write that succeeds — a line about a toggle the
+   * reader has since put right is a line about nothing.
+   */
+  listStatus: string | null;
   /**
    * The platform whose action is in flight, or `null`. Every action on every
    * platform disables while one is running, and the slug is what lets a pane
@@ -280,6 +296,7 @@ export function usePlatformsPage(): PlatformsPageState {
   const [cores, setCores] = useState<Record<string, SystemCoreInfo | null>>({});
   const [saveCounts, setSaveCounts] = useState<Record<string, number | null>>({});
   const [status, setStatus] = useState<DetailStatus | null>(null);
+  const [listStatus, setListStatus] = useState<string | null>(null);
   const [busySlug, setBusySlug] = useState<string | null>(null);
   const [removalProgress, setRemovalProgress] = useState<{ slug: string; removed: number; total: number } | null>(null);
 
@@ -455,14 +472,28 @@ export function usePlatformsPage(): PlatformsPageState {
     platformsRef.current = platforms;
   }, [platforms]);
 
+  // Both sync writes below treat a refusal and a rejection as one outcome: the
+  // write did not take, the optimistic flip goes back, and the reader is told.
+  // A flip that silently returns to where it was is what a toggle that never
+  // moved looks like, and neither callable throws to refuse.
   const toggleSync = useCallback((row: PlatformRow, enabled: boolean) => {
     const flip = (want: boolean) =>
       setPlatforms((prev) => prev.map((p) => (p.slug === row.slug ? { ...p, sync_enabled: want } : p)));
     flip(enabled);
     detach(
-      savePlatformSync(row.id, enabled).catch(() => {
-        flip(!enabled);
-      }),
+      savePlatformSync(row.id, enabled)
+        .then((result) => {
+          if (result.success) {
+            setListStatus(null);
+            return;
+          }
+          flip(!enabled);
+          setListStatus(result.message || SYNC_WRITE_FAILED);
+        })
+        .catch(() => {
+          flip(!enabled);
+          setListStatus(SYNC_WRITE_FAILED);
+        }),
     );
   }, []);
 
@@ -470,9 +501,19 @@ export function usePlatformsPage(): PlatformsPageState {
     const previous = platformsRef.current;
     setPlatforms((prev) => prev.map((p) => ({ ...p, sync_enabled: enabled })));
     detach(
-      setAllPlatformsSync(enabled).catch(() => {
-        setPlatforms(previous);
-      }),
+      setAllPlatformsSync(enabled)
+        .then((result) => {
+          if (result.success) {
+            setListStatus(null);
+            return;
+          }
+          setPlatforms(previous);
+          setListStatus(result.message || SYNC_WRITE_FAILED);
+        })
+        .catch(() => {
+          setPlatforms(previous);
+          setListStatus(SYNC_WRITE_FAILED);
+        }),
     );
   }, []);
 
@@ -765,6 +806,7 @@ export function usePlatformsPage(): PlatformsPageState {
     coreFor,
     saveCountFor,
     status,
+    listStatus,
     busySlug,
     removalProgress,
     toggleSync,

--- a/src/components/qam/ListDetail.tsx
+++ b/src/components/qam/ListDetail.tsx
@@ -33,9 +33,11 @@ export interface ListDetailProps {
   onSelect: (id: string) => void;
   renderDetail: (selectedId: string | null) => ReactNode;
   /**
-   * Controls that act on the whole list — Enable all, Disable all — rendered
-   * above the first row and scrolling with it. Outside every item, so focusing
-   * one reports no selection: these belong to the list, not to a row of it.
+   * Controls that act on the whole list — Enable all, Disable all — and anything
+   * that speaks for the list as a whole, such as a status line about one of
+   * those writes. Rendered above the first row and scrolling with it, outside
+   * every item, so focusing one reports no selection: these belong to the list,
+   * not to a row of it.
    */
   listHeader?: ReactNode;
   /**

--- a/tests/services/test_firmware.py
+++ b/tests/services/test_firmware.py
@@ -647,8 +647,8 @@ class TestAFolderRowCountsWhatWePutInside:
     """The folder branch of the row field, which nothing else exercises.
 
     A declared folder has no name a record could carry, so its ``deletable_count``
-    counts the records written UNDERNEATH it — the rule that a folder is never a
-    download says nothing about the files already in one.
+    counts the distinct FILES our records name underneath it — the rule that a
+    folder is never a download says nothing about the files already in one.
     """
 
     _CORE = "pcsx2_libretro"
@@ -669,7 +669,7 @@ class TestAFolderRowCountsWhatWePutInside:
         return fw
 
     @pytest.mark.asyncio
-    async def test_the_folder_row_counts_the_records_beneath_it(self, plugin, tmp_path):
+    async def test_the_folder_row_counts_the_files_beneath_it(self, plugin, tmp_path):
         _seed_rom(plugin._uow, rom_id=61, platform_slug="dc", app_id=1)
         inside = os.path.join(str(tmp_path / "bios"), "pcsx2", "bios", "scph39001.bin")
         hand_placed = os.path.join(str(tmp_path / "bios"), "pcsx2", "bios", "scph70012.bin")
@@ -699,6 +699,42 @@ class TestAFolderRowCountsWhatWePutInside:
         # there is not ours, and our own download outside it belongs to the
         # platform button rather than to this row.
         assert row["deletable_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_two_records_naming_one_file_are_one_deletion(self, plugin, tmp_path):
+        """The row promises unlinks, and the same path unlinks once.
+
+        A file downloaded twice — once under ``psx``, once under ``ps``, the two
+        spellings RomM files one platform's firmware under — leaves two records
+        at one path. Counting records there offers ``Delete (2)`` and takes one
+        file away, which is the platform count's own rule read one layer in.
+        """
+        _seed_rom(plugin._uow, rom_id=62, platform_slug="psx", app_id=1)
+        inside = os.path.join(str(tmp_path / "bios"), "pcsx2", "bios", "scph39001.bin")
+        store = FakeFirmwareFileStore({inside: b"\x00" * 8})
+        for slug in ("psx", "ps"):
+            plugin._uow.bios_files.save(
+                BiosFile.mark_downloaded(
+                    platform_slug=slug,
+                    file_name="scph39001.bin",
+                    file_path=inside,
+                    downloaded_at="2026-01-01T00:00:00+00:00",
+                    firmware_id=None,
+                )
+            )
+        resolver = FakeFirmwareResolver()
+        resolver.declare(
+            "bios", required_by=[self._CORE], relative_path="pcsx2/bios", present=True, declares_directory=True
+        )
+        fw = self._service(plugin, tmp_path, resolver, store)
+
+        result = await fw.get_firmware_status()
+        plat = next(p for p in result["platforms"] if p["platform_slug"] == "psx")
+
+        assert plat["files"][0]["declared_kind"] == "directory"
+        assert plat["files"][0]["deletable_count"] == 1
+        # And the platform button, which has counted paths all along, agrees.
+        assert plat["deletable_count"] == 1
 
 
 class TestAFolderRequirementIsAnsweredByItsContents:


### PR DESCRIPTION
Three defects on the Library page, and the sibling sites the first one has on
the Collections tab.

A refused write is reverted and said. The Platforms toggle and Enable all /
Disable all reverted their optimistic flip only when the promise rejected; a
backend answer of `success: false` — which is what the migration gate and a
failed RomM listing return — left every toggle on over a write that never
landed, and said nothing. Both now check the answer, revert exactly as the
rejection path does, and write the backend's message into a line under the two
header buttons, in the list column, cleared by the next write that succeeds.
The Collections tab had the same shape at its four writes — the row toggle, the
whole-kind Enable all / Disable all, the batch write a search or filter narrows
them to, and the Mine / All owner scope — and gets the same fix and its own
line; re-entering the tab or switching its sub-tab resets the view and takes the
line with it.

The core switch holds the page's busy state. `changeCore` was the one action
that never set `busySlug`, so during the re-bake of every bound shortcut the
chip stayed pressable, a second pick could start a second continuation, the
download and remove buttons stayed live, and its unconditional status reset
cleared another platform's line. It now takes the hold at the pick and releases
it in `finally`, says what it is doing on the acting pane, clears only the line
it wrote, and treats a prune-lease cancellation as a cancellation rather than a
failure, as the shortcut removal already does: the switch either committed or
never ran, and either way there is no pane left to report to.

A folder row's `deletable_count` counts files, not records. The platform count
already counted distinct paths; the declared-folder row counted records, so two
records naming one file offered `Delete (2)` and removed one. Both now count
distinct paths, which is what the removal loop unlinks.

The sync callables' wire types say `message` is optional, because
`save_platform_sync` answers `{success: true}` alone. Docs: the Library section
of `qam-panel.md` states the refused-write line for both tabs and the busy hold
of a switch; the register's BIOS-delete entry says the folder count is distinct
paths.
