### PR TITLE
feat(qam): a wide-page frame fit for pages without tabs or a list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -557,12 +557,14 @@ Format: **invariant** — tier — enforced by.
   The trap is that a bare `Focusable` is a container rather than a focus stop: the base panel sets `focusable` only from
   a caller prop or an `onActivate`/`onOKButton`, and `GetFocusable()` answers `"none"` for a node with neither and no
   focusable children. The rule spans every page the wide frame will host, and the frame cannot carry it: it holds a
-  page's content as opaque nodes, never as rows it could check. **Its one half the frame DOES carry is the content above
-  a region's first focusable row** — a heading, a counts line, a column header, which is unreachable for the same reason
-  and has nothing below it to ride along with, so `ScrollRegion` scrolls itself to the top when focus reaches the first
-  stop in it (`revealTop`). That half is pinned by `src/components/qam/ScrollRegion.test.tsx` over mocked geometry, so
-  what is tested is the DECISION and not the scroll: whether the panel and the reader agree about which element is
-  topmost stays device-only, like the rest of this entry. Detail: `docs/architecture/qam-panel.md`, "Building blocks"
+  page's content as opaque nodes, never as rows it could check. **What the frame DOES carry is the content outside a
+  region's focusable rows, at both ends** — a heading, a counts line or a column header above the first, a legend or a
+  total below the last, each unreachable for the same reason and with no neighbour to ride along with — so
+  `ScrollRegion` scrolls itself to the top when focus reaches the first stop in it and to its end when focus reaches the
+  last (`revealEdge`, over `revealTop` and `revealBottom`). Both halves are pinned by
+  `src/components/qam/ScrollRegion.test.tsx` over mocked geometry, so what is tested is the DECISION and not the scroll:
+  whether the panel and the reader agree about which element is topmost or last stays device-only, like the rest of this
+  entry. Detail: `docs/architecture/qam-panel.md`, "Building blocks"
 
 When a change applies a guard / sanitize / backup / grouping pattern, sweep for sibling sites of the same pattern — the
 register is what that sweep checks against.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -486,9 +486,9 @@ What the plugin's Quick Access Menu panel shows at one time, chosen by the panel
 page the panel opens on: notices, status, the Sync button, the download summary and the menu. A **wide page** is a page
 that widens the panel from 348 px to 854 px for as long as it is mounted — the full screen width on the Deck, whose Big
 Picture viewport is 854 CSS px across. The width belongs to the page, not to a view inside it, and it collapses again
-when the page unmounts, the QAM tab changes, the panel closes or the plugin is dismounted. Main and Downloads are
-narrow; every other page is wide. _Avoid_: sub-page, screen, route (a **route** is a Steam page outside the QAM, such as
-the game detail page).
+when the page unmounts, the QAM tab changes, the panel closes or the plugin is dismounted. Every page is one or the
+other, and the page table in `docs/architecture/qam-panel.md` is where each page's width is decided. _Avoid_: sub-page,
+screen, route (a **route** is a Steam page outside the QAM, such as the game detail page).
 
 ### List and detail
 

--- a/docs/architecture/qam-panel.md
+++ b/docs/architecture/qam-panel.md
@@ -16,20 +16,21 @@ without restating it. The width mechanism's decision record is
 
 ## Where the code lives
 
-| Module                                                        | Responsibility                                                                                                                            |
-| ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `src/index.tsx` (`QAMPanel`)                                  | The router: one `Page` value, one mounted page, a module-level `currentPage` that survives a QAM remount                                  |
-| `src/types/navigation.ts`                                     | The `Page` union — every page the router can land on                                                                                      |
-| `src/components/MainPage.tsx`                                 | Main                                                                                                                                      |
-| `src/components/LibraryPage.tsx`                              | Library — the frame, the two tabs and their state                                                                                         |
-| `src/components/SettingsPage.tsx`, `src/components/settings/` | Settings and its sections                                                                                                                 |
-| `src/components/DangerZone.tsx`, `RemovedGamesCleanup.tsx`    | Data Management                                                                                                                           |
-| `src/components/DownloadQueue.tsx`                            | Downloads                                                                                                                                 |
-| `src/components/library/`                                     | The Library page's tabs: `usePlatformsPage` (its reads and actions), `PlatformsTab`, `PlatformDetail`                                     |
-| `src/utils/deckyUiInternals.ts`                               | Honest typing for `@decky/ui` values that come from a webpack probe: the frame's class names, `Tabs`, `ScrollPanel`, the controller glyph |
-| `src/utils/qamExpansion.ts`                                   | The panel's width: the expand and hide messages, the injected `max-width` rule, and the four paths that clear both                        |
-| `src/components/qam/`                                         | The wide-page frame: `WidePage` (the Back/title line, tabs, measured height), `ListDetail` and `ScrollRegion`                             |
-| `src/utils/` module stores                                    | State that must outlive a page: sync progress, pending preview, downloads, prune, notices                                                 |
+| Module                                                        | Responsibility                                                                                                                             |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `src/index.tsx` (`QAMPanel`)                                  | The router: one `Page` value, one mounted page, a module-level `currentPage` that survives a QAM remount                                   |
+| `src/types/navigation.ts`                                     | The `Page` union — every page the router can land on                                                                                       |
+| `src/components/MainPage.tsx`                                 | Main                                                                                                                                       |
+| `src/components/LibraryPage.tsx`                              | Library — the frame, the two tabs and their state                                                                                          |
+| `src/components/SettingsPage.tsx`, `src/components/settings/` | Settings and its sections                                                                                                                  |
+| `src/components/DangerZone.tsx`, `RemovedGamesCleanup.tsx`    | Data Management                                                                                                                            |
+| `src/components/DownloadQueue.tsx`                            | Downloads                                                                                                                                  |
+| `src/components/library/`                                     | The Library page's tabs: `usePlatformsPage` (its reads and actions), `PlatformsTab`, `PlatformDetail`                                      |
+| `src/utils/deckyUiInternals.ts`                               | Honest typing for `@decky/ui` values that come from a webpack probe: the frame's class names, `Tabs`, `ScrollPanel`, the controller glyph  |
+| `src/utils/qamExpansion.ts`                                   | The panel's width: the expand and hide messages, the injected `max-width` rule, and the four paths that clear both                         |
+| `src/components/qam/`                                         | The wide-page frame: `WidePage` (the Back/title line, tabs, measured height, entry focus), `ScrollRegion`, `Columns`, `ListDetail`, `pane` |
+| `src/utils/entryFocus.ts`                                     | Which stop a page opens on, and the `.focus()` + `gpfocus` pair that places it — the frame's and the router's one implementation           |
+| `src/utils/` module stores                                    | State that must outlive a page: sync progress, pending preview, downloads, prune, the game-detail caches                                   |
 
 ## Two widths
 
@@ -118,18 +119,22 @@ what makes it a stop: `FocusableProps` exposes no `focusable` prop, an activate 
 a row, a hint under a group, scrolls with its neighbours and need not be reachable itself. This is what focus-driven
 scrolling costs: content nobody can focus cannot be scrolled to.
 
-**The one place a page cannot buy its way out of that is the content ABOVE its first focusable row**, and the frame
-handles it rather than each page: a heading, a counts line, a column header sitting over the topmost row is not
-focusable and has nothing below it to ride along with, so once the reader has scrolled past it Steam has no reason to
-bring it back — it scrolls only far enough to show the focused element. `ScrollRegion` therefore scrolls itself to the
-top when focus reaches the first stop in it. Every region **built with `ScrollRegion`** gets that, which is not the same
-as every region on every wide page: a tabbed page's own tab content sits in Steam's `ScrollingTab`, so a tab that does
-not build its own regions — Collections today — is not covered. Two properties make that safe rather than a fight with
-Steam's own scrolling. The trigger is **"nothing focusable is above me"**, not "I am the first match" — a container
-`Focusable` renders `tabindex="0"` of its own and precedes the row inside it in document order, so an equality test
-would silently never fire on a page that wraps its rows, which `ListDetail` does for every row. And it acts only where
-the focused element still fits in the region at offset zero: where the content above it is taller than the region there
-is no offset showing both, Steam would scroll the element straight back, so nothing is done at all.
+**The one place a page cannot buy its way out of that is the content OUTSIDE its focusable rows**, and the frame handles
+it rather than each page: a heading, a counts line or a column header sitting over the topmost row, and a legend, a
+total or a hint under the last one, are not focusable and have no neighbour to ride along with, so once the reader has
+scrolled past them Steam has no reason to bring them back — it scrolls only far enough to show the focused element.
+`ScrollRegion` therefore scrolls itself to the top when focus reaches the first stop in it, and to its end when focus
+reaches the last. Every region **built with `ScrollRegion`** gets that, which is not the same as every region on every
+wide page: a tabbed page's own tab content sits in Steam's `ScrollingTab`, so a tab that does not build its own regions
+— Collections today — is not covered. Two properties make it safe rather than a fight with Steam's own scrolling. The
+triggers are **"nothing focusable is above me"** and **"nothing focusable is below me"**, never "I am the first match"
+or "the last" — a container `Focusable` renders `tabindex="0"` of its own and precedes in document order every row it
+wraps, so it is never the last match and a wrapped row is never the first, and an equality test against either end would
+silently never fire wherever a page wraps its rows, which `ListDetail` does for every row. So the first rule discounts
+the focused element's own ancestors and the second its own descendants. And each acts only where the focused element
+still fits in the region at the offset it would move to: where the content beyond it is taller than the region there is
+no offset showing both, Steam would scroll the element straight back, so nothing is done at all. A stop at both ends at
+once reveals the top where the top fits, and otherwise the end where that fits.
 
 The set of shapes it counts as a focus stop is measured in the running QAM, not assumed: Steam's own components render
 `div[tabindex="0"]` and a `DialogButton` is a native `button` carrying no tabindex attribute at all.
@@ -150,8 +155,9 @@ tried on the device and rejected. It is focusable and its OK button focuses its 
 became a focus stop of its own: the whole list outlined as one block, A to step into it, and only then rows taking
 focus. Steam's own QAM does not behave that way.
 
-Both of a list-and-detail page's regions are `ScrollRegion`s, and so is the frame's body when the page has no tabs. A
-tabbed body gets none from the frame: see "Building blocks → Tabs" for whose job it is instead.
+Both of a list-and-detail page's regions are `ScrollRegion`s, and so is the frame's body when the page has no tabs and
+does not say it owns its regions. A tabbed body gets none from the frame, and neither does one whose page passes
+`ownRegions`: see "Building blocks → Tabs" for whose job it is instead.
 
 ## Pages
 
@@ -189,9 +195,10 @@ every value, and the wrong one draws the wrong glyph without failing.
 `onCancelButton: !cancelSkipTabHeader && <focus the tab row>` (`chunk~2dcc5aaf7.js`), so without the flag the first B
 inside a tab is spent moving focus to the tab row and never reaches the router. `WidePage` passes `cancelSkipTabHeader`
 — Steam's own prop, which it uses in its controller-configurator dialogs, and which upstream's `TabsProps` predates;
-`src/utils/deckyUiInternals.ts` types it. After a navigation the router scrolls to the top and places gamepad focus on
-the page's first button, as it does today. The module-level `currentPage` survives a QAM remount, so reopening the QAM
-lands on the page that was open, and a wide page re-expands on mount.
+`src/utils/deckyUiInternals.ts` types it. After a navigation the router scrolls the panel to the top, and gamepad focus
+is placed on the page's first stop — by the router for a narrow page, and by the frame itself for a wide one, which says
+so on its root so the router leaves it alone (see "Building blocks → Tabs"). The module-level `currentPage` survives a
+QAM remount, so reopening the QAM lands on the page that was open, and a wide page re-expands on mount.
 
 ## Building blocks
 
@@ -202,14 +209,59 @@ glyphs overlap the labels, which is why the Library page's tab bar is hand-rolle
 
 Entry focus lands in the content — the active tab's, so the list of a list-and-detail page — and the bumper glyphs
 follow, because Steam draws them only while gamepad focus is within the tabbed page. Back stays reachable by moving up.
-A tabbed page therefore marks itself as placing its own entry focus, and the panel's router leaves it alone instead of
-focusing the page's first button, which is the Back row above the tabs.
+
+**Entry focus belongs to the frame, on every wide page.** `WidePage` marks its root as placing its own, so the panel's
+router leaves the page alone rather than focusing its first button, which is the Back chip above the body. Where Steam's
+tabbed page renders, its `autoFocusContents` does the placing; everywhere else — an untabbed page, and a tabbed one
+whose `Tabs` probe missed — the frame focuses the first stop inside the body itself, on the same 50 ms delay the router
+uses, because Steam's navigation resolves a focus pointer it retained across the page swap after the mount.
+
+**The stop it picks is the first enabled focus stop in document order that contains no focus stop at all.** Document
+order rather than "the first button", because a page's first button is not its first row: on a list-and-detail page
+whose list rows carry no control, the first button in the body is in the DETAIL pane, so a button-first rule would open
+the page inside the detail and move as the detail's content changed. Innermost, because a container `Focusable` carries
+`tabindex="0"` of its own and precedes every row it wraps, so the first match would be the container and the reader
+would start a step away from the row. Enabled, because a page opening on a dead control says nothing about where the
+reader is — the reveal rules in `ScrollRegion` read the same shapes and do NOT skip a disabled control, since focus
+still lands on one.
+
+**The two halves read different selectors, and the difference is load-bearing.** A candidate has to be enabled, but a
+container is skipped for holding a stop of ANY kind: a button row whose every button is disabled is still a container
+Steam does not stop on, so treating it as the innermost candidate would put the focus ring on it and take it off the
+next real row. The test cannot tell that row from one carrying an activate handler, so it skips both; a row whose only
+inner stop is disabled is stepped over, which no body's first column produces today. Where that leaves no candidate — no
+enabled stop that is free of stops inside it — nothing is placed and the page keeps whatever Steam's retained pointer
+resolves to. The narrow pages the router still covers keep a button-first rule — their first button, now skipped past a
+disabled one — because a narrow page is one column of Steam's own full-width rows and there the first button IS the
+first row. Both finders, the shared set of shapes and the `.focus()` + `gpfocus` pair are `src/utils/entryFocus.ts`.
 
 **A tab's content is the page's business, not the frame's.** The frame wraps an untabbed body in a `ScrollRegion` and a
 tabbed one in nothing: Steam's tabbed page already wraps each tab's content in this same plain scroll panel, so a region
 from the frame would only nest a second scroller around it. Rows of one column therefore scroll in a tab with nothing
 added. A page that needs more than that one scroller — a list and a detail scrolling independently side by side — builds
-its regions with `ScrollRegion` itself, which is what Library's tabs do.
+its regions with `ScrollRegion` itself, which is what Library's tabs do, and an untabbed page that does the same says so
+with `ownRegions` so the frame wraps its body in none either.
+
+### Columns
+
+One row of side-by-side scrolling regions, which is what every wide page whose content is more than one column is built
+from: a `Focusable` the stick crosses horizontally, and a `ScrollRegion` per column. A column names a fixed width or
+takes what is left, and may name a **region key** — joined to the column's id to form the React key its region carries —
+so that changing it remounts that one column and its content opens at its own top rather than at the offset the previous
+content was left at. A column that names none keeps one constant key and is never remounted. A key rather than a ref
+that scrolls the region back: Steam's scroll panel is reached through a webpack probe and nothing establishes that it
+forwards one.
+
+List and detail is `Columns` with two columns. The Sync page's table beside its controls column is the next.
+
+### The pane primitives
+
+The pieces a detail pane is built from, in `src/components/qam/pane.tsx` so that the next pane is written against the
+same scale rather than a second literal for the same size: the 11 px every secondary line is set in, the verdict
+palette, the two button shapes (`FLAT_BUTTON` for a button sharing a row, `ROW_BUTTON` for a table row's action column),
+a section title, a muted line, a row of buttons, and the two lines that report an action — the status line bound to the
+entry and the group it belongs under, and the sentence saying which other entry is working while this pane's buttons are
+disabled.
 
 ### List and detail
 
@@ -217,6 +269,11 @@ The list takes about a third of the width (264 px in the prototype), the detail 
 the list changes the detail at once, as Steam's own settings do. A list row may carry a toggle; A operates it, never the
 selection. Both regions scroll independently inside the page's measured height, and both scroll by moving focus — so a
 detail pane is built from focusable rows, not from paragraphs.
+
+A list whose rows carry no control of their own — a label and nothing else, which is what Settings and Data Management
+have — asks for `selectOnActivate`, and every row wrapper takes an activate handler that selects it. That handler is
+what makes the wrapper a focus stop rather than a container, so without it those rows are unreachable and the list
+cannot be scrolled. It is off by default, because a row that does carry a control must leave A to it.
 
 A list that is grouped or sorted by state computes its order when the page mounts and keeps it while the page is open,
 so toggling a row does not move it out from under the focus. The next mount shows the new order.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,8 +12,12 @@ export default tseslint.config(
   // `.venv` (local uv/mise Python env) and `site` (local mkdocs build output) are
   // gitignored build artifacts that don't exist in a clean CI checkout; ignoring
   // them keeps local `pnpm lint` from choking on their minified vendored JS.
+  // `.claude/worktrees` is where this repo's git worktrees live, and `.worktrees`
+  // is the convention they were kept under before; both hold whole checkouts of
+  // this repo, `node_modules` and all, which a lint run from a checkout holding
+  // one would otherwise walk until it runs out of V8 heap.
   {
-    ignores: ["dist", "node_modules", "defaults", "bin", "coverage", ".worktrees", ".venv", "site"],
+    ignores: ["dist", "node_modules", "defaults", "bin", "coverage", ".claude", ".worktrees", ".venv", "site"],
   },
   js.configs.recommended,
   ...tseslint.configs.recommended,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ pythonVersion = "3.11"
 extraPaths = ["py_modules"]
 stubPath = "typings"
 typeCheckingMode = "basic"
-exclude = ["py_modules/_vendor", "node_modules", "scripts", ".venv", ".worktrees"]
+exclude = ["py_modules/_vendor", "node_modules", "scripts", ".venv", ".claude", ".worktrees"]
 reportMissingModuleSource = "none"
 reportMissingImports = "warning"
 reportPrivateUsage = "error"
@@ -32,7 +32,11 @@ reportPrivateUsage = "none"
 [tool.ruff]
 target-version = "py311"
 line-length = 120
-extend-exclude = ["py_modules/_vendor", "./scripts"]
+# `.claude/worktrees` is where this repo's git worktrees live, and `.worktrees` is
+# the convention they were kept under before; both hold whole checkouts of this
+# repo. The gate runs `ruff check .` from the repo root, which walks into them
+# and reports another branch's findings against this one.
+extend-exclude = ["py_modules/_vendor", "./scripts", ".claude", ".worktrees"]
 # Ruff applies extend-exclude to a directory walk but ignores it for a path passed
 # explicitly, unless this is set. .githooks/pre-commit passes staged paths explicitly,
 # so without it the hook reformats the vendored verbatim copies it is excluding —

--- a/src/components/library/PlatformDetail.tsx
+++ b/src/components/library/PlatformDetail.tsx
@@ -23,27 +23,30 @@ import { buildEmulatorMenu } from "../../utils/emulatorMenu";
 import { getEventTarget } from "../../utils/events";
 import { pluralize } from "../../utils/pluralize";
 import { SYNC_RUNNING_HINT, useSyncRunning } from "../../utils/syncRunning";
-import type { CoreAnswer, PlatformRow, PlatformsPageState, StatusScope } from "./usePlatformsPage";
+import {
+  AMBER,
+  BusyElsewhere,
+  ButtonRow,
+  FLAT_BUTTON,
+  GREEN,
+  GroupStatus,
+  MUTED,
+  Muted,
+  PALE_GREEN,
+  RED,
+  ROW_BUTTON,
+  SECONDARY_FONT,
+  SectionTitle,
+  VIOLET,
+  type ScopedStatus,
+} from "../qam/pane";
+import type { CoreAnswer, DetailStatus, PlatformRow, PlatformsPageState, StatusScope } from "./usePlatformsPage";
 
-/** The size every secondary LINE on this pane is set in: the header's counts
- *  clause, the under-row description and note lines, the Contents cell beside
- *  them, the muted sentences, the table header and the legend. One constant,
- *  because the device pass asked for the cell to match those lines and a second
- *  literal is how they drift apart again. Button labels are not lines and keep
- *  their own sizes. */
-const SECONDARY_FONT = "11px";
-
-const MUTED = "#8f98a0";
-const RED = "#d94126";
-const GREEN = "#5ba32b";
-const AMBER = "#d4a72c";
-/** A satisfied row nothing is waiting on — present, and not this core's problem.
- *  Green's quieter twin, so "there and needed" and "there and spare" are one
- *  glance apart rather than one reading apart. */
-const PALE_GREEN = "#8fc46b";
-/** The second mark's own colour, deliberately outside the verdict palette's
- *  traffic light: what it reports is not a degree of wrongness. */
-const VIOLET = "#a48fd4";
+/** The page's status line as the pane primitives read it: on this page the key
+ *  a line is bound to is the platform slug. The scope type travels with it, so
+ *  the literal each `GroupStatus` names is checked against the page's groups. */
+const scopedStatus = (status: DetailStatus | null): ScopedStatus<StatusScope> | null =>
+  status && { key: status.slug, scope: status.scope, text: status.text };
 
 /**
  * The second mark: your RomM library does not hold this file.
@@ -59,37 +62,6 @@ const VIOLET = "#a48fd4";
  * fallback the `✓`/`✗` glyphs already rely on for this table.
  */
 const LIBRARY_MARK = { glyph: "⊘", color: VIOLET, title: "not in your RomM library" } as const;
-
-/**
- * The padding a `DialogButton` is given wherever this pane puts buttons in a
- * row.
- *
- * `ButtonItem` — the full-width control most of the panel uses — takes no style
- * or class of its own: its props are `ItemProps`, which has neither
- * (`@decky/ui/dist/components/Item.d.ts`), so its height is Steam's and cannot
- * be argued with from here. `DialogButton` does take `style`
- * (`DialogButtonProps extends DialogCommonProps`, `Dialog.d.ts`), and is Steam's
- * own button component rather than a lookalike of one.
- *
- * They are the same button, and the difference is the row around it. In
- * `chunk~2dcc5aaf7.js` module 12316, the `forwardRef` decky's prop-list regex
- * matches (`highlightOnFocus` then `childrenContainerWidth`) renders a `Field`
- * whose first child is a second `forwardRef`, and that one renders `o.$n`;
- * module 64608 re-exports `$n` from module 44351, where it is the `forwardRef`
- * whose className is `"DialogButton","_DialogLayout","Secondary"` — the exact
- * string `@decky/ui` searches for to bind its own `DialogButton`
- * (`components/Dialog.js`, `DialogButton = DialogButtonSecondary`). So
- * `ButtonItem` IS a `Field` wrapped around this component, and what a `Field`
- * costs is the row's own padding: 10px top and bottom inside the QAM, where it
- * renders in its `Classic` mode.
- */
-const FLAT_BUTTON = { flex: "1 1 auto", minWidth: 0, padding: "6px 10px", fontSize: "13px" } as const;
-
-/** The button in a BIOS row's action column. Narrow because the column is
- *  sized for it and the file name beside it is the thing worth width: 4px of
- *  horizontal padding on a 92px column still leaves a target wider than it is
- *  tall, which is what keeps it pressable at the Deck's scale. */
-const ROW_BUTTON = { width: "100%", minWidth: 0, padding: "4px", fontSize: "11px" } as const;
 
 /**
  * The core picker's button in the header line — the game page's icon button, at
@@ -264,46 +236,6 @@ function diskMark(file: FirmwareRow): { glyph: string; color: string; title: str
 function libraryMark(file: FirmwareRow): typeof LIBRARY_MARK | null {
   return file.on_server === false && file.declared_kind !== "directory" ? LIBRARY_MARK : null;
 }
-
-const SectionTitle: FC<{ title: string; note?: string; noteColor?: string }> = ({ title, note, noteColor }) => (
-  <div style={{ display: "flex", alignItems: "baseline", gap: "8px", padding: "12px 16px 4px" }}>
-    <span style={{ fontSize: "12px", fontWeight: 600, letterSpacing: "0.5px", color: "#dcdedf" }}>
-      {title.toUpperCase()}
-    </span>
-    {note && <span style={{ fontSize: SECONDARY_FONT, color: noteColor ?? MUTED }}>{note}</span>}
-  </div>
-);
-
-const Muted: FC<{ children: ReactNode }> = ({ children }) => (
-  <div style={{ fontSize: SECONDARY_FONT, color: MUTED, padding: "0 16px 6px" }}>{children}</div>
-);
-
-/** The status line for one group of one platform, or nothing. Both halves
- *  matter: a failed core switch must not be reported under Remove, and an
- *  action's result must not follow the reader onto the next platform's pane. */
-const GroupStatus: FC<{ state: PlatformsPageState; slug: string; scope: StatusScope }> = ({ state, slug, scope }) =>
-  state.status && state.status.slug === slug && state.status.scope === scope ? (
-    <div data-testid={`status-${scope}`} style={{ fontSize: "12px", color: "#dcdedf", padding: "0 16px 8px" }}>
-      {state.status.text}
-    </div>
-  ) : null;
-
-/**
- * Why this pane's buttons are dead while nothing on it is running.
- *
- * An action disables every platform's actions, not just its own, because the
- * page holds one `status`, one `removalProgress` and one `busySlug` — a second
- * action would clobber the first's line and the first `finally` would clear the
- * busy state under the second. The line that would explain the wait —
- * {@link GroupStatus} — is bound to the platform the action belongs to, so
- * walking away from a running removal leaves a pane full of disabled buttons and
- * nothing said. This is what it says.
- */
-const BusyElsewhere: FC<{ row: PlatformRow; state: PlatformsPageState }> = ({ row, state }) => {
-  if (state.busySlug === null || state.busySlug === row.slug) return null;
-  const other = state.rows.get(state.busySlug)?.name ?? "another platform";
-  return <Muted>{`Working on ${other} — actions here are paused until it finishes.`}</Muted>;
-};
 
 // File, On disk, Contents, and the row's own button. Every column but the first
 // is sized for the widest thing it can hold, measured on the device at the
@@ -696,7 +628,7 @@ function coreOffer(row: PlatformRow, core: CoreAnswer): CoreOffer {
 const CoreNotice: FC<{ row: PlatformRow; state: PlatformsPageState; offer: CoreOffer }> = ({ row, state, offer }) => (
   <>
     {offer.kind === "blocked" && offer.notice !== undefined && <Muted>{offer.notice}</Muted>}
-    <GroupStatus state={state} slug={row.slug} scope="core" />
+    <GroupStatus status={scopedStatus(state.status)} forKey={row.slug} scope="core" />
   </>
 );
 
@@ -946,7 +878,7 @@ const BiosSection: FC<{ row: PlatformRow; state: PlatformsPageState; firmware: F
           disk, which is exactly what the delete unlinks. The library ratio
           counts a different set and was wrong here in both directions,
           including hiding the button over downloads RomM had stopped listing. */}
-      <Focusable flow-children="horizontal" style={{ display: "flex", gap: "8px", padding: "2px 16px 6px" }}>
+      <ButtonRow padding="2px 16px 6px">
         <DialogButton
           style={FLAT_BUTTON}
           disabled={!showRequired || state.busySlug !== null}
@@ -968,8 +900,8 @@ const BiosSection: FC<{ row: PlatformRow; state: PlatformsPageState; firmware: F
         >
           <span style={{ color: RED }}>{`Delete BIOS (${deletable})`}</span>
         </DialogButton>
-      </Focusable>
-      <GroupStatus state={state} slug={row.slug} scope="bios" />
+      </ButtonRow>
+      <GroupStatus status={scopedStatus(state.status)} forKey={row.slug} scope="bios" />
     </>
   );
 };
@@ -1015,7 +947,7 @@ const RemoveSection: FC<{ row: PlatformRow; state: PlatformsPageState }> = ({ ro
       {/* One row, and no REMOVE heading over it: both buttons say what they
           remove and are drawn in red, so a title above them names nothing the
           buttons do not — and it would cost the pane a row. */}
-      <Focusable flow-children="horizontal" style={{ display: "flex", gap: "8px", padding: "6px 16px 4px" }}>
+      <ButtonRow padding="6px 16px 4px">
         <DialogButton
           style={FLAT_BUTTON}
           disabled={state.busySlug !== null || syncRunning || row.shortcutCount === 0}
@@ -1040,7 +972,7 @@ const RemoveSection: FC<{ row: PlatformRow; state: PlatformsPageState }> = ({ ro
             {typeof saveCount === "number" ? `Delete ${pluralize(saveCount, "save file")}` : "Delete save files"}
           </span>
         </DialogButton>
-      </Focusable>
+      </ButtonRow>
       {/* The one read of the five whose failure had nothing to say. With the
           spinner above it that became worse rather than better — a spinner that
           never stops — so the two land together. */}
@@ -1057,7 +989,7 @@ const RemoveSection: FC<{ row: PlatformRow; state: PlatformsPageState }> = ({ ro
           blocks, and widening it to make a line true would be the tail wagging
           the dog. */}
       {syncRunning && <Muted>{`Removing shortcuts: ${SYNC_RUNNING_HINT}`}</Muted>}
-      <GroupStatus state={state} slug={row.slug} scope="remove" />
+      <GroupStatus status={scopedStatus(state.status)} forKey={row.slug} scope="remove" />
     </>
   );
 };
@@ -1179,7 +1111,11 @@ export const PlatformDetail: FC<{ row: PlatformRow; state: PlatformsPageState }>
       {state.removalProgress?.slug === row.slug && (
         <Muted>{`Removing ${state.removalProgress.removed} of ${state.removalProgress.total}…`}</Muted>
       )}
-      <BusyElsewhere row={row} state={state} />
+      <BusyElsewhere
+        busyKey={state.busySlug}
+        ownKey={row.slug}
+        busyName={state.rows.get(state.busySlug ?? "")?.name ?? "another platform"}
+      />
       <CoreNotice row={row} state={state} offer={offer} />
       {/* A failed read is said on EVERY pane, not only the ones with no entry.
           A failed refresh does not clear the map, so a platform that has an

--- a/src/components/library/PlatformsTab.test.tsx
+++ b/src/components/library/PlatformsTab.test.tsx
@@ -1616,8 +1616,9 @@ describe("Library › Platforms", () => {
       // nobody can focus is a row nobody can scroll past. A row with neither
       // button needs the Focusable wrapper, and the wrapper was lost once
       // because the prop it keys on became an always-truthy element. happy-dom
-      // has no nav tree, but the `Focusable` mock does render a testid, so this
-      // one the suite can see.
+      // has no nav tree, but the `Focusable` mock renders a testid AND surfaces
+      // the activate handler — which is what makes the wrapper a focus stop
+      // rather than a container that passes focus to children it has none of.
       vi.mocked(backend.getFirmwareStatus).mockResolvedValue({
         success: true,
         platforms: [
@@ -1645,6 +1646,7 @@ describe("Library › Platforms", () => {
       // grid cell → grid → the row's wrapper, which must be the Focusable.
       const wrapper = nameCell!.closest("div")!.parentElement!;
       expect(wrapper.dataset.testid).toBe("focusable");
+      expect(wrapper.dataset.activate).toBe("true");
     });
 
     it("offers a per-row Delete only where a download record still holds the file", async () => {

--- a/src/components/qam/Columns.test.tsx
+++ b/src/components/qam/Columns.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * Columns tests — one row of scrolling regions: how a column is sized, that
+ * each is a region of its own, and that a column is remounted exactly when its
+ * region key changes.
+ *
+ * The scroll panel is read at module scope by `ScrollRegion`, so the tests that
+ * need to see the regions load a copy of the component with a stub in its place.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { CSSProperties, FC, ReactNode } from "react";
+import type { ColumnsProps } from "./Columns";
+
+/** Stand-in for Steam's scroll panel: it keeps the style, which is where a
+ *  column's width lands, and is identifiable as one region per column. */
+const StubScrollPanel: FC<{ style?: CSSProperties; children?: ReactNode }> = ({ style, children }) => (
+  <div data-testid="scroll-panel" style={style}>
+    {children}
+  </div>
+);
+
+async function loadColumns(): Promise<FC<ColumnsProps>> {
+  vi.resetModules();
+  vi.doMock("../../utils/deckyUiInternals", () => ({ ScrollPanel: StubScrollPanel }));
+  return (await import("./Columns")).Columns;
+}
+
+describe("Columns", () => {
+  afterEach(() => {
+    vi.doUnmock("../../utils/deckyUiInternals");
+    vi.resetModules();
+  });
+
+  it("gives every column a scrolling region of its own", async () => {
+    const Columns = await loadColumns();
+
+    render(
+      <Columns
+        columns={[
+          { id: "table", content: <button>a table row</button> },
+          { id: "controls", width: "220px", content: <button>a control</button> },
+        ]}
+      />,
+    );
+    const [table, controls] = screen.getAllByTestId("scroll-panel");
+
+    // Two regions rather than one around both: the columns scroll
+    // independently, so a long table must not carry the controls up with it.
+    expect(table).toContainElement(screen.getByRole("button", { name: "a table row" }));
+    expect(controls).toContainElement(screen.getByRole("button", { name: "a control" }));
+    expect(table).not.toContainElement(screen.getByRole("button", { name: "a control" }));
+  });
+
+  it("pins a column to its width and lets the one without take the rest", async () => {
+    const Columns = await loadColumns();
+
+    render(
+      <Columns
+        columns={[
+          { id: "fixed", width: "264px", content: <div>fixed</div> },
+          { id: "rest", content: <div>rest</div> },
+        ]}
+      />,
+    );
+    const [fixed, rest] = screen.getAllByTestId("scroll-panel");
+
+    expect(fixed?.style.flex).toBe("0 0 264px");
+    expect(fixed?.style.width).toBe("264px");
+    expect(rest?.style.flex).toBe("1 1 auto");
+    // A flex item's floor is its content, so without the reset one over-wide row
+    // widens the column past its share.
+    expect(rest?.style.minWidth).toBe("0");
+  });
+
+  it("lays the columns out in one horizontal row the stick can cross", async () => {
+    const Columns = await loadColumns();
+
+    const { container } = render(<Columns columns={[{ id: "only", content: <div>only</div> }]} />);
+    const row = container.firstElementChild as HTMLElement;
+
+    expect(row.style.display).toBe("flex");
+    expect(row.style.gap).toBe("12px");
+    // The row is bounded by the height the frame measured, and a flex child's
+    // min-height is its content unless the floor is reset — without both the
+    // regions grow instead of scrolling.
+    expect(row.style.height).toBe("100%");
+    expect(row.style.minHeight).toBe("0");
+  });
+
+  it("remounts a column when its region key changes, and leaves the others alone", async () => {
+    const Columns = await loadColumns();
+    const columns = (key: string): ColumnsProps["columns"] => [
+      { id: "list", content: <div>the list</div> },
+      { id: "detail", regionKey: key, content: <div>{`detail ${key}`}</div> },
+    ];
+
+    const { rerender } = render(<Columns columns={columns("n64")} />);
+    const [listBefore, detailBefore] = screen.getAllByTestId("scroll-panel");
+    rerender(<Columns columns={columns("psx")} />);
+    const [listAfter, detailAfter] = screen.getAllByTestId("scroll-panel");
+
+    // The remount is how a fresh region opens at its own top; the neighbour
+    // keeping its element is what stops it losing the offset the reader left it
+    // at.
+    expect(detailBefore).not.toBeInTheDocument();
+    expect(detailAfter).toContainElement(screen.getByText("detail psx"));
+    expect(listAfter).toBe(listBefore);
+  });
+
+  it("keeps a column mounted across a re-render when it names no region key", async () => {
+    const Columns = await loadColumns();
+    const columns = (label: string): ColumnsProps["columns"] => [{ id: "only", content: <div>{label}</div> }];
+
+    const { rerender } = render(<Columns columns={columns("before")} />);
+    const before = screen.getByTestId("scroll-panel");
+    rerender(<Columns columns={columns("after")} />);
+
+    // The key joins the id to an empty region key, so it never changes: a
+    // column that says nothing about remounting is never remounted under its
+    // own content.
+    expect(screen.getByTestId("scroll-panel")).toBe(before);
+    expect(screen.getByText("after")).toBeInTheDocument();
+  });
+});

--- a/src/components/qam/Columns.tsx
+++ b/src/components/qam/Columns.tsx
@@ -1,0 +1,63 @@
+/**
+ * The layout of a wide page whose content is side-by-side scrolling regions:
+ * one row of columns, each scrolling on its own inside the frame's measured
+ * height.
+ *
+ * List and detail is one shape of it and `ListDetail` is that shape; the Sync
+ * page's table beside its controls column is another. What is shared is the row
+ * itself — a horizontal `Focusable` so the stick crosses between columns, the
+ * gap between them, and a `ScrollRegion` per column so a long column does not
+ * carry its neighbours up with it.
+ *
+ * Structure and vocabulary: `docs/architecture/qam-panel.md`.
+ */
+
+import type { FC, ReactNode } from "react";
+import { Focusable } from "@decky/ui";
+import { ScrollRegion } from "./ScrollRegion";
+
+export interface Column {
+  id: string;
+  /** A fixed width, or nothing for the column that takes what is left. */
+  width?: string;
+  /**
+   * What makes the page want this column REMOUNTED rather than re-rendered —
+   * which is how a fresh region opens at its own top rather than at the offset
+   * the previous content was left at. The key a region carries joins the
+   * column's `id` to this, so a column that names none keeps one constant key
+   * and is never remounted.
+   *
+   * A key rather than a ref that scrolls the region back: Steam's scroll panel
+   * is reached through a webpack probe and nothing establishes that it forwards
+   * one, while a key needs no handle on the element at all.
+   */
+  regionKey?: string;
+  content: ReactNode;
+}
+
+export interface ColumnsProps {
+  columns: Column[];
+}
+
+export const Columns: FC<ColumnsProps> = ({ columns }) => (
+  <Focusable flow-children="horizontal" style={{ display: "flex", gap: "12px", height: "100%", minHeight: 0 }}>
+    {columns.map((column) => (
+      <ScrollRegion
+        // The id and the region key are joined rather than one standing in
+        // for the other: a page whose region keys are its item ids would
+        // otherwise collide with a column named after one of them.
+        key={`${column.id}:${column.regionKey ?? ""}`}
+        // `minWidth: 0` on the flexible column for the reason the region's own
+        // bounds reset its min-height: a flex item's floor is its content, so
+        // without it one over-wide row widens the column past its share.
+        style={
+          column.width === undefined
+            ? { flex: "1 1 auto", minWidth: 0 }
+            : { flex: `0 0 ${column.width}`, width: column.width }
+        }
+      >
+        {column.content}
+      </ScrollRegion>
+    ))}
+  </Focusable>
+);

--- a/src/components/qam/ListDetail.test.tsx
+++ b/src/components/qam/ListDetail.test.tsx
@@ -199,6 +199,43 @@ describe("ListDetail", () => {
     expect(onSelect).not.toHaveBeenCalled();
   });
 
+  it("makes a control-less row a focus stop, and selects it on press", () => {
+    // A row that renders a label and nothing else is a bare container: Steam's
+    // base panel takes `focusable` from an activate handler, so without one the
+    // reader cannot reach the row and cannot scroll past it. The stub surfaces
+    // the handler as `data-activate`, which is all happy-dom can show — it has
+    // no nav tree.
+    const onSelect = vi.fn();
+    render(
+      <ListDetail
+        items={[
+          { id: "general", render: () => <span>General</span> },
+          { id: "library", render: () => <span>Library</span> },
+        ]}
+        selectedId="general"
+        onSelect={onSelect}
+        renderDetail={(id) => <div>detail for {id ?? "nothing"}</div>}
+        selectOnActivate
+      />,
+    );
+
+    const row = screen.getByText("Library").closest("[data-testid='focusable']") as HTMLElement;
+    expect(row.dataset.activate).toBe("true");
+
+    fireEvent(row, new CustomEvent("decky-button-down", { detail: { button: 1 }, bubbles: true }));
+
+    expect(onSelect).toHaveBeenCalledWith("library");
+  });
+
+  it("leaves a row a plain container without selectOnActivate, so A stays with its control", () => {
+    // The default: a row that carries a toggle must not spend A on the
+    // selection, which focus already made.
+    render(<ControlledHost />);
+
+    const row = screen.getByRole("button", { name: /PlayStation/ }).closest("[data-testid='focusable']");
+    expect((row as HTMLElement).dataset.activate).toBeUndefined();
+  });
+
   it("renders a detail for an empty selection", () => {
     render(
       <ListDetail

--- a/src/components/qam/ListDetail.tsx
+++ b/src/components/qam/ListDetail.tsx
@@ -1,17 +1,18 @@
 /**
  * The list-and-detail layout of a wide QAM page: the list on the left, the
  * focused entry's detail on the right, each scrolling on its own inside the
- * frame's measured height.
+ * frame's measured height. It is `Columns` with those two columns.
  *
  * A region scrolls by moving focus, so what a reader must be able to reach in
  * either pane — a detail's table rows included — has to be focusable; plain
  * text scrolls along with the row it accompanies but cannot be scrolled to.
  *
  * Focus selects — moving through the list changes the detail at once, as Steam's
- * own settings do. The row's own control keeps A, so this component never
- * intercepts it; a row that carries a toggle still toggles on press. A control
- * that acts on the whole list goes in `listHeader` rather than in a row, so
- * reaching it reports no selection.
+ * own settings do. The row's own control keeps A, so this component intercepts
+ * it only where a page asks for `selectOnActivate`, for rows that carry no
+ * control; a row that carries a toggle still toggles on press. A control that
+ * acts on the whole list goes in `listHeader` rather than in a row, so reaching
+ * it reports no selection.
  *
  * Selection is controlled: the page owns `selectedId` and decides what a change
  * means for the rest of it.
@@ -19,7 +20,7 @@
 
 import type { FC, ReactNode } from "react";
 import { Focusable } from "@decky/ui";
-import { ScrollRegion } from "./ScrollRegion";
+import { Columns } from "./Columns";
 
 export interface ListDetailItem {
   id: string;
@@ -37,41 +38,67 @@ export interface ListDetailProps {
    * one reports no selection: these belong to the list, not to a row of it.
    */
   listHeader?: ReactNode;
+  /**
+   * Makes every row wrapper a focus stop by giving it an activate handler, for
+   * a list whose rows carry no control of their own — a label and nothing else.
+   * Without it such a row is a bare container that passes focus to children it
+   * does not have, so the reader cannot reach it and cannot scroll past it.
+   *
+   * Off by default, because a row that DOES carry a control must leave A to it.
+   */
+  selectOnActivate?: boolean;
 }
 
 // The list takes about a third of the 806 px a wide tab panel offers.
 const LIST_WIDTH = "264px";
 
-export const ListDetail: FC<ListDetailProps> = ({ items, selectedId, onSelect, renderDetail, listHeader }) => (
-  <Focusable flow-children="horizontal" style={{ display: "flex", gap: "12px", height: "100%", minHeight: 0 }}>
-    <ScrollRegion style={{ flex: `0 0 ${LIST_WIDTH}`, width: LIST_WIDTH }}>
-      <Focusable flow-children="vertical">
-        {listHeader}
-        {items.map((item) => (
-          // React delivers onFocus through focusin, so this fires for focus
-          // landing on whatever control the row itself renders — and again for
-          // every move between controls inside the same row, or on the way back
-          // from the detail pane. Only a real change is reported, so a page may
-          // treat onSelect as an event and do work on it.
-          <Focusable
-            key={item.id}
-            onFocus={() => {
-              if (item.id !== selectedId) onSelect(item.id);
-            }}
-          >
-            {item.render(item.id === selectedId)}
+export const ListDetail: FC<ListDetailProps> = ({
+  items,
+  selectedId,
+  onSelect,
+  renderDetail,
+  listHeader,
+  selectOnActivate,
+}) => (
+  <Columns
+    columns={[
+      {
+        id: "list",
+        width: LIST_WIDTH,
+        content: (
+          <Focusable flow-children="vertical">
+            {listHeader}
+            {items.map((item) => (
+              // React delivers onFocus through focusin, so this fires for focus
+              // landing on whatever control the row itself renders — and again for
+              // every move between controls inside the same row, or on the way back
+              // from the detail pane. Only a real change is reported, so a page may
+              // treat onSelect as an event and do work on it.
+              <Focusable
+                key={item.id}
+                onFocus={() => {
+                  if (item.id !== selectedId) onSelect(item.id);
+                }}
+                // Spread rather than a conditional value: under
+                // `exactOptionalPropertyTypes` an explicit `undefined` is not
+                // the same as an absent prop, and `FocusableProps` declares the
+                // handler without it.
+                {...(selectOnActivate ? { onActivate: () => onSelect(item.id) } : {})}
+              >
+                {item.render(item.id === selectedId)}
+              </Focusable>
+            ))}
           </Focusable>
-        ))}
-      </Focusable>
-    </ScrollRegion>
-    {/* Keyed on the selection so a new entry's detail opens at its own top.
-        The region is remounted rather than scrolled back by a ref, because
-        Steam's scroll panel is reached through a webpack probe and nothing
-        establishes that it forwards one; a key needs no handle on the element.
-        Focus is in the list when this changes — that is what changed the
-        selection — so nothing focused is unmounted. */}
-    <ScrollRegion key={selectedId ?? ""} style={{ flex: "1 1 auto", minWidth: 0 }}>
-      <Focusable flow-children="vertical">{renderDetail(selectedId)}</Focusable>
-    </ScrollRegion>
-  </Focusable>
+        ),
+      },
+      {
+        id: "detail",
+        // Keyed on the selection so a new entry's detail opens at its own top.
+        // Focus is in the list when this changes — that is what changed the
+        // selection — so nothing focused is unmounted.
+        regionKey: selectedId ?? "",
+        content: <Focusable flow-children="vertical">{renderDetail(selectedId)}</Focusable>,
+      },
+    ]}
+  />
 );

--- a/src/components/qam/ScrollRegion.test.tsx
+++ b/src/components/qam/ScrollRegion.test.tsx
@@ -131,18 +131,18 @@ describe("ScrollRegion", () => {
   });
 
   /**
-   * Revealing the region's top.
+   * Revealing the region's two ends.
    *
    * happy-dom lays nothing out and has no gamepad, so the geometry every branch
    * reads is mocked and what is pinned is the DECISION, not the scroll a reader
    * would see. That the panel and the reader agree about which element is
-   * topmost, and that the scroll looks right on a controller, is the device
-   * round's to settle.
+   * topmost or last, and that the scroll looks right on a controller, is the
+   * device round's to settle.
    */
-  describe("revealing what sits above the first focusable row", () => {
-    /** A region 500 tall over 1200 of content, with each stop placed by data. */
-    function mockGeometry(): void {
-      vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockReturnValue(1200);
+  describe("revealing what sits outside the first and last focusable rows", () => {
+    /** A region 500 tall over `scrollHeight` of content, each stop placed by data. */
+    function mockGeometry(scrollHeight: number): void {
+      vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockReturnValue(scrollHeight);
       vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(500);
       vi.spyOn(HTMLElement.prototype, "clientTop", "get").mockReturnValue(0);
       vi.spyOn(Element.prototype, "scrollTop", "get").mockReturnValue(0);
@@ -151,9 +151,9 @@ describe("ScrollRegion", () => {
       });
     }
 
-    async function renderRegion(children: ReactNode) {
+    async function renderRegion(children: ReactNode, scrollHeight = 1200) {
       const ScrollRegion = await loadScrollRegion(StubScrollPanel);
-      mockGeometry();
+      mockGeometry(scrollHeight);
       render(<ScrollRegion>{children}</ScrollRegion>);
       const region = screen.getByTestId("scroll-panel");
       const scrollTo = vi.spyOn(region, "scrollTo").mockImplementation(() => {});
@@ -184,13 +184,14 @@ describe("ScrollRegion", () => {
       expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: "smooth" });
     });
 
-    it("leaves the scroll alone for every stop below the first", async () => {
+    it("leaves the scroll alone for a stop with focusable rows on both sides", async () => {
       const { scrollTo } = await renderRegion(
         <>
           <button data-top="90">first</button>
           <button data-testid="second" data-top="140">
             second
           </button>
+          <button data-top="190">third</button>
         </>,
       );
 
@@ -223,17 +224,12 @@ describe("ScrollRegion", () => {
     });
 
     it("does nothing where the region has nothing to scroll", async () => {
-      const ScrollRegion = await loadScrollRegion(StubScrollPanel);
-      mockGeometry();
-      vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockReturnValue(500);
-      render(
-        <ScrollRegion>
-          <button data-testid="only" data-top="90">
-            only
-          </button>
-        </ScrollRegion>,
+      const { scrollTo } = await renderRegion(
+        <button data-testid="only" data-top="90">
+          only
+        </button>,
+        500,
       );
-      const scrollTo = vi.spyOn(screen.getByTestId("scroll-panel"), "scrollTo").mockImplementation(() => {});
 
       fireEvent.focusIn(screen.getByTestId("only"));
       vi.advanceTimersByTime(50);
@@ -304,9 +300,106 @@ describe("ScrollRegion", () => {
       }
     });
 
+    it("scrolls to the end when focus reaches the last stop in it", async () => {
+      // The mirror of the heading above the first row: a legend, a total or a
+      // hint under the last row has nothing below it to ride along with, and
+      // Steam scrolls only far enough to show the focused element.
+      const { scrollTo } = await renderRegion(
+        <>
+          <button data-top="90">first</button>
+          <button data-testid="last" data-top="800">
+            last
+          </button>
+        </>,
+      );
+
+      fireEvent.focusIn(screen.getByTestId("last"));
+      vi.advanceTimersByTime(50);
+
+      expect(scrollTo).toHaveBeenCalledWith({ top: 1200, behavior: "smooth" });
+    });
+
+    it("counts the row inside a focused wrapper as its descendant, not as something below it", async () => {
+      // The same shape as the first-stop case read from the other end: a
+      // container `Focusable` carries `tabindex="0"` and precedes the row it
+      // wraps, so focus landing on the wrapper has a match after it that is its
+      // own child. Counting that as something below would make the rule
+      // silently never fire wherever a page wraps its rows.
+      const { scrollTo } = await renderRegion(
+        <>
+          <button data-top="90">first</button>
+          {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- reproducing verbatim what Steam's container Focusable renders, which is the shape under test; giving it an interactive role would make it a different node from the one the handler has to see through. */}
+          <div tabIndex={0} data-testid="wrapper" data-top="800">
+            <button data-top="800">last</button>
+          </div>
+        </>,
+      );
+
+      fireEvent.focusIn(screen.getByTestId("wrapper"));
+      vi.advanceTimersByTime(50);
+
+      expect(scrollTo).toHaveBeenCalledWith({ top: 1200, behavior: "smooth" });
+    });
+
+    it("refuses to scroll the last stop out of view to show what is below it", async () => {
+      // Content below it taller than the region: there is no offset that shows
+      // both, so Steam would scroll the element straight back and the two would
+      // fight. Doing nothing leaves the reader the behaviour they had.
+      const { scrollTo } = await renderRegion(
+        <>
+          <button data-top="50">first</button>
+          <button data-testid="last" data-top="100">
+            last
+          </button>
+        </>,
+      );
+
+      fireEvent.focusIn(screen.getByTestId("last"));
+      vi.advanceTimersByTime(50);
+
+      expect(scrollTo).not.toHaveBeenCalled();
+    });
+
+    it("reveals the top rather than the end for a stop at both ends at once", async () => {
+      // A region only a little taller than its viewport, where one stop
+      // qualifies for both ends — 1200/500 cannot produce that, since no offset
+      // is both within one screen of the top and within one of the end.
+      // Reaching such a stop is entering the region, so the top wins.
+      const { scrollTo } = await renderRegion(
+        <button data-testid="only" data-top="150">
+          only
+        </button>,
+        600,
+      );
+
+      fireEvent.focusIn(screen.getByTestId("only"));
+      vi.advanceTimersByTime(50);
+
+      expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: "smooth" });
+      expect(scrollTo).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls through to the end for a stop at both ends whose top does not fit", async () => {
+      // The region's one row sits below a screenful of heading: no offset shows
+      // that row and the region's top together, so revealing the top is refused
+      // — and the end, which does fit, is still worth revealing. Stopping at the
+      // refusal would leave whatever sits under the row permanently off-screen.
+      const { scrollTo } = await renderRegion(
+        <button data-testid="only" data-top="800" data-h="40">
+          only
+        </button>,
+      );
+
+      fireEvent.focusIn(screen.getByTestId("only"));
+      vi.advanceTimersByTime(50);
+
+      expect(scrollTo).toHaveBeenCalledWith({ top: 1200, behavior: "smooth" });
+      expect(scrollTo).toHaveBeenCalledTimes(1);
+    });
+
     it("reveals the top on the fallback branch too", async () => {
       const ScrollRegion = await loadScrollRegion(undefined);
-      mockGeometry();
+      mockGeometry(1200);
       render(
         <ScrollRegion>
           <button data-testid="first" data-top="90">

--- a/src/components/qam/ScrollRegion.tsx
+++ b/src/components/qam/ScrollRegion.tsx
@@ -30,6 +30,11 @@
 import type { CSSProperties, FC, FocusEvent, ReactNode } from "react";
 import { Focusable } from "@decky/ui";
 import { ScrollPanel } from "../../utils/deckyUiInternals";
+// The shapes a focus stop takes, shared with the entry-focus finder that reads
+// the same DOM for a different question. Disabled controls are in it: focus
+// lands on them, so a reveal rule that skipped them would misjudge which stop
+// is the first or the last.
+import { FOCUS_STOPS } from "../../utils/entryFocus";
 import { offsetWithinScroller } from "../../utils/scrollHelpers";
 
 export interface ScrollRegionProps {
@@ -57,15 +62,6 @@ export interface ScrollRegionProps {
 // and took the Back row off the top with it. A controller never showed it,
 // because Steam scrolls a region by moving focus rather than by wheel events.
 const BOUNDS: CSSProperties = { height: "100%", minHeight: 0, overscrollBehavior: "contain" };
-
-// Every shape Steam gives a focus stop inside a region, measured in the running
-// QAM rather than assumed: its own components render `div[tabindex="0"]`
-// (`Focusable`, a toggle row, a table row carrying an activate handler) and a
-// `DialogButton` is a native `button` with no tabindex attribute at all. A
-// container `Focusable` can carry `tabindex="0"` too, which is why the rule
-// below excludes the focused element's own ancestors rather than comparing
-// against the first match.
-const FOCUS_STOPS = "[tabindex], button, a[href], input, select, textarea";
 
 // Long enough to land after Steam's own focus scroll, which would otherwise
 // undo this one. The same 50 ms every helper in `utils/scrollHelpers.ts` uses,

--- a/src/components/qam/ScrollRegion.tsx
+++ b/src/components/qam/ScrollRegion.tsx
@@ -8,12 +8,12 @@
  * the bargain — every row a reader must reach is a focusable row, and text that
  * only accompanies one scrolls along with it.
  *
- * The one thing the caller cannot buy that way is the content ABOVE its first
- * focusable row: Steam scrolls a region only far enough to show the focused
- * element, so a heading, a counts line or a column header sitting over the
- * topmost row stays off the top once the reader has scrolled past it. That is
+ * The one thing the caller cannot buy that way is the content OUTSIDE its
+ * focusable rows: Steam scrolls a region only far enough to show the focused
+ * element, so a heading or a column header over the topmost row stays off the
+ * top, and a legend or a total under the last row stays off the bottom. That is
  * this component's own job, and it is here rather than on a page so that every
- * region built with `ScrollRegion` inherits it — see `revealTop`. That is not
+ * region built with `ScrollRegion` inherits it — see `revealEdge`. That is not
  * every region on every wide page: a TABBED page's content sits in Steam's own
  * `ScrollingTab`, which the frame does not wrap, so a tab that does not build
  * its own regions does not get this.
@@ -69,23 +69,58 @@ const BOUNDS: CSSProperties = { height: "100%", minHeight: 0, overscrollBehavior
 const AFTER_STEAMS_OWN_SCROLL_MS = 50;
 
 /**
- * Reveal the region's top once focus reaches the first thing in it that can
- * hold focus.
- *
- * The rule is "nothing focusable is above me", not "I am the first match":
- * a container `Focusable` renders `tabindex="0"` of its own and precedes the
- * row inside it in document order, so an equality test would silently never
- * fire wherever a page wraps its rows. An ancestor of the focused element is
- * therefore not something above it.
+ * Reveal the region's top, once focus has reached the first thing in it that
+ * can hold focus, and answer whether it did.
  *
  * **It cannot fight Steam's own scrolling, because it never moves the focused
  * element out of view**: the scroll happens only when that element still fits
  * within the region at offset zero. Where the content above the first row is
  * taller than the region itself there is no offset that shows both, and Steam
- * would immediately scroll the element back — so nothing is done at all and the
- * reader keeps the behaviour they had.
+ * would immediately scroll the element back — so this refuses, and the caller
+ * decides what else is worth trying.
  */
-function revealTop(event: FocusEvent<HTMLElement>): void {
+function revealTop(region: HTMLElement, focused: HTMLElement): boolean {
+  const focusedBottom = offsetWithinScroller(focused, region) + focused.getBoundingClientRect().height;
+  if (focusedBottom > region.clientHeight) return false;
+  setTimeout(() => region.scrollTo({ top: 0, behavior: "smooth" }), AFTER_STEAMS_OWN_SCROLL_MS);
+  return true;
+}
+
+/**
+ * Reveal the region's end, once focus has reached the last thing in it that can
+ * hold focus — the mirror of {@link revealTop}, for the legend, the total line
+ * or the hint a page puts under its last row.
+ *
+ * It never moves the focused element out of view either, and by the same test
+ * read from the other end: the scroll happens only where everything from that
+ * element to the end of the content fits within the region, so the element is
+ * still on screen once the region sits at its end. It answers whether it
+ * scrolled for symmetry with {@link revealTop}; nothing follows it today.
+ */
+function revealBottom(region: HTMLElement, focused: HTMLElement): boolean {
+  if (region.scrollHeight - offsetWithinScroller(focused, region) > region.clientHeight) return false;
+  setTimeout(() => region.scrollTo({ top: region.scrollHeight, behavior: "smooth" }), AFTER_STEAMS_OWN_SCROLL_MS);
+  return true;
+}
+
+/**
+ * Reveal whichever end of the region focus has just reached, if either.
+ *
+ * Both rules are stated against what else can hold focus, never against a
+ * position in the match list: a container `Focusable` renders `tabindex="0"` of
+ * its own and precedes in document order every row it wraps, so it is never the
+ * last match and a wrapped row is never the first — an equality test against
+ * either end would silently never fire wherever a page wraps its rows. So
+ * "nothing focusable is above me" discounts the focused element's own ancestors,
+ * and "nothing focusable is below me" discounts its own descendants.
+ *
+ * A stop at both ends at once reveals the top where the top fits, and otherwise
+ * the end where that fits. Reaching such a stop is entering the region, so the
+ * top is what a reader has yet to see; but a region whose one row sits below a
+ * screenful of heading has no offset showing that row and its top together, and
+ * there the end is still worth revealing.
+ */
+function revealEdge(event: FocusEvent<HTMLElement>): void {
   const region = event.currentTarget;
   const focused = event.target;
   // Asked of the node's OWN view, never the module's global. Plugin code runs
@@ -100,10 +135,12 @@ function revealTop(event: FocusEvent<HTMLElement>): void {
 
   const stops = [...region.querySelectorAll(FOCUS_STOPS)];
   const reached = stops.indexOf(focused);
-  if (reached < 0 || stops.slice(0, reached).some((stop) => !stop.contains(focused))) return;
+  if (reached < 0) return;
 
-  if (offsetWithinScroller(focused, region) + focused.getBoundingClientRect().height > region.clientHeight) return;
-  setTimeout(() => region.scrollTo({ top: 0, behavior: "smooth" }), AFTER_STEAMS_OWN_SCROLL_MS);
+  const isFirst = !stops.slice(0, reached).some((stop) => !stop.contains(focused));
+  const isLast = !stops.slice(reached + 1).some((stop) => !focused.contains(stop));
+  if (isFirst && revealTop(region, focused)) return;
+  if (isLast) revealBottom(region, focused);
 }
 
 export const ScrollRegion: FC<ScrollRegionProps> = ({ style, children }) =>
@@ -118,11 +155,11 @@ export const ScrollRegion: FC<ScrollRegionProps> = ({ style, children }) =>
   // and that is the element the attribute lands on. React delivers it through
   // `focusin`, so it fires for focus landing anywhere inside the region.
   ScrollPanel ? (
-    <ScrollPanel style={{ ...BOUNDS, ...style }} onFocus={revealTop}>
+    <ScrollPanel style={{ ...BOUNDS, ...style }} onFocus={revealEdge}>
       {children}
     </ScrollPanel>
   ) : (
-    <Focusable style={{ ...BOUNDS, overflow: "auto", ...style }} onFocus={revealTop}>
+    <Focusable style={{ ...BOUNDS, overflow: "auto", ...style }} onFocus={revealEdge}>
       {children}
     </Focusable>
   );

--- a/src/components/qam/WidePage.test.tsx
+++ b/src/components/qam/WidePage.test.tsx
@@ -1,6 +1,7 @@
 /**
  * WidePage tests — the frame's own contract: the Back row, the title, a body
- * with a definite measured height, a tab bar that survives Steam's `Tabs` probe
+ * with a definite measured height, whose regions and entry focus it owns and
+ * whose it leaves to the page, a tab bar that survives Steam's `Tabs` probe
  * coming back undefined, and the two ends of the width the frame is for.
  *
  * `Tabs` is read at module scope, so each test loads a fresh copy of the
@@ -11,7 +12,7 @@
  */
 
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { render, screen, fireEvent, cleanup, act } from "@testing-library/react";
 import type { FC, ReactNode } from "react";
 import { WIDE_ROOT_CLASS } from "../../utils/qamExpansion";
 import { OWNS_ENTRY_FOCUS_ATTR, type WidePageProps, type WidePageTab } from "./WidePage";
@@ -372,28 +373,87 @@ describe("WidePage", () => {
     expect(container.firstElementChild).toHaveAttribute(OWNS_ENTRY_FOCUS_ATTR);
   });
 
-  it("claims no entry focus without tabs, where nothing here places any", async () => {
+  it("claims entry focus without tabs too, and puts it in the body", async () => {
     const WidePage = await loadWidePage(StubTabs);
+    vi.useFakeTimers();
+    try {
+      const { container } = render(
+        <WidePage title="Settings" onBack={vi.fn()}>
+          <button>a page row</button>
+        </WidePage>,
+      );
+      act(() => {
+        vi.advanceTimersByTime(50);
+      });
 
-    const { container } = render(
-      <WidePage title="Settings" onBack={vi.fn()}>
+      // The frame's first button is the Back chip, which is above the body: the
+      // router's own focus would land there, which is why the page claims it.
+      const row = screen.getByRole("button", { name: "a page row" });
+      expect(body()).toContainElement(row);
+      expect(row).toHaveFocus();
+      expect(row).toHaveClass("gpfocus");
+      expect(screen.getByRole("button", { name: "‹ Back" })).not.toHaveFocus();
+      expect(container.firstElementChild).toHaveAttribute(OWNS_ENTRY_FOCUS_ATTR);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("places entry focus in the active tab's content when the Tabs probe missed", async () => {
+    const WidePage = await loadWidePage(undefined);
+    const tabs: WidePageTab[] = [{ id: "platforms", title: "Platforms", content: <button>a tab row</button> }];
+    vi.useFakeTimers();
+    try {
+      const { container } = render(
+        <WidePage title="Library" onBack={vi.fn()} tabs={tabs} activeTab="platforms" onShowTab={vi.fn()} />,
+      );
+      act(() => {
+        vi.advanceTimersByTime(50);
+      });
+
+      // The fallback renders the tab's content raw, with no `autoFocusContents`
+      // to consume it — so the frame's own timer is what places focus, and the
+      // claim on the root stays true.
+      const row = screen.getByRole("button", { name: "a tab row" });
+      expect(row).toHaveFocus();
+      expect(row).toHaveClass("gpfocus");
+      expect(container.firstElementChild).toHaveAttribute(OWNS_ENTRY_FOCUS_ATTR);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("leaves entry focus to Steam's tabbed page, placing none itself", async () => {
+    const WidePage = await loadWidePage(StubTabs);
+    vi.useFakeTimers();
+    try {
+      render(<WidePage title="Library" onBack={vi.fn()} tabs={TAB_SET} activeTab="platforms" onShowTab={vi.fn()} />);
+      act(() => {
+        vi.advanceTimersByTime(50);
+      });
+
+      // `autoFocusContents` has already done it. A second placement from here
+      // would race Steam's for the same page and could land elsewhere in it.
+      expect(screen.getByTestId("steam-tabs")).toHaveAttribute("data-auto-focus-contents", "true");
+      expect(document.querySelector(".gpfocus")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("wraps no region around a body whose page builds its own", async () => {
+    const WidePage = await loadWidePage(StubTabs, StubScrollPanel);
+
+    render(
+      <WidePage title="Sync" onBack={vi.fn()} ownRegions>
         <div>page body</div>
       </WidePage>,
     );
 
-    expect(container.firstElementChild).not.toHaveAttribute(OWNS_ENTRY_FOCUS_ATTR);
-  });
-
-  it("claims no entry focus when the Tabs probe missed, so the router still covers the page", async () => {
-    const WidePage = await loadWidePage(undefined);
-
-    const { container } = render(
-      <WidePage title="Library" onBack={vi.fn()} tabs={TAB_SET} activeTab="platforms" onShowTab={vi.fn()} />,
-    );
-
-    // The fallback renders the tab's content raw, with nothing to autofocus. A
-    // marker here would opt the page out of the only focus it would get.
-    expect(container.firstElementChild).not.toHaveAttribute(OWNS_ENTRY_FOCUS_ATTR);
+    // A page laying regions out side by side would get one wrapped around both
+    // of them, which is a scroller over the two that must not scroll together.
+    expect(screen.queryByTestId("scroll-panel")).not.toBeInTheDocument();
+    expect(body().firstElementChild).toBe(screen.getByText("page body"));
   });
 
   it("takes no children beside tabs, whose body is the active tab's content", async () => {

--- a/src/components/qam/WidePage.tsx
+++ b/src/components/qam/WidePage.tsx
@@ -13,15 +13,16 @@
  * as the discoverable half and as the mouse path.
  *
  * The page's own content is `children`, or — when the page has tabs — the
- * `content` of each tab, which Steam's `Tabs` renders itself. A tabbed page
- * also opens with focus in that content rather than on the Back row.
+ * `content` of each tab, which Steam's `Tabs` renders itself. Either way the
+ * frame opens the page with focus inside that body rather than on the Back row.
  *
  * Structure and vocabulary: `docs/architecture/qam-panel.md`.
  */
 
-import { useLayoutEffect, useRef, useState, type FC, type ReactNode } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, type FC, type ReactNode } from "react";
 import { DialogButton, Focusable } from "@decky/ui";
 import { ControllerGlyph, GLYPH_BUTTON_B, Tabs } from "../../utils/deckyUiInternals";
+import { ENTRY_FOCUS_DELAY_MS, firstBodyStop, placeEntryFocus } from "../../utils/entryFocus";
 import { WIDE_ROOT_CLASS, useWideQamPanel } from "../../utils/qamExpansion";
 import { offsetWithinScroller } from "../../utils/scrollHelpers";
 import { ScrollRegion } from "./ScrollRegion";
@@ -36,10 +37,32 @@ export interface WidePageTab {
  * A page has all three tab props or none of them, and `children` belongs to the
  * second case alone: a tabbed page's body is the active tab's `content`, so
  * children passed beside `tabs` would render nowhere.
+ *
+ * `ownRegions` belongs to that second case too, for the same reason the frame
+ * gives a tabbed body no region: it answers whose job the scrolling is, and a
+ * tabbed page has already handed that to Steam's tabbed page.
  */
 type TabProps =
-  | { tabs: WidePageTab[]; activeTab: string; onShowTab: (tabId: string) => void; children?: undefined }
-  | { tabs?: undefined; activeTab?: undefined; onShowTab?: undefined; children?: ReactNode };
+  | {
+      tabs: WidePageTab[];
+      activeTab: string;
+      onShowTab: (tabId: string) => void;
+      children?: undefined;
+      ownRegions?: undefined;
+    }
+  | {
+      tabs?: undefined;
+      activeTab?: undefined;
+      onShowTab?: undefined;
+      children?: ReactNode;
+      /**
+       * The page builds its own scrolling regions, so the frame wraps the body
+       * in none. For a page whose content is side-by-side regions — a list and
+       * a detail, a table beside a controls column — where a region from the
+       * frame would nest a scroller around both of them.
+       */
+      ownRegions?: boolean;
+    };
 
 export type WidePageProps = {
   title: string;
@@ -48,10 +71,10 @@ export type WidePageProps = {
 
 /**
  * Marks a page that places its own entry focus, which the panel's router reads
- * to keep its first-button focus away. A tabbed page sets it, because the
- * `autoFocusContents` it hands Steam's tabbed page is what puts focus in the
- * content; a page that cannot place focus itself never sets it, so the router
- * still covers it.
+ * to keep its first-button focus away. Every wide page sets it, because the
+ * frame places that focus: `autoFocusContents` where Steam's tabbed page is
+ * there to consume it, and this frame's own timer everywhere else. Either way
+ * focus lands inside the body, never on the Back row above it.
  */
 export const OWNS_ENTRY_FOCUS_ATTR = "data-romm-owns-entry-focus";
 
@@ -167,7 +190,7 @@ function remainingBodyHeight(body: HTMLElement, view: Window): number {
   return Math.max(MIN_BODY_HEIGHT, remaining - BODY_BOTTOM_GAP);
 }
 
-export const WidePage: FC<WidePageProps> = ({ title, onBack, tabs, activeTab, onShowTab, children }) => {
+export const WidePage: FC<WidePageProps> = ({ title, onBack, tabs, activeTab, onShowTab, children, ownRegions }) => {
   const rootRef = useRef<HTMLDivElement>(null);
   const bodyRef = useRef<HTMLDivElement>(null);
   const [bodyHeight, setBodyHeight] = useState<number | null>(null);
@@ -205,23 +228,36 @@ export const WidePage: FC<WidePageProps> = ({ title, onBack, tabs, activeTab, on
     return () => observer.disconnect();
   }, []);
 
+  // `autoFocusContents` lands entry focus in the active tab's content, so where
+  // Steam's tabbed page renders there is nothing for the frame to do. It is also
+  // what makes Steam draw the L1/R1 glyphs: its tab row shows them only while
+  // gamepad focus is within the tabbed page, and the Back row above the tabs is
+  // outside it (`chunk~2dcc5aaf7.js`, the tab row's `showGlyphs`).
+  const steamPlacesFocus = Boolean(tabs && Tabs);
+
+  useEffect(() => {
+    const body = bodyRef.current;
+    if (steamPlacesFocus || !body) return;
+    // The same delay the panel's router uses for the pages it still covers:
+    // Steam's navigation resolves its retained focus pointer after the mount,
+    // and a focus placed before that is taken back.
+    const timer = setTimeout(() => placeEntryFocus(body, firstBodyStop), ENTRY_FOCUS_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [steamPlacesFocus]);
+
   // A `min-height` is not enough here — Steam's tabbed page fills its parent and
   // clips instead of growing, so the body needs a definite height.
   const bodyStyle = { height: bodyHeight === null ? undefined : `${bodyHeight}px`, overflow: "hidden" };
 
-  // Only the untabbed body gets a region from the frame. Steam's tabbed page
-  // already wraps each tab's content in this same plain scroll panel
-  // (`ScrollingTab<id>`, `scrollDirection: "y"`, in `chunk~2dcc5aaf7.js`), so
-  // one from the frame would nest a second scroller inside it. A tab that needs
-  // more than that one — a list and a detail scrolling side by side — builds its
-  // regions with `ScrollRegion` itself.
-  let body: ReactNode = <ScrollRegion>{children}</ScrollRegion>;
+  // The frame's region is for a body of rows in one column, and nothing else
+  // gets one. Steam's tabbed page already wraps each tab's content in this same
+  // plain scroll panel (`ScrollingTab<id>`, `scrollDirection: "y"`, in
+  // `chunk~2dcc5aaf7.js`), so a region from the frame would nest a second
+  // scroller inside it; and a page whose content is side-by-side regions —
+  // `ownRegions` — would get one wrapped around both of them. Either way any
+  // region the body needs is the page's to build with `ScrollRegion`.
+  let body: ReactNode = ownRegions ? children : <ScrollRegion>{children}</ScrollRegion>;
   if (tabs) {
-    // `autoFocusContents` lands entry focus in the active tab's content — the
-    // list of a list-and-detail page — which is also what makes Steam draw the
-    // L1/R1 glyphs: its tab row shows them only while gamepad focus is within
-    // the tabbed page, and the Back row above the tabs is outside it
-    // (`chunk~2dcc5aaf7.js`, the tab row's `showGlyphs`).
     body = Tabs ? (
       // `cancelSkipTabHeader` leaves the content pane's cancel handler unset, so
       // B reaches the router's binding instead of being spent moving focus to
@@ -232,12 +268,8 @@ export const WidePage: FC<WidePageProps> = ({ title, onBack, tabs, activeTab, on
     );
   }
 
-  // Claimed only where the claim is true: without Steam's tabbed page nothing
-  // here places focus, so the router's own must still run.
-  const ownsEntryFocus = Boolean(tabs && Tabs);
-
   return (
-    <div className={WIDE_ROOT_CLASS} ref={rootRef} {...(ownsEntryFocus ? { [OWNS_ENTRY_FOCUS_ATTR]: "" } : {})}>
+    <div className={WIDE_ROOT_CLASS} ref={rootRef} {...{ [OWNS_ENTRY_FOCUS_ATTR]: "" }}>
       {/* One line, not three: the full-width Back row and the title on its own
           line cost two of the four rows the Deck's body has to spend. */}
       <Focusable style={{ display: "flex", alignItems: "center", gap: "10px", padding: "4px 16px 6px" }}>

--- a/src/components/qam/pane.tsx
+++ b/src/components/qam/pane.tsx
@@ -1,0 +1,161 @@
+/**
+ * The pieces a wide page's detail pane is built from: the type scale it sets
+ * secondary lines in, the colours it says things with, the two button shapes,
+ * and the small components every pane repeats — a section title, a muted line,
+ * a row of buttons, and the two lines that report an action.
+ *
+ * They are here rather than on a page because the next pane is written against
+ * the same scale: a second literal for the same size is how two panes drift
+ * apart, and a reader moving between them reads the drift as meaning.
+ *
+ * Structure and vocabulary: `docs/architecture/qam-panel.md`.
+ */
+
+import type { FC, ReactElement, ReactNode } from "react";
+import { Focusable } from "@decky/ui";
+
+/** The size every secondary LINE on a pane is set in: a header's counts clause,
+ *  the under-row description and note lines, a table cell beside them, the muted
+ *  sentences, the table header and the legend. One constant, because the device
+ *  pass asked for the cell to match those lines and a second literal is how they
+ *  drift apart again. Button labels are not lines and keep their own sizes. */
+export const SECONDARY_FONT = "11px";
+
+export const MUTED = "#8f98a0";
+export const RED = "#d94126";
+export const GREEN = "#5ba32b";
+export const AMBER = "#d4a72c";
+/** The BIOS table's verdict mark for a file that is present and that the core
+ *  the platform launches with does not require — green's quieter twin, so
+ *  "there and needed" and "there and spare" are one glance apart rather than one
+ *  reading apart. */
+export const PALE_GREEN = "#8fc46b";
+/** The BIOS table's library mark, deliberately outside the verdict palette's
+ *  traffic light: what it reports — that the RomM library does not hold the
+ *  file — is not a degree of wrongness. */
+export const VIOLET = "#a48fd4";
+
+/**
+ * The padding a `DialogButton` is given wherever a pane puts buttons in a row.
+ *
+ * `ButtonItem` — the full-width control most of the panel uses — takes no style
+ * or class of its own: its props are `ItemProps`, which has neither
+ * (`@decky/ui/dist/components/Item.d.ts`), so its height is Steam's and cannot
+ * be argued with from here. `DialogButton` does take `style`
+ * (`DialogButtonProps extends DialogCommonProps`, `Dialog.d.ts`), and is Steam's
+ * own button component rather than a lookalike of one.
+ *
+ * They are the same button, and the difference is the row around it. In
+ * `chunk~2dcc5aaf7.js` module 12316, the `forwardRef` decky's prop-list regex
+ * matches (`highlightOnFocus` then `childrenContainerWidth`) renders a `Field`
+ * whose first child is a second `forwardRef`, and that one renders `o.$n`;
+ * module 64608 re-exports `$n` from module 44351, where it is the `forwardRef`
+ * whose className is `"DialogButton","_DialogLayout","Secondary"` — the exact
+ * string `@decky/ui` searches for to bind its own `DialogButton`
+ * (`components/Dialog.js`, `DialogButton = DialogButtonSecondary`). So
+ * `ButtonItem` IS a `Field` wrapped around this component, and what a `Field`
+ * costs is the row's own padding: 10px top and bottom inside the QAM, where it
+ * renders in its `Classic` mode.
+ */
+export const FLAT_BUTTON = { flex: "1 1 auto", minWidth: 0, padding: "6px 10px", fontSize: "13px" } as const;
+
+/** The button in a table row's action column. Narrow because the column is
+ *  sized for it and the name beside it is the thing worth width: 4px of
+ *  horizontal padding on the BIOS table's 92px action column still leaves a
+ *  target wider than it is tall, which is what keeps it pressable at the Deck's
+ *  scale. */
+export const ROW_BUTTON = { width: "100%", minWidth: 0, padding: "4px", fontSize: "11px" } as const;
+
+export const SectionTitle: FC<{ title: string; note?: string; noteColor?: string }> = ({ title, note, noteColor }) => (
+  <div style={{ display: "flex", alignItems: "baseline", gap: "8px", padding: "12px 16px 4px" }}>
+    <span style={{ fontSize: "12px", fontWeight: 600, letterSpacing: "0.5px", color: "#dcdedf" }}>
+      {title.toUpperCase()}
+    </span>
+    {note && <span style={{ fontSize: SECONDARY_FONT, color: noteColor ?? MUTED }}>{note}</span>}
+  </div>
+);
+
+export const Muted: FC<{ children: ReactNode }> = ({ children }) => (
+  <div style={{ fontSize: SECONDARY_FONT, color: MUTED, padding: "0 16px 6px" }}>{children}</div>
+);
+
+/**
+ * A row of side-by-side buttons, crossed horizontally by the stick.
+ *
+ * The padding is the caller's because it is the row's place on the pane rather
+ * than the row's own shape — how much air it needs above and below depends on
+ * what it sits between.
+ */
+export const ButtonRow: FC<{ padding: string; children: ReactNode }> = ({ padding, children }) => (
+  <Focusable flow-children="horizontal" style={{ display: "flex", gap: "8px", padding }}>
+    {children}
+  </Focusable>
+);
+
+/**
+ * A line reporting what an action did, bound to the entry it was produced for
+ * and the group of the pane it belongs under.
+ *
+ * `key` is the pane's own identity — a platform slug, a section id — and `scope`
+ * the group. Both halves matter: a failed core switch must not be reported under
+ * Remove, and an action's result must not follow the reader onto the next
+ * entry's pane.
+ *
+ * A page names its own set of groups as `Scope`, so the literals it writes at
+ * each call site are checked against that set. Defaulting to `string` keeps a
+ * page that has only one group from having to declare one.
+ */
+export interface ScopedStatus<Scope extends string = string> {
+  key: string;
+  scope: Scope;
+  text: string;
+}
+
+/**
+ * A generic function rather than an `FC`, because `FC` takes no type parameter.
+ *
+ * `Scope` is inferred from `status` alone and `scope` is only checked against
+ * it, which is what `NoInfer` buys: with both as inference sites a literal
+ * naming no group of the page's set is simply a second candidate, `Scope` widens
+ * to the union of the two, and the typo passes. Catching it is the whole point
+ * of the parameter, because a scope matching nothing renders no line and says
+ * nothing about why.
+ */
+export function GroupStatus<Scope extends string>({
+  status,
+  forKey,
+  scope,
+}: {
+  status: ScopedStatus<Scope> | null;
+  forKey: string;
+  scope: NoInfer<Scope>;
+}): ReactElement | null {
+  return status?.key === forKey && status.scope === scope ? (
+    <div data-testid={`status-${scope}`} style={{ fontSize: "12px", color: "#dcdedf", padding: "0 16px 8px" }}>
+      {status.text}
+    </div>
+  ) : null;
+}
+
+/**
+ * Why this pane's buttons are dead while nothing on it is running.
+ *
+ * A page that holds one status line, one progress and one busy key runs one
+ * action at a time across every entry: a second would clobber the first's line
+ * and the first `finally` would clear the busy state under the second. The line
+ * that would explain the wait — {@link GroupStatus} — is bound to the entry the
+ * action belongs to, so walking away from a running action leaves a pane full of
+ * disabled buttons and nothing said. This is what it says.
+ *
+ * `busyName` is what the page calls the entry that is working, and is required:
+ * a page that cannot name it has to choose the words the reader sees rather than
+ * inherit them from here.
+ */
+export const BusyElsewhere: FC<{ busyKey: string | null; ownKey: string; busyName: string }> = ({
+  busyKey,
+  ownKey,
+  busyName,
+}) => {
+  if (busyKey === null || busyKey === ownKey) return null;
+  return <Muted>{`Working on ${busyName} — actions here are paused until it finishes.`}</Muted>;
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -60,6 +60,7 @@ import { setSaveSortMigrationStatus } from "./utils/saveSortMigrationStore";
 import { setVersionError, setServerRetryProgress } from "./utils/connectionState";
 import { initSessionManager, destroySessionManager } from "./utils/sessionManager";
 import { findOutermostScrollParent } from "./utils/scrollHelpers";
+import { ENTRY_FOCUS_DELAY_MS, firstPageButton, placeEntryFocus } from "./utils/entryFocus";
 import { collapseQamOnDismount } from "./utils/qamExpansion";
 import { detach } from "./utils/detach";
 import type {
@@ -114,25 +115,20 @@ const QAMPanel: FC = () => {
     });
     // Steam's gamepad nav retains a focus pointer across page swaps and
     // resolves it on the next input — landing on a button at the old page's
-    // position. Force focus to the first button so navigation starts at the
-    // top. Same querySelector + .focus() + gpfocus pattern as CustomPlayButton.
+    // position. Force focus to the page's first stop so navigation starts at
+    // the top.
     //
-    // A page carrying the opt-out marker places entry focus itself, and this
-    // focus would undo it: the first button of a wide page is the Back row,
-    // which sits above the tabs and therefore outside Steam's tabbed page —
-    // and Steam draws the L1/R1 glyphs only while gamepad focus is within it
-    // (`chunk~2dcc5aaf7.js`, the tab row's `showGlyphs`). Landing here would
-    // leave a tabbed page with no visible way to switch tabs.
+    // A page carrying the marker places entry focus itself, and this focus
+    // would undo it: the first button of a wide page is the Back row, which
+    // sits above the body — and above the tabs of a tabbed one, therefore
+    // outside Steam's tabbed page, whose tab row draws the L1/R1 glyphs only
+    // while gamepad focus is within it (`chunk~2dcc5aaf7.js`, the tab row's
+    // `showGlyphs`). Landing here would leave such a page with no visible way
+    // to switch tabs.
     const ownsFocus = el.querySelector(`[${OWNS_ENTRY_FOCUS_ATTR}]`) !== null;
     const focusTimer = ownsFocus
       ? undefined
-      : setTimeout(() => {
-          const btn = el.querySelector("button");
-          if (btn) {
-            btn.focus();
-            btn.classList.add("gpfocus");
-          }
-        }, 50);
+      : setTimeout(() => placeEntryFocus(el, firstPageButton), ENTRY_FOCUS_DELAY_MS);
     return () => {
       cancelAnimationFrame(rafHandle);
       clearTimeout(focusTimer);

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -176,9 +176,14 @@ vi.mock("@decky/ui", () => {
     // Focusable forwards onButtonDown as a real DOM "decky-button-down"
     // listener so tests can drive gamepad input via
     // fireEvent(el, new CustomEvent("decky-button-down", { detail: { button } })).
-    // onCancelButton rides the same event, filtered to CANCEL (B), because that
-    // is how Steam delivers it — one gamepad stream, dispatched to the handler
-    // the button maps to — so a test drives it the same way.
+    // onCancelButton and onActivate ride the same event, filtered to CANCEL (B)
+    // and OK (A), because that is how Steam delivers them — one gamepad stream,
+    // dispatched to the handler the button maps to — so a test drives them the
+    // same way.
+    // onActivate is also surfaced as data-activate, because it is what makes a
+    // Focusable a focus stop rather than a container: a test asserting that a
+    // row with no control of its own is reachable has nothing else to look at,
+    // and happy-dom has no nav tree to ask.
     // onFocus is forwarded because a Focusable is how the list-and-detail layout
     // learns that focus moved to a row — dropping it would make focus-selects
     // vacuously untestable. Other FooterLegend-only props (flow-children,
@@ -189,6 +194,7 @@ vi.mock("@decky/ui", () => {
       style,
       onButtonDown,
       onCancelButton,
+      onActivate,
       onFocus,
       role,
       tabIndex,
@@ -197,12 +203,14 @@ vi.mock("@decky/ui", () => {
       style?: unknown;
       onButtonDown?: (evt: unknown) => void;
       onCancelButton?: (evt: unknown) => void;
+      onActivate?: (evt: unknown) => void;
       onFocus?: (evt: unknown) => void;
     }) =>
       createElement(
         "div",
         {
           "data-testid": "focusable",
+          "data-activate": onActivate ? "true" : undefined,
           style,
           role,
           tabIndex,
@@ -212,11 +220,12 @@ vi.mock("@decky/ui", () => {
             if (!el) return;
             const prev = (el as unknown as { _deckyButtonDown?: EventListener })._deckyButtonDown;
             if (prev) el.removeEventListener("decky-button-down", prev);
-            if (!onButtonDown && !onCancelButton) return;
+            if (!onButtonDown && !onCancelButton && !onActivate) return;
             const listener = ((e: Event) => {
               onButtonDown?.(e);
               const button = (e as CustomEvent<{ button?: number } | null>).detail?.button;
               if (button === 2) onCancelButton?.(e);
+              if (button === 1) onActivate?.(e);
             }) as EventListener;
             (el as unknown as { _deckyButtonDown?: EventListener })._deckyButtonDown = listener;
             el.addEventListener("decky-button-down", listener);

--- a/src/utils/entryFocus.test.ts
+++ b/src/utils/entryFocus.test.ts
@@ -1,0 +1,126 @@
+/**
+ * entryFocus tests — which stop each of the two rules picks, and what placing
+ * focus on it leaves behind.
+ *
+ * happy-dom has no gamepad and no nav tree, so what is pinned is the CHOICE of
+ * element and the two marks Steam's own navigation leaves on it; that the reader
+ * then sees the focus ring is the device round's to settle.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { firstBodyStop, firstPageButton, placeEntryFocus } from "./entryFocus";
+
+function page(html: string): HTMLElement {
+  const root = document.createElement("div");
+  root.innerHTML = html;
+  document.body.append(root);
+  return root;
+}
+
+// Each root is appended to the document so `.focus()` has somewhere real to put
+// focus; without this the next test starts on the last one's leftovers.
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe("firstBodyStop", () => {
+  it("takes the innermost stop in document order, not the first button", () => {
+    // The shape of a list-and-detail body whose list rows carry no control: the
+    // first button in the body is in the DETAIL pane, so a button-first rule
+    // would open the page inside the detail.
+    const root = page(`
+      <div tabindex="0" id="list">
+        <div tabindex="0" id="row">General</div>
+      </div>
+      <div tabindex="0" id="detail"><button id="action">Do the thing</button></div>
+    `);
+
+    expect(firstBodyStop(root)?.id).toBe("row");
+  });
+
+  it("skips a disabled control and takes the next stop", () => {
+    // A page opening with focus on a dead control says nothing about where the
+    // reader is.
+    const root = page(`<button id="dead" disabled>Download</button><button id="live">Delete</button>`);
+
+    expect(firstBodyStop(root)?.id).toBe("live");
+  });
+
+  it("skips a container whose stops are all disabled, and takes the next row", () => {
+    // The shape a pane really produces: a button row whose every button is
+    // disabled. It carries `tabindex="0"` but is a container Steam's navigation
+    // does not stop on, so taking the DOM focus and the ring there would put the
+    // reader nowhere and take both off the next real row. A candidate must be
+    // enabled; a container is skipped for holding a stop of any kind.
+    const root = page(`
+      <div tabindex="0" id="buttons">
+        <button disabled>Download required</button>
+        <button disabled>Download all</button>
+      </div>
+      <div tabindex="0" id="row">Nintendo 64</div>
+    `);
+
+    expect(firstBodyStop(root)?.id).toBe("row");
+  });
+
+  it("takes a button over a container that wraps it", () => {
+    const root = page(`<div tabindex="0" id="wrapper"><button id="btn">go</button></div>`);
+
+    expect(firstBodyStop(root)?.id).toBe("btn");
+  });
+
+  it("answers nothing for a body with no stop at all", () => {
+    const root = page(`<div>just words</div>`);
+
+    expect(firstBodyStop(root)).toBeNull();
+  });
+
+  it("answers nothing where every stop is disabled", () => {
+    // The page then keeps whatever focus Steam's retained pointer resolves to,
+    // which is the state this whole helper exists to replace — worth pinning as
+    // a known edge rather than discovering it on a device.
+    const root = page(`<button id="dead" disabled>Download</button>`);
+
+    expect(firstBodyStop(root)).toBeNull();
+  });
+});
+
+describe("firstPageButton", () => {
+  it("takes the first enabled button, ignoring the focus tree around it", () => {
+    // A narrow page is one column of Steam's own full-width rows, so its first
+    // button is its first row and nothing is bought by walking inwards.
+    const root = page(`<div tabindex="0" id="wrapper"></div><button id="first">first</button><button>second</button>`);
+
+    expect(firstPageButton(root)?.id).toBe("first");
+  });
+
+  it("skips a disabled button", () => {
+    const root = page(`<button id="dead" disabled>dead</button><button id="live">live</button>`);
+
+    expect(firstPageButton(root)?.id).toBe("live");
+  });
+
+  it("answers nothing for a page with no button", () => {
+    const root = page(`<div tabindex="0">a row nobody wrote a button for</div>`);
+
+    expect(firstPageButton(root)).toBeNull();
+  });
+});
+
+describe("placeEntryFocus", () => {
+  it("focuses the stop its finder picks and marks it the way Steam does", () => {
+    const root = page(`<button id="btn">go</button>`);
+
+    expect(placeEntryFocus(root, firstPageButton)).toBe(true);
+    // `.focus()` alone moves DOM focus and leaves the element undrawn: the class
+    // is what Steam's own navigation adds, and what the focus ring keys on.
+    expect(root.querySelector("#btn")).toHaveFocus();
+    expect(root.querySelector("#btn")).toHaveClass("gpfocus");
+  });
+
+  it("reports that it placed nothing when the finder answers nothing", () => {
+    const root = page(`<div>just words</div>`);
+
+    expect(placeEntryFocus(root, firstBodyStop)).toBe(false);
+  });
+});

--- a/src/utils/entryFocus.ts
+++ b/src/utils/entryFocus.ts
@@ -1,0 +1,97 @@
+/**
+ * What can hold gamepad focus, where a page's focus lands when it opens, and how
+ * it is put there.
+ *
+ * Steam's gamepad navigation keeps a focus pointer across a page swap and
+ * resolves it on the next input — onto whatever sits at the old page's
+ * position — so a newly mounted page has to claim focus itself. Two callers do,
+ * on the same delay and by different rules: the wide-page frame for its own body
+ * (`src/components/qam/WidePage.tsx`), and the panel's router for the narrow
+ * pages that place none of their own (`src/index.tsx`).
+ */
+
+/**
+ * Every shape Steam gives a focus stop, measured in the running QAM rather than
+ * assumed: its own components render `div[tabindex="0"]` (`Focusable`, a toggle
+ * row, a table row carrying an activate handler) and a `DialogButton` is a
+ * native `button` with no tabindex attribute at all.
+ *
+ * The two selectors below are joined from this one list rather than written out
+ * twice, so a shape added here reaches both.
+ */
+const FOCUS_STOP_SHAPES = ["[tabindex]", "button", "a[href]", "input", "select", "textarea"];
+
+/**
+ * Anything focus can land on, disabled controls included.
+ *
+ * A wide page keeps its buttons rendered and disabled rather than hidden, and
+ * the injected sheet gives them Steam's focus outline, so the stick lands on
+ * them and the row stays walkable — which is why `ScrollRegion` reads this one,
+ * and the entry-focus finder below takes its candidates from the narrower one
+ * while testing containment against this.
+ */
+export const FOCUS_STOPS = FOCUS_STOP_SHAPES.join(", ");
+
+// The same shapes, less anything disabled: what entry focus may land ON.
+const ENTRY_STOPS = FOCUS_STOP_SHAPES.map((shape) => `${shape}:not([disabled])`).join(", ");
+
+/**
+ * The stop a wide page's body opens on: the first enabled thing in document
+ * order that can take focus and contains no focus stop of its own.
+ *
+ * Document order, never "the first button", because a page's first button is not
+ * its first row. On a list-and-detail page whose list rows carry no control of
+ * their own, the first button in the body is in the DETAIL pane, so a
+ * button-first rule opens the page somewhere inside the detail and moves as the
+ * detail's content changes.
+ *
+ * Innermost, because a container `Focusable` carries `tabindex="0"` of its own
+ * and precedes in document order every row it wraps: taking the first match
+ * lands focus on the container and leaves the reader a step away from the row.
+ *
+ * **The two halves read different selectors on purpose.** A candidate must be
+ * enabled, but a container is skipped for holding a stop of ANY kind: a button
+ * row whose every button is disabled is still a container Steam's navigation
+ * does not stop on, so focusing it would put the reader nowhere and take the
+ * ring off the next real row. The test cannot tell that row from one carrying an
+ * activate handler, so it skips both; a row whose only inner stop is disabled is
+ * stepped over, which no body's first column produces today. Where that leaves
+ * no candidate — no enabled stop that is free of stops inside it — nothing is
+ * placed and the page keeps whatever Steam's retained pointer resolves to.
+ */
+export function firstBodyStop(root: ParentNode): HTMLElement | null {
+  const stops = [...root.querySelectorAll<HTMLElement>(ENTRY_STOPS)];
+  return stops.find((stop) => stop.querySelector(FOCUS_STOPS) === null) ?? null;
+}
+
+/**
+ * The stop a narrow page opens on: its first enabled button.
+ *
+ * A narrow page is one column of Steam's own full-width rows, where the first
+ * button IS the first row, so nothing is bought by walking the focus tree.
+ */
+export function firstPageButton(root: ParentNode): HTMLElement | null {
+  return root.querySelector<HTMLElement>("button:not([disabled])");
+}
+
+/**
+ * Long enough to land after Steam has finished mounting the page and resolving
+ * its own focus pointer. The same 50 ms the scroll helpers use.
+ */
+export const ENTRY_FOCUS_DELAY_MS = 50;
+
+/**
+ * Put entry focus on the stop `findStop` picks out of `root`, and answer whether
+ * there was one.
+ *
+ * `gpfocus` is the class Steam's own navigation adds to the focused element —
+ * `.focus()` alone moves the DOM focus and leaves the element undrawn, so both
+ * halves are needed for the reader to see where they are.
+ */
+export function placeEntryFocus(root: ParentNode, findStop: (root: ParentNode) => HTMLElement | null): boolean {
+  const stop = findStop(root);
+  if (!stop) return false;
+  stop.focus();
+  stop.classList.add("gpfocus");
+  return true;
+}


### PR DESCRIPTION
The wide-page frame carried one page, Library, and its contract fitted that page
alone: an untabbed body was always wrapped in the frame's own scroll region, a
page without tabs opened with focus on the Back chip, content under a region's
last focus stop could not be reached, and the pane's building blocks lived
inside `PlatformDetail`. The next page, Sync, has no tabs and no list, and the
two after it are list-and-detail with rows that carry no control. This makes
the frame fit them before any of them is built. Platforms renders the same DOM
as before.

A page may own its regions. `WidePage` takes `ownRegions`; the frame then
renders the body bare and the page builds its `ScrollRegion`s itself, as a
tabbed page already does. `Columns` is the two-column shell lifted out of
`ListDetail` — one region per column, a fixed or flexible width, a key per
column so a caller can remount one — and `ListDetail` is now two columns of it.

Entry focus belongs to the frame. Every wide page claims it: Steam's tabbed page
places it when the probe finds it, and in every other case the frame focuses,
after the same delay the router uses, the first enabled focus stop in document
order that contains no focus stop of its own — so a list-and-detail page opens
on its first row, not on the first button the detail happens to hold, and a
button row whose buttons are all disabled is stepped over. The router keeps a
button-first rule for the narrow pages through the same helper, now skipping a
disabled one.

`ScrollRegion` reveals both ends. It scrolled to its top when focus reached the
first stop; it now scrolls to its end when focus reaches the last one and the
remainder fits, so a result line under a button row comes into view. A stop
that is both first and last reveals the top where it fits, else the end where
that fits.

The pane primitives move to `qam/pane.tsx`: the secondary font size, the
palette, the two button styles, `SectionTitle`, `Muted`, `ButtonRow`, and
`GroupStatus` / `BusyElsewhere` generalised to a keyed, scoped status so a page
other than Platforms can render them. `ListDetail` gains `selectOnActivate` so
a row with no control of its own is still a focus stop, and the test stub now
carries `onActivate`, which is what made the BIOS-row reachability test able to
fail.

ESLint, basedpyright and ruff ignore `.claude`, where this repo's worktrees
live; from a checkout that holds one, `pnpm lint` ran out of heap and
`basedpyright` reported the sibling tree's files.

Docs: `qam-panel.md` states the regions rule, the entry focus, both reveal ends,
`Columns` and the pane primitives, and names the module stores that exist;
`CONTEXT.md` binds the width claim to the structure being built; the register's
reachability entry says the frame carries both ends.
