### PR TITLE
refactor(qam): derive a sync run once, for both pages that show it

### DIFF
--- a/docs/architecture/qam-panel.md
+++ b/docs/architecture/qam-panel.md
@@ -16,21 +16,23 @@ without restating it. The width mechanism's decision record is
 
 ## Where the code lives
 
-| Module                                                        | Responsibility                                                                                                                             |
-| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `src/index.tsx` (`QAMPanel`)                                  | The router: one `Page` value, one mounted page, a module-level `currentPage` that survives a QAM remount                                   |
-| `src/types/navigation.ts`                                     | The `Page` union — every page the router can land on                                                                                       |
-| `src/components/MainPage.tsx`                                 | Main                                                                                                                                       |
-| `src/components/LibraryPage.tsx`                              | Library — the frame, the two tabs and their state                                                                                          |
-| `src/components/SettingsPage.tsx`, `src/components/settings/` | Settings and its sections                                                                                                                  |
-| `src/components/DangerZone.tsx`, `RemovedGamesCleanup.tsx`    | Data Management                                                                                                                            |
-| `src/components/DownloadQueue.tsx`                            | Downloads                                                                                                                                  |
-| `src/components/library/`                                     | The Library page's tabs: `usePlatformsPage` (its reads and actions), `PlatformsTab`, `PlatformDetail`                                      |
-| `src/utils/deckyUiInternals.ts`                               | Honest typing for `@decky/ui` values that come from a webpack probe: the frame's class names, `Tabs`, `ScrollPanel`, the controller glyph  |
-| `src/utils/qamExpansion.ts`                                   | The panel's width: the expand and hide messages, the injected `max-width` rule, and the four paths that clear both                         |
-| `src/components/qam/`                                         | The wide-page frame: `WidePage` (the Back/title line, tabs, measured height, entry focus), `ScrollRegion`, `Columns`, `ListDetail`, `pane` |
-| `src/utils/entryFocus.ts`                                     | Which stop a page opens on, and the `.focus()` + `gpfocus` pair that places it — the frame's and the router's one implementation           |
-| `src/utils/` module stores                                    | State that must outlive a page: sync progress, pending preview, downloads, prune, the game-detail caches                                   |
+| Module                                                        | Responsibility                                                                                                                                                      |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/index.tsx` (`QAMPanel`)                                  | The router: one `Page` value, one mounted page, a module-level `currentPage` that survives a QAM remount                                                            |
+| `src/types/navigation.ts`                                     | The `Page` union — every page the router can land on                                                                                                                |
+| `src/components/MainPage.tsx`                                 | Main                                                                                                                                                                |
+| `src/components/LibraryPage.tsx`                              | Library — the frame, the two tabs and their state                                                                                                                   |
+| `src/components/SettingsPage.tsx`, `src/components/settings/` | Settings and its sections                                                                                                                                           |
+| `src/components/DangerZone.tsx`, `RemovedGamesCleanup.tsx`    | Data Management                                                                                                                                                     |
+| `src/components/DownloadQueue.tsx`                            | Downloads                                                                                                                                                           |
+| `src/components/library/`                                     | The Library page's tabs: `usePlatformsPage` (its reads and actions), `PlatformsTab`, `PlatformDetail`                                                               |
+| `src/utils/deckyUiInternals.ts`                               | Honest typing for `@decky/ui` values that come from a webpack probe: the frame's class names, `Tabs`, `ScrollPanel`, the controller glyph                           |
+| `src/utils/qamExpansion.ts`                                   | The panel's width: the expand and hide messages, the injected `max-width` rule, and the four paths that clear both                                                  |
+| `src/components/qam/`                                         | The wide-page frame: `WidePage` (the Back/title line, tabs, measured height, entry focus), `ScrollRegion`, `Columns`, `ListDetail`, `pane`                          |
+| `src/utils/entryFocus.ts`                                     | Which stop a page opens on, and the `.focus()` + `gpfocus` pair that places it — the frame's and the router's one implementation                                    |
+| `src/utils/syncRunView.ts`                                    | `useSyncRunView` — the run in flight as a page renders it: stage label, coarse bar, position within the running unit, fine-detail line, estimate, and the run's end |
+| `src/utils/runUnitsStore.ts`                                  | The run's work queue, one row per unit: the plan's riders, how far the run has got, and what each unit's apply produced                                             |
+| `src/utils/` module stores                                    | State that must outlive a page: sync progress, pending preview, downloads, prune, the game-detail caches                                                            |
 
 ## Two widths
 
@@ -342,6 +344,22 @@ the invariant register's pending-preview entry names the Sync page's three paths
 fourth path — a cancel that lands just after a preview was staged and is discharged server-side alone — is unchanged.
 With **Skip preview** on, the button starts the run directly and Main shows progress as today. The last run's one-line
 result stays on Main for a moment after a run, as today; the run itself is on the Sync page's list.
+
+While a run is in flight Main shows the stage caption and step counter, the bar, the fine-detail line, the estimate and
+Cancel. Those numbers come from `useSyncRunView`, and the Sync page will read the same hook, so one derivation of a run
+serves both pages rather than each keeping its own. What stays Main's is what belongs to Main. Two of those are the
+run's end, which the hook hands back as callbacks: the once-per-run announcement, with the two re-reads it provokes and
+the ask for a preview the run may have staged, and the correction that follows when the run's own terminal frame arrives
+with better wording. Only the page that owns those side effects passes any, or a second page reading the same run would
+announce the end a second time. The rest never leaves Main's own handlers — the "Cancelling…" drain, the transient
+status line, and the optimistic start those handlers retract.
+
+Alongside the hook, `runUnitsStore.ts` holds one run's work queue per unit: a row per unit, seeded from the plan and
+bound to the run id the plan carried, advanced to `running` and then `done` by that run's frames, and carrying what the
+unit's apply created and updated. The binding is what keeps a later run off an earlier run's rows — a preview emits a
+frame per unit over the same queue and no plan at all, so the step index alone would walk them a second time. The store
+outlives every page, so a page opened mid-run can show the units already worked through rather than only the current
+one. Main renders none of it.
 
 ## Sync
 

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -30,19 +30,8 @@ import {
 import { formatTimeAgo } from "../utils/formatters";
 import { pluralize } from "../utils/pluralize";
 import { formatDuration, formatTimeRemaining, previewApplySeconds } from "../utils/syncEstimate";
-import {
-  observeApplyProgress,
-  displayedEtaSeconds,
-  resetEta,
-  formatEtaCountdown,
-  latchedCoarseFraction,
-} from "../utils/syncEta";
-import {
-  getSyncProgress,
-  setSyncProgress as setStoredSyncProgress,
-  onSyncProgressChange,
-  withinUnitFraction,
-} from "../utils/syncProgress";
+import { getSyncProgress, setSyncProgress as setStoredSyncProgress } from "../utils/syncProgress";
+import { useSyncRunView } from "../utils/syncRunView";
 import { useDownloads } from "../utils/downloadStore";
 import {
   usePendingPreview,
@@ -74,7 +63,7 @@ import { MigrationBlockedPage } from "./MigrationBlockedPage";
 import { SettingsResetBanner } from "./SettingsResetBanner";
 import { PlaytimeScopeBanner } from "./PlaytimeScopeBanner";
 import { SessionBudgetBanner, formatGb, formatSignedGb, memoryLevelColor } from "./SessionBudgetBanner";
-import type { SyncProgress, SyncStage, SyncStats, SyncPreview, SyncPreviewSummary, Page } from "../types";
+import type { SyncProgress, SyncStats, SyncPreview, SyncPreviewSummary, Page } from "../types";
 import { detach } from "../utils/detach";
 import { wrapText } from "../utils/textStyles";
 
@@ -152,34 +141,6 @@ export const ConnectionIndicator: FC<{
     </>
   );
 };
-
-const TERMINAL_STAGES: ReadonlySet<SyncStage> = new Set<SyncStage>(["done", "cancelled", "error"]);
-
-function isTerminalStage(stage: SyncProgress["stage"]): boolean {
-  return !!stage && TERMINAL_STAGES.has(stage);
-}
-
-const STAGE_LABELS: Record<SyncStage, string> = {
-  discovering: "Discovering platforms",
-  fetching: "Fetching library",
-  applying: "Applying shortcuts",
-  finalizing: "Finalizing",
-  done: "Done",
-  cancelled: "Cancelled",
-  error: "Error",
-};
-
-function stageLabel(stage: SyncProgress["stage"]): string {
-  return stage ? STAGE_LABELS[stage] : "Syncing";
-}
-
-function formatProgressText(progress: SyncProgress | null): string {
-  // The bare fine-detail message. The coarse "step/totalSteps" is already shown
-  // on the bar row (sync-step), so it is not repeated here. The message wraps to
-  // up to two lines in the QAM via CSS rather than being clipped mid-word.
-  if (!progress) return "Syncing...";
-  return progress.message || "Syncing...";
-}
 
 // The fine-detail line is clamped to two lines (``WebkitLineClamp``) and its box
 // is reserved at exactly that height up front. Without the reservation a message
@@ -450,38 +411,6 @@ function terminalStatusTone(stage: SyncProgress["stage"]): StatusTone {
   return stage === "done" ? "success" : "neutral";
 }
 
-/** The id of the run a frame belongs to, `""` for a frame that names none — the
- *  panel's own optimistic start, or a backend with no run stamped yet. */
-function frameRunId(progress: SyncProgress): string {
-  return progress.runId ?? "";
-}
-
-/** The run a frame puts in flight, or `null` when the frame has none running. */
-function inFlightRunId(progress: SyncProgress): string | null {
-  return progress.running ? frameRunId(progress) : null;
-}
-
-/**
- * Whether a terminal frame ends the run the panel is watching — true unless it
- * names a DIFFERENT run, since an unnamed run on either side (the panel's own
- * optimistic start before the backend stamps an id, or a frame that carries
- * none) cannot be shown to be another one, and refusing it would strand the
- * panel on a run that has already ended. `null` — nothing watched at all — is
- * the one case that ends nothing: that is a terminal frame the panel FOUND
- * rather than witnessed, the stored frame every QAM close leaves behind (#1019).
- *
- * The leniency leaves one window open, knowingly: between a run's two terminal
- * signals — the merged `sync_complete` and the frame that follows it, under
- * 100 ms apart — a user who starts the next run in the gap has the old run's
- * second frame taken as ending the new one, costing that run its first status
- * line. Accepted rather than closed: the previous boolean had the same window,
- * nothing here can widen it, and the alternative — refusing an unnamed terminal
- * frame — strands the panel on the far more reachable case above.
- */
-function endsWatchedRun(watched: string | null, runId: string): boolean {
-  return watched !== null && (watched === "" || runId === "" || watched === runId);
-}
-
 export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   // Both facts are owned by `utils/syncStatsStore.ts`: seven refresh sites in
   // this file ask for them, and the store is what keeps an older answer from
@@ -502,28 +431,6 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   // sync_progress stage re-arms it, so a quick re-press can't hit the
   // sync_in_progress reject and look like an instant finish (#1202, RC-B).
   const [cancelling, setCancelling] = useState(false);
-  // The frame this panel last saw, seeded from the store so a remount mid-run
-  // renders the live run on its first pass rather than a frame later.
-  const [syncProgress, setSyncProgress] = useState<SyncProgress | null>(() => getSyncProgress());
-  // "A run is in flight" is DERIVED from that frame, never mirrored in a second
-  // boolean: DangerZone and RemovedGamesCleanup read the same store field, so a
-  // path that ends the run locally without ending it in the store would make the
-  // three disagree (#1019). The optimistic start is not lost — a Sync click writes
-  // running:true into the store, which the subscription below feeds straight back.
-  const syncing = syncProgress?.running ?? false;
-  // Last non-empty fine-detail line, carried across unit-boundary anchor frames
-  // so the fine-detail row (and its inline spinner) stay MOUNTED when the next
-  // unit's FETCHING anchor frame resets current/total to 0 (#1415) — otherwise
-  // the row unmounts for a frame and the panel flickers. Populated by the store
-  // subscriber from any frame with real fine detail; reset to null when the run
-  // ends, so a terminal/idle state never surfaces a stale line.
-  const [carriedFineDetail, setCarriedFineDetail] = useState<string | null>(null);
-  // A dumb mirror of syncEta's live countdown (seconds), or null when not measured
-  // yet / between runs. syncEta owns the sticky deadline; the impure now-read that
-  // resolves it to seconds lives in the store subscriber (an event handler), NOT
-  // the render — the render must stay pure. Progress frames drive the subscriber,
-  // so the countdown ticks per frame exactly as before.
-  const [liveEtaDisplay, setLiveEtaDisplay] = useState<number | null>(null);
   const [status, setStatus] = useState<TransientStatus | null>(null);
   // The preview lives in a module store, not here: the answer to `sync_preview`
   // is delivered to the instance that pressed Sync, and leaving the main page
@@ -548,28 +455,51 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
   const saveSortMigration = useSaveSortMigrationState();
   const downloads = useDownloads();
   const statusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // The run this panel is watching, by id, and whether its end has been handled.
-  // Seeded at first render — BEFORE the subscription below exists, so the mount
-  // seed's own write is measured against the state it replaced rather than against
-  // itself; a stored terminal frame the panel merely finds therefore watches
-  // nothing and announces nothing (#1019).
-  //
-  // The pair is a run key rather than a "have I seen a terminal" boolean because
-  // the backend signals a run's end TWICE, in a fixed order: `sync_complete`,
-  // which index.tsx merges into the store as `{running:false, stage}` — keeping
-  // the PREVIOUS frame's message, e.g. "Finalizing…" — and then the run's own
-  // terminal frame carrying the authoritative wording ("Sync complete: N games
-  // from M platforms", the cancelled/interrupted sentence, or a budget pause's
-  // resume guidance). Both belong to the same run: the first does the once-per-run
-  // teardown, the second is allowed to correct the text it left behind.
-  const watchedRunId = useRef<string | null>(inFlightRunId(getSyncProgress()));
-  const watchedRunEnded = useRef(false);
 
   const showTransientStatus = (text: string, tone: StatusTone = "neutral") => {
     if (statusTimeoutRef.current) clearTimeout(statusTimeoutRef.current);
     setStatus({ text, tone });
     statusTimeoutRef.current = setTimeout(() => setStatus(null), STATUS_CLEAR_MS);
   };
+
+  // The run in flight, read through the shared hook, so the Sync page will show
+  // the same derivation of it rather than a second copy. What stays here is what
+  // belongs to THIS page: the once-per-run work below, the "Cancelling…" drain,
+  // the transient status line and the optimistic start the handlers retract.
+  //
+  // "A run is in flight" is DERIVED from the run's own frame, never mirrored in
+  // a second boolean: DangerZone and RemovedGamesCleanup read the same store
+  // field, so a path that ends the run locally without ending it in the store
+  // would make the three disagree (#1019). The optimistic start is not lost — a
+  // Sync click writes running:true into the store, which the hook feeds straight
+  // back.
+  const run = useSyncRunView({
+    onRunEnd: (progress) => {
+      // True terminal reached — re-arm the button out of any "Cancelling…"
+      // drain state (#1202, RC-B).
+      setCancelling(false);
+      showTransientStatus(progress.message || "Sync finished", terminalStatusTone(progress.stage));
+      // A preview run that just ended may have staged a card this panel never
+      // received: `sync_preview` answers the instance that pressed Sync, and that
+      // instance is gone whenever the user left the page mid-run. Ask for it —
+      // unless the store already has it, which is the same run answering through
+      // the other door. A run that staged nothing (an apply, a cancel, Skip
+      // Preview) is answered `preview: null` and the store is left as it stands.
+      // Stamp the countdown's clock either way: this is where a preview can
+      // appear without this instance adopting it, and the impure now-read
+      // belongs in a handler.
+      setPreviewNowMs(Date.now());
+      if (getPendingPreviewSnapshot() === null) detach(refreshPendingPreview());
+      // Both re-reads are provoked by the run ending, so neither may join a read
+      // issued while it was still going — see the two AfterChange functions.
+      detach(refreshSyncStatsAfterChange());
+      // Refresh the live heap reading so the paused / high-heap banner reflects
+      // the run's end state (a pause leaves it high; a completed run may too).
+      detach(refreshSessionBudgetAfterChange());
+    },
+    onTerminalWording: (message, stage) => showTransientStatus(message, terminalStatusTone(stage)),
+  });
+  const syncing = run.running;
 
   useEffect(() => {
     refreshMigrationState()
@@ -690,149 +620,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
       })
       .catch((e) => logError(`Failed to query sync status: ${e}`));
 
-    /**
-     * The watched run has ended: everything that happens once per run.
-     *
-     * Which of the three actions below a frame calls for is decided at the call
-     * site and never re-derived in any of them. Those verdicts are taken from the
-     * run refs before the refs move on and OUTSIDE the subscriber's try, so a
-     * throw in here can never leave the panel believing a finished run is still
-     * live; recomputing them inside would put that decision back into the guarded
-     * region. This is also why the run's ending and the correction that follows
-     * it are two functions rather than one with a mode: they are different
-     * actions, not one action told which way to behave.
-     */
-    const endWatchedRun = (progress: SyncProgress) => {
-      // Tear down the run's live-ETA state (deadline included) so the next run
-      // measures fresh, and clear the display mirror.
-      resetEta();
-      setLiveEtaDisplay(null);
-      // True terminal reached — re-arm the button out of any "Cancelling…"
-      // drain state (#1202, RC-B).
-      setCancelling(false);
-      showTransientStatus(progress.message || "Sync finished", terminalStatusTone(progress.stage));
-      // A preview run that just ended may have staged a card this panel never
-      // received: `sync_preview` answers the instance that pressed Sync, and that
-      // instance is gone whenever the user left the page mid-run. Ask for it —
-      // unless the store already has it, which is the same run answering through
-      // the other door. A run that staged nothing (an apply, a cancel, Skip
-      // Preview) is answered `preview: null` and the store is left as it stands.
-      // Stamp the countdown's clock either way: this is where a preview can
-      // appear without this instance adopting it, and the impure now-read
-      // belongs in a handler.
-      setPreviewNowMs(Date.now());
-      if (getPendingPreviewSnapshot() === null) detach(refreshPendingPreview());
-      // Both re-reads are provoked by the run ending, so neither may join a read
-      // issued while it was still going — see the two AfterChange functions.
-      detach(refreshSyncStatsAfterChange());
-      // Refresh the live heap reading so the paused / high-heap banner reflects
-      // the run's end state (a pause leaves it high; a completed run may too).
-      detach(refreshSessionBudgetAfterChange());
-    };
-
-    /**
-     * The same run's SECOND terminal signal, which ends nothing — {@link
-     * endWatchedRun} has already run for this run. What this frame adds is the
-     * run's own account of how it ended, replacing the text the merged
-     * sync_complete frame carried over from mid-run. A frame with no message of
-     * its own changes nothing rather than blanking what is already shown, which
-     * is why the message is a required argument: the caller's guard is the only
-     * place that decision is taken, and the signature makes calling without one
-     * impossible rather than merely wrong.
-     */
-    const correctTerminalWording = (message: string, stage: SyncProgress["stage"]) => {
-      showTransientStatus(message, terminalStatusTone(stage));
-    };
-
-    /**
-     * The non-terminal half: keep the live-rate ETA moving. Called only from the
-     * subscriber, and only for a frame whose stage is not terminal.
-     *
-     * Feeds the estimator from applying frames that carry ITEM progress only —
-     * fetch frames carry page/cover counters, and an applying-stage cover-refresh
-     * frame (``coverRefresh``, #1456) carries a cover counter, not item progress,
-     * so both must be skipped. syncEta re-anchors its sticky deadline internally;
-     * the countdown is then mirrored into state here. Both now-reads are impure
-     * and so must stay on this side of the render boundary, which they do — this
-     * runs from an event handler, never from render.
-     */
-    const advanceLiveEta = (progress: SyncProgress) => {
-      if (
-        progress.stage === "applying" &&
-        progress.step !== undefined &&
-        progress.current !== undefined &&
-        !progress.coverRefresh
-      ) {
-        observeApplyProgress(progress.step, progress.current, Date.now());
-      }
-      setLiveEtaDisplay(displayedEtaSeconds(Date.now()));
-    };
-
-    // Subscribe to the module store — every backend sync_progress event and
-    // every frontend updateSyncProgress notifies, driving a re-render. What the
-    // end-of-run work keys on is the watched RUN reaching a terminal stage, not a
-    // terminal stage being present: the frame the panel finds in the store on
-    // mount ends nothing, and the two frames that end the same run are one ending
-    // (see the run refs above).
-    const unsubProgress = onSyncProgressChange(() => {
-      // The local mirror must update FIRST and unconditionally — it is what
-      // drives the re-render. Everything after it is derived work (terminal
-      // teardown, estimator feeding, ETA state) that must never be able to break
-      // the re-render chain (on-device freeze, cause not yet reproduced in tests).
-      const progress = getSyncProgress();
-      setSyncProgress(progress);
-      // Run bookkeeping, taken before the refs move on and outside the try below so
-      // a subscriber throw can never leave the panel believing a finished run is
-      // still live. A running frame is what starts a watch; the frames that end one
-      // split into the first (the run ended: tear down and announce) and any that
-      // follow it (the same run's authoritative wording: the text, nothing else).
-      const inFlight = inFlightRunId(progress);
-      if (inFlight !== null) {
-        watchedRunId.current = inFlight;
-        watchedRunEnded.current = false;
-      }
-      const terminal = isTerminalStage(progress.stage);
-      const runEndedNow =
-        terminal && !watchedRunEnded.current && endsWatchedRun(watchedRunId.current, frameRunId(progress));
-      const laterTerminalFrame = terminal && watchedRunEnded.current;
-      if (runEndedNow) watchedRunEnded.current = true;
-      // Carry the fine-detail line so the row survives a unit boundary's anchor
-      // frame (which resets current/total, #1415); drop it the moment the run
-      // ends so the next run starts clean. Kept outside the try below so the
-      // reset can never be skipped by a subscriber throw.
-      //
-      // The carry is refreshed by any running frame that has a message AND a
-      // position: a real fine-detail frame (``total`` > 0) OR a unit-boundary
-      // FETCHING anchor (``total`` 0 but ``totalSteps`` > 0). At the boundary the
-      // anchor's own message ("Fetching <next unit>") REPLACES the previous
-      // unit's carried text, so the fine line names the new unit immediately
-      // instead of lagging on the old one until the next real frame lands a
-      // network RTT later. The initial optimistic "Fetching library…" start (no
-      // total, no totalSteps) is excluded, so it keeps the stage-label spinner;
-      // an empty-message frame never clears the carry (replace, never remove).
-      if (!progress.running) {
-        setCarriedFineDetail(null);
-      } else if (progress.message && (progress.total || progress.totalSteps)) {
-        setCarriedFineDetail(progress.message);
-      }
-      // A terminal frame that is neither verdict — the stored one a mount merely
-      // finds, watching nothing (#1019) — matches no arm and does nothing, which
-      // is the whole of what it should do.
-      try {
-        if (runEndedNow) {
-          endWatchedRun(progress);
-        } else if (laterTerminalFrame && progress.message) {
-          correctTerminalWording(progress.message, progress.stage);
-        } else if (!terminal) {
-          advanceLiveEta(progress);
-        }
-      } catch (e) {
-        logError(`sync-progress subscriber failed: ${e}`);
-      }
-    });
-
     return () => {
-      unsubProgress();
       if (statusTimeoutRef.current) clearTimeout(statusTimeoutRef.current);
     };
   }, []);
@@ -1055,68 +843,6 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     }
   };
 
-  // Two-level progress. The main determinate bar tracks COARSE unit progress
-  // but INTERPOLATES within the running unit so a large unit (e.g. 2091 items at
-  // step 2/8) doesn't sit frozen: the bar fills from the step's floor toward the
-  // next notch as the unit is worked. Notch positions come from the plan's
-  // per-unit item weights when measured (#1382), else each unit is an equal
-  // 1/totalSteps slice. 0/0 totalSteps means the run hasn't reached a unit yet →
-  // indeterminate. ``nProgress`` is a percentage (0-100), not a fraction.
-  //
-  // While actively working a unit (``fetching``/``applying``) the current unit
-  // is not yet done, so the completed count is ``step - 1``; the terminal-ish
-  // stages (``finalizing``/``done``) carry ``step == totalSteps`` as a
-  // completed count, so they keep the full ``step`` and the bar reads 100%.
-  // The within-unit fill splits the running unit's width into three monotonic
-  // sub-slices — fetch → covers → apply (#1407, ``withinUnitFraction``) — each
-  // filling by its own phase's ``current/total`` within a strictly-higher band
-  // than the phase before. So the fetch and cover frames now DO advance the bar
-  // (within their own sub-slice), never backwards at a phase boundary even
-  // though each phase restarts ``current/total`` from zero. An old backend that
-  // sends no sub-stage falls back to resting at the unit floor during fetch.
-  const step = syncProgress?.step ?? 0;
-  const activeUnit = syncProgress?.stage === "fetching" || syncProgress?.stage === "applying";
-  const completedSteps = activeUnit ? Math.max(0, step - 1) : step;
-  const withinUnit = withinUnitFraction(syncProgress);
-  // Weight the bar by the plan's per-unit item weights (#1382) — the same
-  // skip-aware, delta-corrected weights the countdown uses — so a
-  // predicted-skip unit takes no width and a huge platform takes its real
-  // share — except a run's LEADING zero-weight units, which still refresh
-  // covers and so claim an equal index slice rather than pinning the bar to
-  // empty (#1506). The latched wrapper adds a run-scoped high-water floor so a
-  // mid-run upward weight correction (observeUnitTotal on a mispredicted
-  // trailing skip) can't retract shown width (#1509). Falls back to
-  // equal-per-unit index weighting when no plan is measured (QAM opened mid-run
-  // before any sync_plan, old backend) or the plan can't apportion (unit-count
-  // mismatch, all-zero weights).
-  const weightedFraction = syncProgress?.totalSteps
-    ? latchedCoarseFraction(completedSteps, withinUnit, syncProgress.totalSteps)
-    : null;
-  const coarseFraction = syncProgress?.totalSteps
-    ? Math.max(0, Math.min(100, (weightedFraction ?? (completedSteps + withinUnit) / syncProgress.totalSteps) * 100))
-    : undefined;
-  const currentHasFineDetail = !!(syncProgress?.total && syncProgress.message);
-  // Keep the fine-detail row mounted across unit boundaries: the next unit's
-  // FETCHING anchor frame resets current/total (#1415), so fall back to the last
-  // non-empty fine detail carried by the store subscriber. Cleared when the run
-  // ends, so terminal/idle states never surface a stale line. The bar's own
-  // within-unit fill still reads the live current/total (never the carry), so
-  // this affects only which rows mount, not the bar (#1407).
-  const hasFineDetail = currentHasFineDetail || carriedFineDetail !== null;
-  const fineDetailText = currentHasFineDetail ? formatProgressText(syncProgress) : (carriedFineDetail ?? "");
-
-  // Estimated-time readout for the in-flight run. Prefer the live measured
-  // countdown ("9 min left") once the estimator has a rate; before that, fall
-  // back to the static seed carried on the store as an upper bound ("up to
-  // X min"). Absent both, the row is omitted (honest silence).
-  const staticEtaSeconds = syncProgress?.etaSeconds;
-  let etaText: string | null = null;
-  if (liveEtaDisplay !== null) {
-    etaText = formatEtaCountdown(liveEtaDisplay);
-  } else if (staticEtaSeconds !== undefined) {
-    etaText = `up to ${formatDuration(staticEtaSeconds)}`;
-  }
-
   const activeDownloads = downloads.filter((d) => d.status === "queued" || d.status === "downloading");
   const completedDownloads = downloads.filter(
     (d) => d.status === "completed" || d.status === "failed" || d.status === "cancelled",
@@ -1315,7 +1041,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
       </>
     );
   } else if (syncing) {
-    const stepText = syncProgress?.totalSteps ? `${syncProgress.step ?? 0}/${syncProgress.totalSteps}` : "";
+    const stepText = run.totalSteps ? `${run.step}/${run.totalSteps}` : "";
     syncBody = (
       <>
         <PanelSectionRow>
@@ -1343,18 +1069,18 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
                     Show the spinner inline with the stage label so a running
                     sync always has motion. When the fine line is present it
                     already has its own spinner — don't show two. */}
-                {!hasFineDetail && <Spinner width={14} height={14} />}
-                <span data-testid="sync-stage">{stageLabel(syncProgress?.stage)}</span>
+                {!run.hasFineDetail && <Spinner width={14} height={14} />}
+                <span data-testid="sync-stage">{run.stageLabel}</span>
               </span>
               {stepText && <span data-testid="sync-step">{stepText}</span>}
             </div>
             <ProgressBar
-              indeterminate={coarseFraction === undefined}
-              {...(coarseFraction !== undefined ? { nProgress: coarseFraction } : {})}
+              indeterminate={run.coarseFraction === undefined}
+              {...(run.coarseFraction !== undefined ? { nProgress: run.coarseFraction } : {})}
             />
           </div>
         </PanelSectionRow>
-        {hasFineDetail && (
+        {run.hasFineDetail && (
           <PanelSectionRow>
             <Field
               bottomSeparator="none"
@@ -1380,18 +1106,18 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
                       minHeight: `${FINE_DETAIL_CLAMP_LINES * FINE_DETAIL_LINE_HEIGHT}em`,
                     }}
                   >
-                    {fineDetailText}
+                    {run.fineDetailText}
                   </span>
                 </div>
               }
             />
           </PanelSectionRow>
         )}
-        {etaText !== null && (
+        {run.etaText !== null && (
           <PanelSectionRow>
             <Field label="Estimated time" bottomSeparator="none">
               <span data-testid="estimate-time" style={{ fontSize: "12px" }}>
-                {etaText}
+                {run.etaText}
               </span>
             </Field>
           </PanelSectionRow>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -56,6 +56,7 @@ import {
 import { setMigrationStatus } from "./utils/migrationStore";
 import { fetchSettingsResetState } from "./utils/settingsResetStore";
 import { resetSyncDelta, recordSyncRemoved, getSyncDelta } from "./utils/syncDeltaStore";
+import { attachRunUnitsMirror, seedRunUnits } from "./utils/runUnitsStore";
 import { setSaveSortMigrationStatus } from "./utils/saveSortMigrationStore";
 import { setVersionError, setServerRetryProgress } from "./utils/connectionState";
 import { initSessionManager, destroySessionManager } from "./utils/sessionManager";
@@ -662,16 +663,25 @@ export default definePlugin(() => {
   >("sync_complete", onSyncComplete);
 
   const syncApplyUnitListener = initUnitSyncManager();
+  // Mirror the run's frames into its per-unit rows for as long as the plugin is
+  // loaded, so a run that spans a page change keeps filling them in.
+  const detachRunUnitsMirror = attachRunUnitsMirror();
 
   // Per-unit pipeline: planning + stale + collections events.
-  // ``sync_plan`` arrives once per run with the full work queue (info only
-  // for now — future PR adds a per-platform progress view).
+  // ``sync_plan`` arrives once per run with the full work queue: the per-run
+  // resets below and the run's per-unit rows both key off it.
   const syncPlanListener = addEventListener<[SyncPlanData]>("sync_plan", (data: SyncPlanData) => {
     syncContinuationController.abort();
     syncContinuationController = new AbortController();
     // sync_plan fires once per run, before any unit — reset the per-run delta
     // so the terminal toast counts only this run's created/removed shortcuts.
     resetSyncDelta();
+    // The run's work queue, held where a page opened mid-run can still read it:
+    // this event is the only place the frontend is told what the run will work
+    // through, and it arrives whether or not a QAM page is mounted. Its run id
+    // binds the rows, so a later run's frames — a preview's included — cannot
+    // walk them.
+    seedRunUnits(data.units, data.run_id);
     // Clear the per-run cancel flag once per run, before any unit. Doing it
     // here (not only in the per-unit handler) keeps the flag fresh even on a
     // skip-only run, where no unit handler ever fires (#1198). Run identity for
@@ -1038,6 +1048,7 @@ export default definePlugin(() => {
       removeEventListener("sync_stale", syncStaleListener);
       removeEventListener("sync_collections", syncCollectionsListener);
       removeEventListener("sync_progress", syncProgressListener);
+      detachRunUnitsMirror();
       removeEventListener("download_progress", downloadProgressListener);
       removeEventListener("download_complete", downloadCompleteListener);
       removeEventListener("download_failed", downloadFailedListener);

--- a/src/utils/runUnitsStore.test.ts
+++ b/src/utils/runUnitsStore.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import {
+  attachRunUnitsMirror,
+  getRunUnitsSnapshot,
+  onRunUnitsChange,
+  recordUnitCreated,
+  recordUnitUpdated,
+  resetRunUnitsStoreForTests,
+  seedRunUnits,
+  useRunUnits,
+} from "./runUnitsStore";
+import { setSyncProgress } from "./syncProgress";
+import type { SyncPlanUnit } from "../types";
+
+const RUN_ID = "run-1";
+
+function planUnit(name: string, over: Partial<SyncPlanUnit> = {}): SyncPlanUnit {
+  return {
+    type: "platform",
+    id: name,
+    name,
+    slug: name.toLowerCase(),
+    rom_count: 10,
+    ...over,
+  };
+}
+
+/** The plan the frames below belong to: three platforms, so a frame's
+ *  ``totalSteps`` of 3 matches the seeded row count. */
+function seedThree(): void {
+  seedRunUnits([planUnit("PSX"), planUnit("SNES"), planUnit("Game Boy")], RUN_ID);
+}
+
+/** A running frame for one unit, in the shape the backend and the apply loop
+ *  emit: the run's id, a 1-based ``step``, the plan's unit total, and a message
+ *  naming the unit. */
+function frame(step: number, name: string, over: Record<string, unknown> = {}): void {
+  setSyncProgress({
+    running: true,
+    stage: "applying",
+    step,
+    totalSteps: 3,
+    current: 0,
+    total: 0,
+    message: `${name}: 1/10`,
+    runId: RUN_ID,
+    ...over,
+  });
+}
+
+describe("runUnitsStore", () => {
+  let detachMirror: () => void;
+
+  beforeEach(() => {
+    resetRunUnitsStoreForTests();
+    setSyncProgress({ running: false, stage: "", current: 0, total: 0, message: "", runId: "" });
+    detachMirror = attachRunUnitsMirror();
+  });
+
+  afterEach(() => {
+    detachMirror();
+  });
+
+  describe("seeding from the plan", () => {
+    it("holds one waiting row per plan unit, in plan order, carrying the plan's riders", () => {
+      seedRunUnits(
+        [
+          planUnit("PSX", { rom_count: 2091, predicted_skip: true, bound_count: 12, new_shortcut_count: 3 }),
+          planUnit("Sci-Fi", { type: "collection", id: 7, rom_count: 40 }),
+        ],
+        RUN_ID,
+      );
+
+      expect(getRunUnitsSnapshot()).toEqual([
+        {
+          id: "PSX",
+          type: "platform",
+          name: "PSX",
+          romCount: 2091,
+          predictedSkip: true,
+          boundCount: 12,
+          newShortcutCount: 3,
+          state: "waiting",
+          created: 0,
+          updated: 0,
+        },
+        {
+          id: 7,
+          type: "collection",
+          name: "Sci-Fi",
+          romCount: 40,
+          predictedSkip: false,
+          boundCount: null,
+          newShortcutCount: null,
+          state: "waiting",
+          created: 0,
+          updated: 0,
+        },
+      ]);
+    });
+
+    it("a fresh plan replaces the previous run's rows, results included", () => {
+      seedThree();
+      frame(1, "PSX");
+      recordUnitCreated(0);
+
+      seedRunUnits([planUnit("Mega Drive")], "run-2");
+
+      expect(getRunUnitsSnapshot().map((u) => [u.name, u.state, u.created])).toEqual([["Mega Drive", "waiting", 0]]);
+    });
+  });
+
+  describe("the running unit advances with the frames", () => {
+    it("marks the frame's unit running and every unit before it done", () => {
+      seedThree();
+
+      frame(1, "PSX", { current: 4, total: 10 });
+      expect(getRunUnitsSnapshot().map((u) => u.state)).toEqual(["running", "waiting", "waiting"]);
+
+      frame(3, "Game Boy", { current: 1, total: 6 });
+      expect(getRunUnitsSnapshot().map((u) => u.state)).toEqual(["done", "done", "running"]);
+    });
+
+    it("a finalizing frame at the plan's last step leaves every unit done", () => {
+      seedThree();
+      frame(3, "Game Boy", { current: 6, total: 6 });
+
+      setSyncProgress({
+        running: true,
+        stage: "finalizing",
+        step: 3,
+        totalSteps: 3,
+        message: "Finalizing…",
+        runId: RUN_ID,
+      });
+
+      expect(getRunUnitsSnapshot().map((u) => u.state)).toEqual(["done", "done", "done"]);
+    });
+
+    it("ignores a frame whose unit count does not match the plan it holds", () => {
+      seedThree();
+      // This run's own frame, so the run-id guard passes and the count check is
+      // what refuses it.
+      frame(2, "SNES", { totalSteps: 8 });
+
+      expect(getRunUnitsSnapshot().map((u) => u.state)).toEqual(["waiting", "waiting", "waiting"]);
+    });
+
+    it("ignores a frame from another run", () => {
+      seedThree();
+      frame(2, "SNES", { runId: "run-other" });
+
+      expect(getRunUnitsSnapshot().map((u) => u.state)).toEqual(["waiting", "waiting", "waiting"]);
+    });
+
+    it("a preview started after the run does not walk the finished run's rows", () => {
+      // A completed run: every unit done.
+      seedThree();
+      frame(3, "Game Boy", { current: 6, total: 6 });
+      setSyncProgress({
+        running: true,
+        stage: "finalizing",
+        step: 3,
+        totalSteps: 3,
+        message: "Finalizing…",
+        runId: RUN_ID,
+      });
+      setSyncProgress({
+        running: false,
+        stage: "done",
+        message: "Sync complete: 26 games from 3 platforms",
+        runId: RUN_ID,
+      });
+      const afterTheRun = getRunUnitsSnapshot();
+
+      // Pressing Sync again runs a preview: no plan, but a running FETCHING frame
+      // per unit over the same work queue, under the preview's own run id.
+      setSyncProgress({
+        running: true,
+        stage: "fetching",
+        current: 0,
+        step: 1,
+        totalSteps: 3,
+        message: "Fetching PSX... (1/3)",
+        runId: "run-preview",
+      });
+
+      expect(getRunUnitsSnapshot()).toBe(afterTheRun);
+      expect(getRunUnitsSnapshot().map((u) => u.state)).toEqual(["done", "done", "done"]);
+    });
+
+    it("ignores a frame that names no unit yet", () => {
+      seedThree();
+      setSyncProgress({ running: true, stage: "fetching", message: "Fetching library...", runId: RUN_ID });
+
+      expect(getRunUnitsSnapshot().map((u) => u.state)).toEqual(["waiting", "waiting", "waiting"]);
+    });
+  });
+
+  describe("results recorded per unit", () => {
+    it("counts creates and updates against the unit that produced them", () => {
+      seedThree();
+      recordUnitCreated(0);
+      recordUnitCreated(0);
+      recordUnitUpdated(0);
+      recordUnitUpdated(2);
+
+      expect(getRunUnitsSnapshot().map((u) => [u.created, u.updated])).toEqual([
+        [2, 1],
+        [0, 0],
+        [0, 1],
+      ]);
+    });
+
+    it("drops a result for a unit the plan it holds does not have", () => {
+      seedThree();
+      recordUnitCreated(9);
+
+      expect(getRunUnitsSnapshot().map((u) => u.created)).toEqual([0, 0, 0]);
+    });
+  });
+
+  describe("the rows outlive the run", () => {
+    it("keeps what a cancelled run got through — the unit it stopped on still reads running", () => {
+      seedThree();
+      frame(2, "SNES", { current: 40, total: 200 });
+
+      setSyncProgress({
+        running: false,
+        stage: "cancelled",
+        step: 2,
+        totalSteps: 3,
+        message: "Sync cancelled: 40 of 200 games processed",
+        runId: RUN_ID,
+      });
+
+      expect(getRunUnitsSnapshot().map((u) => u.state)).toEqual(["done", "running", "waiting"]);
+    });
+  });
+
+  describe("subscribers", () => {
+    it("notifies on a seed, on a frame that moves a unit, and on a recorded result", () => {
+      let notified = 0;
+      const unsubscribe = onRunUnitsChange(() => {
+        notified++;
+      });
+      try {
+        seedThree();
+        frame(1, "PSX", { current: 1, total: 10 });
+        recordUnitCreated(0);
+        expect(notified).toBe(3);
+      } finally {
+        unsubscribe();
+      }
+    });
+
+    it("does not notify while the run works within one unit", () => {
+      seedThree();
+      frame(1, "PSX", { current: 1, total: 10 });
+      let notified = 0;
+      const unsubscribe = onRunUnitsChange(() => {
+        notified++;
+      });
+      try {
+        frame(1, "PSX", { current: 2, total: 10 });
+        frame(1, "PSX", { current: 3, total: 10 });
+        expect(notified).toBe(0);
+      } finally {
+        unsubscribe();
+      }
+    });
+
+    it("a component mounting mid-run reads the rows the run has already filled in", () => {
+      seedThree();
+      frame(2, "SNES", { current: 5, total: 200 });
+      recordUnitCreated(0);
+
+      const { result, unmount } = renderHook(() => useRunUnits());
+      try {
+        expect(result.current.map((u) => [u.name, u.state, u.created])).toEqual([
+          ["PSX", "done", 1],
+          ["SNES", "running", 0],
+          ["Game Boy", "waiting", 0],
+        ]);
+
+        act(() => {
+          frame(3, "Game Boy", { current: 1, total: 6 });
+        });
+        expect(result.current.map((u) => u.state)).toEqual(["done", "done", "running"]);
+      } finally {
+        unmount();
+      }
+    });
+  });
+});

--- a/src/utils/runUnitsStore.ts
+++ b/src/utils/runUnitsStore.ts
@@ -1,0 +1,228 @@
+/**
+ * Module-level owner of one sync run's per-unit state — one row per unit of the
+ * run's work queue, in plan order, holding how far the run has got with that
+ * unit and what its apply produced.
+ *
+ * **Why a module store.** A QAM page mounts and unmounts as the user navigates,
+ * while the run keeps going. A page opened mid-run therefore sees the plan only
+ * if something outside the page kept it, and sees a finished unit's created and
+ * updated counts only if something outside the page recorded them — the apply
+ * events they were derived from are long gone. This store is that something. The
+ * one case it cannot cover is a plugin reload mid-run: the plan arrives once per
+ * run, so a store that starts empty after a reload stays empty for the rest of
+ * the run and refuses every frame that follows.
+ *
+ * **Three writers.** {@link seedRunUnits} takes the plan (`sync_plan`, once per
+ * run, before any unit); {@link recordUnitCreated} / {@link recordUnitUpdated}
+ * take the apply loop's per-item outcome; and {@link attachRunUnitsMirror}
+ * subscribes to the sync-progress store. It mirrors that store rather than the
+ * backend's `sync_progress` event because three writers feed it — the backend
+ * listener in `index.tsx`, the apply loop's per-item updates, and Main's own
+ * writes (its re-seed from `get_sync_status` on mount, its optimistic start and
+ * that start's retraction) — and the store is the one place all three meet.
+ *
+ * **The rows belong to ONE run, by its id.** A row is seeded with the run id the
+ * plan carried, and a frame moves nothing unless it names that same run. Nothing
+ * weaker will do: `sync_preview` emits no plan but does emit a FETCHING frame per
+ * unit, over the same work queue, carrying a running flag, a 1-based `step`, the
+ * unit count and the unit's name (`services/library/sync_orchestrator.py`), so a
+ * preview started after a completed run would otherwise walk that run's rows
+ * forward a second time. Its own run id — minted per run and claimed through
+ * `try_begin_run`, like every run's — is what tells the two apart. `totalSteps` is still checked against the
+ * row count as a cheap sanity check, and a frame carrying none skips that check;
+ * a frame naming no unit (`step` 0, which is what the backend sends before the
+ * queue) moves nothing either way.
+ *
+ * **Only a running frame moves a row**, which is what leaves a stopped run
+ * readable: the `sync_complete` frame `index.tsx` merges into the store keeps
+ * the step the run stopped on, so without that guard it would mark the
+ * interrupted unit `done`. (The reporter's own CANCELLED frame that follows
+ * carries step 0 and would move nothing either way.) The rows instead
+ * stand as the last running frame left them. A clean run passes through the
+ * FINALIZING frame at the plan's last step first, so its rows all read `done`
+ * before the terminal frame lands.
+ *
+ * **There is no `skipped` state**, because no frame carries one. A wholesale
+ * incremental skip emits nothing at all between the unit's own fetch anchor and
+ * the next unit's (`services/library/sync_orchestrator.py` logs the skip and
+ * returns), so a skipped unit reads `done` the moment the run moves past it. The
+ * plan's own `predictedSkip` rides the row and is what a reader can say
+ * something about — it is a plan-time prediction, never the run's verdict
+ * (ADR-0023).
+ *
+ * **A row carries no live position.** Exactly one unit runs at a time, so the
+ * running unit's stage and within-unit fraction are the frame the whole panel is
+ * already reading: a reader takes them from `useSyncRunView` and pairs them with
+ * the row it finds in `running`. Mirroring them here would replace the snapshot
+ * on every frame, so every reader of the rows would re-render for all of it,
+ * including the ones that show none of it.
+ */
+
+import { useSyncExternalStore } from "react";
+import { getSyncProgress, onSyncProgressChange } from "./syncProgress";
+import type { SyncPlanUnit, SyncProgress } from "../types";
+
+/**
+ * How far the run has got with one unit: `waiting` until a frame names it,
+ * `running` while a frame names it, `done` once the run has moved past it.
+ *
+ * `running` after the run has stopped is not a stale value but the answer: it is
+ * the unit a cancelled, interrupted or errored run was working when it
+ * stopped. Whether
+ * the run is still going is the frame's to say, never a row's.
+ */
+export type RunUnitState = "waiting" | "running" | "done";
+
+/** One unit of the run's work queue: what the plan said about it, how far the
+ *  run has got with it, and what its apply produced. */
+export interface RunUnit {
+  readonly id: number | string;
+  readonly type: "platform" | "collection";
+  readonly name: string;
+  readonly romCount: number;
+  /** The plan's prediction that this unit will skip wholesale — an estimate, not
+   *  the fetch-time skip decision. `false` where the plan carried none. */
+  readonly predictedSkip: boolean;
+  /** This unit's ROMs that already carry a Steam shortcut, or `null` where the
+   *  plan carried no count (collections with no stamped member set, older
+   *  backends). `0` is knowledge; `null` is its absence. */
+  readonly boundCount: number | null;
+  /** Shortcuts this unit's apply was expected to create, or `null` where the
+   *  plan carried no count (collections, older backends). */
+  readonly newShortcutCount: number | null;
+  readonly state: RunUnitState;
+  /** Shortcuts this unit's apply brought under management — a fresh create or an
+   *  adopted orphan — counted as the apply loop resolves each item. */
+  readonly created: number;
+  /** Shortcuts this unit's apply rewrote in place. */
+  readonly updated: number;
+}
+
+/** The rows as they stand. Handed out as the `useSyncExternalStore` snapshot,
+ *  which React compares by identity, so it is only ever REPLACED — and replaced
+ *  only when a row actually changes, so a reader re-renders at a unit transition
+ *  and per recorded item rather than per frame. */
+let _units: readonly RunUnit[] = [];
+/** The run the rows belong to, or `null` before any plan is seeded. */
+let _runId: string | null = null;
+const _listeners = new Set<() => void>();
+
+function notify(): void {
+  _listeners.forEach((fn) => fn());
+}
+
+/** The rows for the run in flight, or the last run's rows once it has ended. */
+export function getRunUnitsSnapshot(): readonly RunUnit[] {
+  return _units;
+}
+
+export function onRunUnitsChange(fn: () => void): () => void {
+  _listeners.add(fn);
+  return () => {
+    _listeners.delete(fn);
+  };
+}
+
+/** Subscribe a component to the run's units. Renders what the run has filled in
+ *  so far immediately — the store outlives the page, so a page opened mid-run
+ *  shows the units behind the running one rather than starting from nothing. */
+export function useRunUnits(): readonly RunUnit[] {
+  return useSyncExternalStore(onRunUnitsChange, getRunUnitsSnapshot);
+}
+
+/** Take one run's work queue from its plan, discarding the previous run's rows.
+ *  `sync_plan` fires once per run, before any unit, which is what makes this the
+ *  per-run reset; *runId* is the plan's own, and every frame is measured against
+ *  it from here. */
+export function seedRunUnits(units: readonly SyncPlanUnit[], runId: string): void {
+  _runId = runId;
+  _units = units.map((unit) => ({
+    id: unit.id,
+    type: unit.type,
+    name: unit.name,
+    romCount: unit.rom_count,
+    predictedSkip: unit.predicted_skip ?? false,
+    boundCount: unit.bound_count ?? null,
+    newShortcutCount: unit.new_shortcut_count ?? null,
+    state: "waiting" as const,
+    created: 0,
+    updated: 0,
+  }));
+  notify();
+}
+
+/** Count one shortcut this unit's apply brought under management. Plain counts,
+ *  not a deduplicated set like the run-wide delta: the backend emits each rom_id
+ *  in exactly one unit's shortcuts per run, so a unit's items are counted once. */
+export function recordUnitCreated(unitIndex: number): void {
+  recordUnitOutcome(unitIndex, 1, 0);
+}
+
+/** Count one shortcut this unit's apply rewrote in place. */
+export function recordUnitUpdated(unitIndex: number): void {
+  recordUnitOutcome(unitIndex, 0, 1);
+}
+
+function recordUnitOutcome(unitIndex: number, created: number, updated: number): void {
+  const unit = _units[unitIndex];
+  if (unit === undefined) return;
+  _units = _units.map((row, i) =>
+    i === unitIndex ? { ...row, created: row.created + created, updated: row.updated + updated } : row,
+  );
+  notify();
+}
+
+/** Start mirroring the frame stream into the rows, and hand back the teardown.
+ *  Called once where the plugin's other long-lived listeners are installed, so
+ *  the store's lifetime is the plugin's and its writers stay explicit. */
+export function attachRunUnitsMirror(): () => void {
+  return onSyncProgressChange(() => observeRunFrame(getSyncProgress()));
+}
+
+/** Reset the module state between tests. Not for production use. */
+export function resetRunUnitsStoreForTests(): void {
+  _units = [];
+  _runId = null;
+  _listeners.clear();
+}
+
+/** Whether a frame is being emitted from inside a unit rather than around the
+ *  queue. It says nothing about whether the run is still going — `cancelled` and
+ *  `error` stop it mid-queue, and a frame may carry no stage at all; that
+ *  question is the frame's `running` flag, which {@link observeRunFrame} checks
+ *  first. */
+function isActiveUnitStage(stage: SyncProgress["stage"]): boolean {
+  return stage === "fetching" || stage === "applying";
+}
+
+function withState(unit: RunUnit, state: RunUnitState): RunUnit {
+  return unit.state === state ? unit : { ...unit, state };
+}
+
+/**
+ * Move the rows to where *progress* says the run is. A frame belonging to
+ * another run — or to no run this store was given a plan for — moves nothing at
+ * all: it is never evidence that a unit is finished, only that this store is not
+ * the one it is about.
+ */
+function observeRunFrame(progress: SyncProgress): void {
+  if (!progress.running || _runId === null || _units.length === 0) return;
+  if ((progress.runId ?? "") !== _runId) return;
+  const step = progress.step ?? 0;
+  if (step <= 0 || step > _units.length) return;
+  if (progress.totalSteps !== undefined && progress.totalSteps !== _units.length) return;
+  const active = isActiveUnitStage(progress.stage);
+  // The running unit is `step - 1` while one is being worked; a frame past the
+  // queue (FINALIZING at the plan's last step) counts the whole of `step` as
+  // complete, the same reading the coarse bar takes.
+  const runningIndex = active ? step - 1 : -1;
+  const completed = active ? step - 1 : step;
+  const next = _units.map((unit, i) => {
+    if (i < completed) return withState(unit, "done");
+    if (i === runningIndex) return withState(unit, "running");
+    return unit;
+  });
+  if (next.every((unit, i) => unit === _units[i])) return;
+  _units = next;
+  notify();
+}

--- a/src/utils/syncEta.ts
+++ b/src/utils/syncEta.ts
@@ -9,10 +9,10 @@
  * ``remainingSeconds`` / ``formatEtaCountdown``). A thin run-scoped state layer
  * (``beginEtaRun`` / ``observeApplyProgress`` / ``liveEtaSeconds`` /
  * ``displayedEtaSeconds`` / ``resetEta``) is the seam the ``sync_plan`` listener
- * (index.tsx) and MainPage drive: the plan sets the per-unit weights + total, and
- * MainPage feeds one sample per applying progress frame and renders the sticky
- * countdown via ``displayedEtaSeconds`` — the module owns the deadline, so the UI
- * holds no ETA state of its own.
+ * (index.tsx) and ``syncRunView.ts`` drive: the plan sets the per-unit weights +
+ * total, and the hook feeds one sample per applying progress frame and exposes
+ * the sticky countdown via ``displayedEtaSeconds`` — the module owns the
+ * deadline, so the UI holds no ETA state of its own.
  *
  * Approximation, by design — though a narrow one since the plan went skip-aware
  * (#1382): a unit's seeded weight is 0 when the backend predicts its wholesale
@@ -317,13 +317,13 @@ export function displayedEtaSeconds(nowMs: number): number | null {
 
 /**
  * Weighted coarse-bar fraction (0..1) over the run's per-unit plan weights —
- * the size-aware replacement for MainPage's equal-per-unit index weighting
- * (#1382). ``completedUnits`` units are done in full; the running unit (index
- * ``completedUnits``) contributes ``withinUnitFraction`` (clamped to 0..1) of
- * its own weight share. Uses the SAME weights the countdown uses (skip-aware
- * seeds, delta-corrected by {@link observeUnitTotal} as units dispatch), so a
- * predicted-skip unit occupies no bar width and a huge platform occupies its
- * real share instead of ``1/totalUnits``.
+ * the size-aware replacement for the equal-per-unit index weighting the hook
+ * falls back to (#1382). ``completedUnits`` units are done in full; the running
+ * unit (index ``completedUnits``) contributes ``withinUnitFraction`` (clamped
+ * to 0..1) of its own weight share. Uses the SAME weights the countdown uses
+ * (skip-aware seeds, delta-corrected by {@link observeUnitTotal} as units
+ * dispatch), so a predicted-skip unit occupies no bar width and a huge platform
+ * occupies its real share instead of ``1/totalUnits``.
  *
  * A zero-weight unit is not free: an empty delta still refreshes covers, so a
  * plan whose LEADING units all weigh zero would pin the bar to empty for as
@@ -341,7 +341,7 @@ export function displayedEtaSeconds(nowMs: number): number | null {
  *
  * A pure reader of the run snapshot. The monotonic bar latch that keeps an
  * upward weight correction from retracting shown width lives in
- * {@link latchedCoarseFraction}, the wrapper MainPage actually calls.
+ * {@link latchedCoarseFraction}, the wrapper ``syncRunView.ts`` actually calls.
  */
 export function weightedCoarseFraction(
   completedUnits: number,

--- a/src/utils/syncManager.test.ts
+++ b/src/utils/syncManager.test.ts
@@ -13,7 +13,8 @@ import { act } from "@testing-library/react";
 import * as backend from "../api/backend";
 import { emitDeckyEvent } from "../test-utils/decky-api-mock";
 import { resetSyncDelta, getSyncDelta } from "./syncDeltaStore";
-import { getSyncProgress, onSyncProgressChange } from "./syncProgress";
+import { getSyncProgress, onSyncProgressChange, setSyncProgress } from "./syncProgress";
+import * as syncProgress from "./syncProgress";
 import type { SyncApplyUnitData, SyncProgress } from "../types";
 
 const setLaunchOptionsConfirmed = vi.fn().mockResolvedValue(true);
@@ -478,6 +479,59 @@ describe("syncManager — records created shortcuts into the per-run delta store
 
     expect(addShortcut).toHaveBeenCalledTimes(1);
     expect(getSyncDelta()).toEqual({ added: 0, removed: 0 });
+  });
+});
+
+describe("syncManager — every frame it writes names the chunk's run", () => {
+  beforeEach(() => {
+    setLaunchOptionsConfirmed.mockClear();
+    setLaunchOptionsConfirmed.mockResolvedValue(true);
+    addShortcut.mockReset();
+    getExistingRomMShortcuts.mockReset();
+    getExistingRomMShortcuts.mockResolvedValue(new Map<number, number>([[42, 5042]]));
+    vi.mocked(backend.getArtworkBase64).mockResolvedValue({ base64: null });
+    vi.stubGlobal("SteamClient", {
+      Apps: {
+        AddShortcut: vi.fn(),
+        SetShortcutName: vi.fn(),
+        SetShortcutExe: vi.fn(),
+        SetShortcutStartDir: vi.fn(),
+        SetAppLaunchOptions: vi.fn(),
+        SetCustomArtworkForApp: vi.fn().mockResolvedValue(undefined),
+        RemoveShortcut: vi.fn(),
+      },
+    });
+  });
+
+  it("stamps the chunk's run id on the seed, the per-item and the cover-refresh frames", async () => {
+    // Asserted on the CALLS, not on the store the calls leave behind: these are
+    // merges, so the seed's stamp alone would carry the right run id into every
+    // later frame's state and a missing stamp would be invisible there. That is
+    // the whole defect — the id would then be inherited by event ordering, and
+    // the per-unit rows refuse a frame naming another run.
+    setSyncProgress({ running: false, stage: "done", message: "Sync complete", runId: "run-previous" });
+    const update = vi.spyOn(syncProgress, "updateSyncProgress");
+    try {
+      initUnitSyncManager();
+      await act(async () => {
+        emitDeckyEvent<[SyncApplyUnitData]>("sync_apply_unit", {
+          ...unit("", "run-now"),
+          cover_refreshes: [{ rom_id: 7, app_id: 5007 }],
+        });
+        await flush(200);
+      });
+
+      // The three writes: the chunk seed, one per item, and the cover counter.
+      expect(update.mock.calls.length).toBeGreaterThanOrEqual(3);
+      for (const [frame] of update.mock.calls) {
+        expect(frame).toMatchObject({ runId: "run-now" });
+      }
+      // Non-vacuous about the cover write specifically, which only a chunk
+      // carrying cover_refreshes reaches.
+      expect(update.mock.calls.some(([frame]) => frame.coverRefresh === true)).toBe(true);
+    } finally {
+      update.mockRestore();
+    }
   });
 });
 

--- a/src/utils/syncManager.ts
+++ b/src/utils/syncManager.ts
@@ -16,6 +16,7 @@ import {
 } from "./steamShortcuts";
 import { updateSyncProgress } from "./syncProgress";
 import { recordSyncCreated } from "./syncDeltaStore";
+import { recordUnitCreated, recordUnitUpdated } from "./runUnitsStore";
 import { observeUnitTotal } from "./syncEta";
 import { registerRomMAppId } from "../patches/gameDetailPatch";
 import { pacedForEach } from "./pacedOps";
@@ -286,6 +287,7 @@ async function processCoverRefreshes(data: SyncApplyUnitData): Promise<void> {
       message: `${data.unit_name}: covers ${done}/${total}`,
       step: data.unit_index + 1,
       totalSteps: data.total_units,
+      runId: data.run_id,
       coverRefresh: true,
     });
   };
@@ -344,10 +346,19 @@ async function processUnitShortcuts(
           message: `${data.unit_name}: ${unitCurrent}/${data.unit_total}`,
           step: data.unit_index + 1,
           totalSteps: data.total_units,
+          runId: data.run_id,
         });
         const { appId, created } = await resolveShortcutAppId(item, existing, data.run_id, liveAppIds);
         if (appId) {
           romIdToAppId[String(item.rom_id)] = appId;
+          // What this unit produced, against the unit itself. The run-wide delta
+          // (``recordSyncCreated``, inside the resolve above) counts creates
+          // across the whole run for the terminal toast and knows nothing about
+          // units; a page showing the run's work queue needs the split per unit,
+          // and the apply events it is derived from are gone by the time such a
+          // page opens.
+          if (created) recordUnitCreated(data.unit_index);
+          else recordUnitUpdated(data.unit_index);
           // Register the appId as RomM-owned the moment the mapping exists — the
           // earliest point the game-detail patch and launch interceptor can gate
           // on it. Registering only at sync_complete leaves a newly created
@@ -483,6 +494,12 @@ export function initUnitSyncManager(): ReturnType<typeof addEventListener> {
         message: `${data.unit_name}: ${data.chunk_offset}/${data.unit_total}`,
         step: data.unit_index + 1,
         totalSteps: data.total_units,
+        // Stamped from the chunk, never inherited. These are merges, so an
+        // unstamped frame would carry whatever run the store happened to hold —
+        // today always this run's, by event ordering rather than by
+        // construction. The per-unit rows refuse a frame that names another run,
+        // so what is ordering today would be a dropped frame tomorrow.
+        runId: data.run_id,
         // Clear any cover-refresh marker a prior unit left in the store so this
         // unit's shortcut phase feeds the ETA again (#1456).
         coverRefresh: false,

--- a/src/utils/syncProgress.ts
+++ b/src/utils/syncProgress.ts
@@ -8,9 +8,11 @@
  *   - MainPage on handleSync click (optimistic running:true)
  *
  * Read by:
- *   - MainPage.tsx, which subscribes via onSyncProgressChange and re-renders
- *     on every notify (no setInterval polling), and reads ``runId`` to scope a
- *     Cancel click to the active run (#1202).
+ *   - utils/syncRunView.ts, whose hook subscribes via onSyncProgressChange and
+ *     re-renders its page on every notify (no setInterval polling)
+ *   - utils/runUnitsStore.ts, whose mirror advances the run's per-unit rows
+ *   - MainPage.tsx, which reads ``runId`` to scope a Cancel click to the active
+ *     run (#1202).
  *
  * The ``runId`` field is fed straight from the backend ``sync_progress`` payload
  * (the persistent listener in index.tsx passes the whole event through), so it

--- a/src/utils/syncRunView.test.ts
+++ b/src/utils/syncRunView.test.ts
@@ -1,0 +1,456 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useSyncRunView } from "./syncRunView";
+import { setSyncProgress, updateSyncProgress, FETCH_SHARE, COVERS_SHARE, APPLY_SHARE } from "./syncProgress";
+import { beginEtaRun, resetEta } from "./syncEta";
+import { attachRunUnitsMirror, recordUnitCreated, resetRunUnitsStoreForTests, seedRunUnits } from "./runUnitsStore";
+import type { SyncPlanUnit, SyncProgress } from "../types";
+
+const IDLE: SyncProgress = { running: false, stage: "", current: 0, total: 0, message: "", runId: "" };
+
+function planUnit(name: string): SyncPlanUnit {
+  return { type: "platform", id: name, name, slug: name.toLowerCase(), rom_count: 10 };
+}
+
+describe("useSyncRunView", () => {
+  let detachMirror: () => void;
+
+  beforeEach(() => {
+    resetEta();
+    resetRunUnitsStoreForTests();
+    setSyncProgress(IDLE);
+    detachMirror = attachRunUnitsMirror();
+  });
+
+  afterEach(() => {
+    detachMirror();
+  });
+
+  describe("the coarse bar", () => {
+    it("apportions the run by the plan's per-unit weights, not by unit count", () => {
+      // Three units of unequal size. Unit 1 is done, unit 2 is half-applied.
+      beginEtaRun("run-1", [300, 100, 100], 500);
+      setSyncProgress({
+        running: true,
+        stage: "applying",
+        step: 2,
+        totalSteps: 3,
+        current: 50,
+        total: 100,
+        message: "SNES: 50/100",
+        runId: "run-1",
+      });
+
+      const { result, unmount } = renderHook(() => useSyncRunView());
+      try {
+        // Within the running unit the apply phase sits above the fetch and cover
+        // shares, half-filled: 0.15 + 0.25 + 0.6 * 0.5.
+        const within = FETCH_SHARE + COVERS_SHARE + APPLY_SHARE * 0.5;
+        expect(result.current.coarseFraction).toBeCloseTo(((300 + within * 100) / 500) * 100, 5);
+        // Equal-per-unit weighting would have read a much lower number, so the
+        // assertion above is about the weights and not about arithmetic that
+        // happens to agree.
+        expect(result.current.coarseFraction).not.toBeCloseTo(((1 + within) / 3) * 100, 5);
+      } finally {
+        unmount();
+      }
+    });
+
+    it("falls back to an equal share per unit when no plan is measured", () => {
+      setSyncProgress({
+        running: true,
+        stage: "applying",
+        step: 2,
+        totalSteps: 3,
+        current: 50,
+        total: 100,
+        message: "SNES: 50/100",
+        runId: "run-1",
+      });
+
+      const { result, unmount } = renderHook(() => useSyncRunView());
+      try {
+        const within = FETCH_SHARE + COVERS_SHARE + APPLY_SHARE * 0.5;
+        expect(result.current.coarseFraction).toBeCloseTo(((1 + within) / 3) * 100, 5);
+      } finally {
+        unmount();
+      }
+    });
+
+    it("is undefined before the run reaches a unit, which the bar reads as indeterminate", () => {
+      setSyncProgress({ running: true, stage: "fetching", message: "Fetching library...", runId: "" });
+
+      const { result, unmount } = renderHook(() => useSyncRunView());
+      try {
+        expect(result.current.coarseFraction).toBeUndefined();
+      } finally {
+        unmount();
+      }
+    });
+  });
+
+  describe("the fine-detail line", () => {
+    it("keeps the fine-detail row mounted across a unit boundary, and drops it when the run ends", () => {
+      const { result, unmount } = renderHook(() => useSyncRunView());
+      try {
+        act(() => {
+          setSyncProgress({
+            running: true,
+            stage: "applying",
+            step: 1,
+            totalSteps: 2,
+            current: 40,
+            total: 200,
+            message: "PSX: 40/200",
+            runId: "run-1",
+          });
+        });
+        expect(result.current.hasFineDetail).toBe(true);
+        expect(result.current.fineDetailText).toBe("PSX: 40/200");
+
+        // The next unit's anchor frame resets the within-unit counters, so the
+        // row would unmount for a frame without the carry.
+        act(() => {
+          setSyncProgress({
+            running: true,
+            stage: "fetching",
+            step: 2,
+            totalSteps: 2,
+            current: 0,
+            total: 0,
+            message: "Fetching SNES",
+            runId: "run-1",
+          });
+        });
+        expect(result.current.hasFineDetail).toBe(true);
+        expect(result.current.fineDetailText).toBe("Fetching SNES");
+
+        act(() => {
+          setSyncProgress({ running: false, stage: "done", message: "Sync complete: 200 games", runId: "run-1" });
+        });
+        expect(result.current.hasFineDetail).toBe(false);
+        expect(result.current.fineDetailText).toBe("");
+      } finally {
+        unmount();
+      }
+    });
+  });
+
+  describe("the estimate", () => {
+    it("reads nothing while the run carries no estimate at all", () => {
+      setSyncProgress({ running: true, stage: "applying", step: 1, totalSteps: 1, message: "X: 1/2", runId: "run-1" });
+
+      const { result, unmount } = renderHook(() => useSyncRunView());
+      try {
+        expect(result.current.etaText).toBeNull();
+      } finally {
+        unmount();
+      }
+    });
+
+    it("reads the static seed as an upper bound until a rate is measured", () => {
+      setSyncProgress({
+        running: true,
+        stage: "applying",
+        step: 1,
+        totalSteps: 1,
+        current: 1,
+        total: 100,
+        message: "X: 1/100",
+        runId: "run-1",
+        etaSeconds: 600,
+      });
+
+      const { result, unmount } = renderHook(() => useSyncRunView());
+      try {
+        expect(result.current.etaText).toBe("up to 10 min");
+      } finally {
+        unmount();
+      }
+    });
+
+    it("replaces the seed with the measured countdown once the rate is known", () => {
+      vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout", "setInterval", "clearInterval"] });
+      try {
+        vi.setSystemTime(0);
+        beginEtaRun("run-1", [54700], 54700);
+        setSyncProgress({
+          running: true,
+          stage: "applying",
+          step: 1,
+          totalSteps: 1,
+          current: 100,
+          total: 54700,
+          message: "X: 100/54700",
+          runId: "run-1",
+          etaSeconds: 600,
+        });
+
+        const { result, unmount } = renderHook(() => useSyncRunView());
+        try {
+          act(() => {
+            updateSyncProgress({ current: 100 });
+          });
+          // One sample so far — the estimator has no span to measure yet.
+          expect(result.current.etaText).toBe("up to 10 min");
+
+          // 600 items in 6 s = 100/s over the remaining 54000 → 540 s.
+          vi.setSystemTime(6000);
+          act(() => {
+            updateSyncProgress({ current: 700, message: "X: 700/54700" });
+          });
+          expect(result.current.etaText).toBe("9 min left");
+        } finally {
+          unmount();
+        }
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe("the run's end", () => {
+    it("tears the live countdown down, so the next run does not inherit it", () => {
+      vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout", "setInterval", "clearInterval"] });
+      try {
+        vi.setSystemTime(0);
+        beginEtaRun("run-1", [54700], 54700);
+        setSyncProgress({
+          running: true,
+          stage: "applying",
+          step: 1,
+          totalSteps: 1,
+          current: 100,
+          total: 54700,
+          message: "X: 100/54700",
+          runId: "run-1",
+          etaSeconds: 600,
+        });
+
+        const { result, unmount } = renderHook(() => useSyncRunView());
+        try {
+          act(() => {
+            updateSyncProgress({ current: 100 });
+          });
+          vi.setSystemTime(6000);
+          act(() => {
+            updateSyncProgress({ current: 700, message: "X: 700/54700" });
+          });
+          expect(result.current.etaText).toBe("9 min left");
+
+          // The run ends: the measured deadline goes with it, and a frame of the
+          // next run reads its own seed rather than the dead run's countdown.
+          act(() => {
+            setSyncProgress({ running: false, stage: "done", message: "Sync complete", runId: "run-1" });
+          });
+          vi.setSystemTime(7000);
+          act(() => {
+            setSyncProgress({
+              running: true,
+              stage: "applying",
+              step: 1,
+              totalSteps: 1,
+              current: 1,
+              total: 100,
+              message: "Y: 1/100",
+              runId: "run-2",
+              etaSeconds: 600,
+            });
+          });
+          expect(result.current.etaText).toBe("up to 10 min");
+        } finally {
+          unmount();
+        }
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    function startedRun(runId: string): void {
+      setSyncProgress({
+        running: true,
+        stage: "applying",
+        step: 1,
+        totalSteps: 1,
+        current: 1,
+        total: 10,
+        message: "PSX: 1/10",
+        runId,
+      });
+    }
+
+    it("calls onRunEnd once for the run it is watching, with the terminal frame", () => {
+      const onRunEnd = vi.fn();
+      startedRun("run-1");
+      const { unmount } = renderHook(() => useSyncRunView({ onRunEnd }));
+      try {
+        act(() => {
+          setSyncProgress({ running: false, stage: "done", message: "Sync complete: 10 games", runId: "run-1" });
+        });
+
+        expect(onRunEnd).toHaveBeenCalledTimes(1);
+        expect(onRunEnd.mock.calls[0]?.[0]).toMatchObject({ stage: "done", message: "Sync complete: 10 games" });
+      } finally {
+        unmount();
+      }
+    });
+
+    it("does not end the run twice — the second terminal frame only corrects the wording", () => {
+      const onRunEnd = vi.fn();
+      const onTerminalWording = vi.fn();
+      startedRun("run-1");
+      const { unmount } = renderHook(() => useSyncRunView({ onRunEnd, onTerminalWording }));
+      try {
+        // The merged sync_complete frame ends the run, keeping the mid-run message.
+        act(() => {
+          updateSyncProgress({ running: false, stage: "done" });
+        });
+        // The run's own terminal frame follows with the authoritative wording.
+        act(() => {
+          setSyncProgress({ running: false, stage: "done", message: "Sync complete: 10 games", runId: "run-1" });
+        });
+
+        expect(onRunEnd).toHaveBeenCalledTimes(1);
+        expect(onTerminalWording).toHaveBeenCalledTimes(1);
+        expect(onTerminalWording).toHaveBeenCalledWith("Sync complete: 10 games", "done");
+      } finally {
+        unmount();
+      }
+    });
+
+    it("does not end the watched run on another run's terminal frame", () => {
+      const onRunEnd = vi.fn();
+      startedRun("run-1");
+      const { unmount } = renderHook(() => useSyncRunView({ onRunEnd }));
+      try {
+        act(() => {
+          setSyncProgress({ running: false, stage: "cancelled", message: "Sync cancelled", runId: "run-2" });
+        });
+
+        expect(onRunEnd).not.toHaveBeenCalled();
+      } finally {
+        unmount();
+      }
+    });
+
+    it("announces nothing for the terminal frame a mount merely finds in the store", () => {
+      const onRunEnd = vi.fn();
+      setSyncProgress({ running: false, stage: "done", message: "Sync complete: 10 games", runId: "run-0" });
+      const { unmount } = renderHook(() => useSyncRunView({ onRunEnd }));
+      try {
+        act(() => {
+          updateSyncProgress({ message: "Sync complete: 10 games" });
+        });
+
+        expect(onRunEnd).not.toHaveBeenCalled();
+      } finally {
+        unmount();
+      }
+    });
+
+    it("a second consumer without callbacks reads the same run and announces nothing", () => {
+      const onRunEnd = vi.fn();
+      startedRun("run-1");
+      const owner = renderHook(() => useSyncRunView({ onRunEnd }));
+      const reader = renderHook(() => useSyncRunView());
+      try {
+        act(() => {
+          setSyncProgress({ running: false, stage: "done", message: "Sync complete: 10 games", runId: "run-1" });
+        });
+
+        // The run ended once, for the consumer that owns the side effects.
+        expect(onRunEnd).toHaveBeenCalledTimes(1);
+        // The reader saw the same run end.
+        expect(reader.result.current.running).toBe(false);
+        expect(reader.result.current.stage).toBe("done");
+        expect(owner.result.current.running).toBe(false);
+      } finally {
+        owner.unmount();
+        reader.unmount();
+      }
+    });
+  });
+
+  describe("what it does not read", () => {
+    it("re-renders for a frame, and not for a unit result recorded against the rows", () => {
+      // The rows are a store a page reads for itself. If this hook subscribed to
+      // them — as it did for a unit's display name — every page reading the run
+      // would re-render per applied item for rows it may not show at all.
+      seedRunUnits([planUnit("PSX")], "run-1");
+      setSyncProgress({
+        running: true,
+        stage: "applying",
+        step: 1,
+        totalSteps: 1,
+        current: 1,
+        total: 10,
+        message: "PSX: 1/10",
+        runId: "run-1",
+      });
+
+      let renders = 0;
+      const { unmount } = renderHook(() => {
+        renders++;
+        return useSyncRunView();
+      });
+      try {
+        const afterMount = renders;
+        act(() => {
+          updateSyncProgress({ current: 2, message: "PSX: 2/10" });
+        });
+        // Non-vacuous: a frame really does re-render the consumer, so the count
+        // below is measuring something.
+        expect(renders).toBeGreaterThan(afterMount);
+
+        const afterFrame = renders;
+        act(() => {
+          recordUnitCreated(0);
+        });
+        expect(renders).toBe(afterFrame);
+      } finally {
+        unmount();
+      }
+    });
+  });
+
+  describe("what the run is working on", () => {
+    it("exposes the running unit's within-unit position, which no row carries", () => {
+      setSyncProgress({
+        running: true,
+        stage: "applying",
+        step: 2,
+        totalSteps: 2,
+        current: 25,
+        total: 100,
+        message: "SNES: 25/100",
+        runId: "run-1",
+      });
+
+      const { result, unmount } = renderHook(() => useSyncRunView());
+      try {
+        // The apply phase sits above the fetch and cover shares, a quarter filled.
+        expect(result.current.withinUnitFraction).toBeCloseTo(FETCH_SHARE + COVERS_SHARE + APPLY_SHARE * 0.25, 5);
+        expect(result.current.stage).toBe("applying");
+        expect(result.current.stageLabel).toBe("Applying shortcuts");
+        expect(result.current.step).toBe(2);
+        expect(result.current.totalSteps).toBe(2);
+        expect(result.current.runId).toBe("run-1");
+      } finally {
+        unmount();
+      }
+    });
+
+    it("rests the position at the unit floor before the run reaches a unit", () => {
+      setSyncProgress({ running: true, stage: "fetching", message: "Fetching library...", runId: "" });
+
+      const { result, unmount } = renderHook(() => useSyncRunView());
+      try {
+        expect(result.current.withinUnitFraction).toBe(0);
+        expect(result.current.step).toBe(0);
+        expect(result.current.totalSteps).toBe(0);
+      } finally {
+        unmount();
+      }
+    });
+  });
+});

--- a/src/utils/syncRunView.ts
+++ b/src/utils/syncRunView.ts
@@ -1,0 +1,379 @@
+/**
+ * The numbers a QAM page shows for the sync run in flight, derived in one place
+ * so a second page will be able to render the same run without a second copy of
+ * the derivation.
+ *
+ * The facts themselves live in module stores that outlive every page — the frame
+ * stream in `syncProgress.ts`, the run-scoped rate and plan weights in
+ * `syncEta.ts`. The run's per-unit rows are a fourth store a page reads for
+ * itself, never through this hook (`runUnitsStore.ts`). What this hook owns is
+ * the reading: which stage label the run is at, how full the coarse bar is, how
+ * far into the running unit it has got, what the fine-detail line says across a
+ * unit boundary, what the estimate reads, and — once per run — that the run has
+ * ended.
+ *
+ * **The side effects of a run ending are the caller's, and only one caller's.**
+ * A run ends once, but every mounted consumer of this hook watches it end: each
+ * holds its own watch, so each would fire its own {@link
+ * SyncRunViewOptions.onRunEnd}. The page that owns the run's end — today Main,
+ * which announces it, re-reads the stats and the session budget, and asks for a
+ * preview the run may have staged — passes the callbacks. A second consumer
+ * passes none and reads the same numbers. What the hook does for every consumer
+ * is tear down the live-ETA state, which is idempotent and belongs to the
+ * reading rather than to the page.
+ *
+ * **Why a run's end is two callbacks and not one with a mode.** The backend
+ * signals a run's end TWICE, in a fixed order: `sync_complete`, which
+ * `index.tsx` merges into the store as `{running: false, stage}` — keeping the
+ * PREVIOUS frame's message, e.g. "Finalizing…" — and then the run's own terminal
+ * frame carrying the authoritative wording ("Sync complete: N games from M
+ * platforms", the cancelled/interrupted sentence, or a budget pause's resume
+ * guidance). Both belong to the same run: the first does the once-per-run
+ * teardown, the second is allowed to correct the text it left behind. They are
+ * different actions, so they are different callbacks.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { logError } from "../api/backend";
+import { formatDuration } from "./syncEstimate";
+import {
+  displayedEtaSeconds,
+  formatEtaCountdown,
+  latchedCoarseFraction,
+  observeApplyProgress,
+  resetEta,
+} from "./syncEta";
+import { getSyncProgress, onSyncProgressChange, withinUnitFraction } from "./syncProgress";
+import type { SyncProgress, SyncStage } from "../types";
+
+const TERMINAL_STAGES: ReadonlySet<SyncStage> = new Set<SyncStage>(["done", "cancelled", "error"]);
+
+/** Whether a stage stops the run — the three the backend pairs with
+ *  `running: false`, and the only frames that may end a watch. */
+function isTerminalStage(stage: SyncProgress["stage"]): boolean {
+  return !!stage && TERMINAL_STAGES.has(stage);
+}
+
+const STAGE_LABELS: Record<SyncStage, string> = {
+  discovering: "Discovering platforms",
+  fetching: "Fetching library",
+  applying: "Applying shortcuts",
+  finalizing: "Finalizing",
+  done: "Done",
+  cancelled: "Cancelled",
+  error: "Error",
+};
+
+/** The caption a page shows for the run's stage; "Syncing" before the run names
+ *  one (a panel's own optimistic start carries no stage). */
+function stageLabel(stage: SyncProgress["stage"]): string {
+  return stage ? STAGE_LABELS[stage] : "Syncing";
+}
+
+/** The bare fine-detail message. The coarse "step/totalSteps" is shown on the
+ *  bar row, so it is not repeated here. */
+function formatProgressText(progress: SyncProgress | null): string {
+  if (!progress) return "Syncing...";
+  return progress.message || "Syncing...";
+}
+
+/** The id of the run a frame belongs to, `""` for a frame that names none — a
+ *  panel's own optimistic start, or a backend with no run stamped yet. */
+function frameRunId(progress: SyncProgress): string {
+  return progress.runId ?? "";
+}
+
+/** The run a frame puts in flight, or `null` when the frame has none running. */
+function inFlightRunId(progress: SyncProgress): string | null {
+  return progress.running ? frameRunId(progress) : null;
+}
+
+/**
+ * Whether a terminal frame ends the run being watched — true unless it names a
+ * DIFFERENT run, since an unnamed run on either side (a panel's own optimistic
+ * start before the backend stamps an id, or a frame that carries none) cannot be
+ * shown to be another one, and refusing it would strand the reading on a run
+ * that has already ended. `null` — nothing watched at all — is the one case that
+ * ends nothing: that is a terminal frame the consumer FOUND rather than
+ * witnessed, the stored frame every QAM close leaves behind (#1019).
+ *
+ * The leniency leaves one window open, knowingly: between a run's two terminal
+ * signals — the merged `sync_complete` and the frame that follows it, under
+ * 100 ms apart — a user who starts the next run in the gap has the old run's
+ * second frame taken as ending the new one, costing that run its first status
+ * line. Accepted rather than closed: the previous boolean had the same window,
+ * nothing here can widen it, and the alternative — refusing an unnamed terminal
+ * frame — strands the reading on the far more reachable case above.
+ */
+function endsWatchedRun(watched: string | null, runId: string): boolean {
+  return watched !== null && (watched === "" || runId === "" || watched === runId);
+}
+
+/** The callbacks a run's end fires. Both are the OWNING page's — a second
+ *  consumer of the same run passes neither. */
+export interface SyncRunViewOptions {
+  /** The watched run has just ended, once per run, with its terminal frame. */
+  onRunEnd?: (progress: SyncProgress) => void;
+  /** The same run's second terminal frame, carrying the account of how it ended
+   *  that replaces the text the merged `sync_complete` frame left behind. Called
+   *  only for a frame that has a message of its own, so a page never has to
+   *  decide whether an empty one should blank what is already shown. */
+  onTerminalWording?: (message: string, stage: SyncProgress["stage"]) => void;
+}
+
+/** What a page needs to render the run in flight. */
+export interface SyncRunView {
+  /** Whether a run is in flight, read from the frame and never mirrored in a
+   *  second boolean — other readers of the same store would disagree with a page
+   *  that ended a run locally without ending it in the store (#1019). */
+  running: boolean;
+  stage: SyncProgress["stage"];
+  stageLabel: string;
+  /** The running unit's 1-based index, `0` before the run reaches one. */
+  step: number;
+  /** The run's unit count, `0` before the plan reaches the frontend. */
+  totalSteps: number;
+  /** How far into the running unit the run is (0..1), placed in the running
+   *  phase's own monotonic sub-slice. Exactly one unit runs at a time, so this
+   *  is the live position of whichever row `runUnitsStore` has in `running`. */
+  withinUnitFraction: number;
+  /** The coarse bar's percentage (0-100), or `undefined` while the run has no
+   *  unit count — which the bar reads as indeterminate. */
+  coarseFraction: number | undefined;
+  /** Whether a fine-detail line should be shown at all. */
+  hasFineDetail: boolean;
+  fineDetailText: string;
+  /** The estimate readout, or `null` when neither a measured countdown nor a
+   *  static seed exists — honest silence. */
+  etaText: string | null;
+  runId: string;
+}
+
+export function useSyncRunView(options: SyncRunViewOptions = {}): SyncRunView {
+  // The frame this consumer last saw, seeded from the store so a mount mid-run
+  // renders the live run on its first pass rather than a frame later.
+  const [progress, setProgress] = useState<SyncProgress | null>(() => getSyncProgress());
+  // Last non-empty fine-detail line, carried across unit-boundary anchor frames
+  // so the fine-detail row (and its inline spinner) stay MOUNTED when the next
+  // unit's FETCHING anchor frame resets current/total to 0 (#1415) — otherwise
+  // the row unmounts for a frame and the panel flickers. Populated by the store
+  // subscriber from any frame with real fine detail; reset to null when the run
+  // ends, so a terminal/idle state never surfaces a stale line.
+  const [carriedFineDetail, setCarriedFineDetail] = useState<string | null>(null);
+  // A dumb mirror of syncEta's live countdown (seconds), or null when not measured
+  // yet / between runs. syncEta owns the sticky deadline; the impure now-read that
+  // resolves it to seconds lives in the store subscriber (an event handler), NOT
+  // the render — the render must stay pure. Progress frames drive the subscriber,
+  // so the countdown ticks once per frame.
+  const [liveEtaDisplay, setLiveEtaDisplay] = useState<number | null>(null);
+  // The run this consumer is watching, by id, and whether its end has been
+  // handled. Seeded at first render — BEFORE the subscription below exists, so
+  // the mount seed's own write is measured against the state it replaced rather
+  // than against itself; a stored terminal frame the consumer merely finds
+  // therefore watches nothing and announces nothing (#1019).
+  const watchedRunId = useRef<string | null>(inFlightRunId(getSyncProgress()));
+  const watchedRunEnded = useRef(false);
+  // The callbacks as of the latest render, so the subscription below can be made
+  // once and still call the page's current closures — an inline callback is a
+  // fresh function every render, and re-subscribing per render would put the
+  // run's end back in reach of a race with its own teardown.
+  const callbacks = useRef(options);
+  useEffect(() => {
+    callbacks.current = options;
+  });
+
+  useEffect(() => {
+    /**
+     * The watched run has ended: everything that happens once per run.
+     *
+     * Which of the three actions below a frame calls for is decided at the call
+     * site and never re-derived in any of them. Those verdicts are taken from the
+     * run refs before the refs move on and OUTSIDE the subscriber's try, so a
+     * throw in here can never leave a page believing a finished run is still
+     * live; recomputing them inside would put that decision back into the guarded
+     * region.
+     */
+    const endWatchedRun = (frame: SyncProgress) => {
+      // Tear down the run's live-ETA state (deadline included) so the next run
+      // measures fresh, and clear the display mirror.
+      resetEta();
+      setLiveEtaDisplay(null);
+      callbacks.current.onRunEnd?.(frame);
+    };
+
+    /**
+     * The same run's SECOND terminal signal, which ends nothing — {@link
+     * endWatchedRun} has already run for this run. A frame with no message of its
+     * own changes nothing rather than blanking what is already shown, which is
+     * why the message is a required argument: the caller's guard is the only
+     * place that decision is taken, and the signature makes calling without one
+     * impossible rather than merely wrong.
+     */
+    const correctTerminalWording = (message: string, stage: SyncProgress["stage"]) => {
+      callbacks.current.onTerminalWording?.(message, stage);
+    };
+
+    /**
+     * The non-terminal half: keep the live-rate ETA moving. Called only from the
+     * subscriber, and only for a frame whose stage is not terminal.
+     *
+     * Feeds the estimator from applying frames that carry ITEM progress only —
+     * fetch frames carry page/cover counters, and an applying-stage cover-refresh
+     * frame (``coverRefresh``, #1456) carries a cover counter, not item progress,
+     * so both must be skipped. syncEta re-anchors its sticky deadline internally;
+     * the countdown is then mirrored into state here. Both now-reads are impure
+     * and so must stay on this side of the render boundary, which they do — this
+     * runs from an event handler, never from render.
+     */
+    const advanceLiveEta = (frame: SyncProgress) => {
+      if (
+        frame.stage === "applying" &&
+        frame.step !== undefined &&
+        frame.current !== undefined &&
+        !frame.coverRefresh
+      ) {
+        observeApplyProgress(frame.step, frame.current, Date.now());
+      }
+      setLiveEtaDisplay(displayedEtaSeconds(Date.now()));
+    };
+
+    // Subscribe to the module store — every backend sync_progress event and
+    // every frontend updateSyncProgress notifies, driving a re-render. What the
+    // end-of-run work keys on is the watched RUN reaching a terminal stage, not a
+    // terminal stage being present: the frame found in the store on mount ends
+    // nothing, and the two frames that end the same run are one ending (see the
+    // run refs above).
+    return onSyncProgressChange(() => {
+      // The local mirror must update FIRST and unconditionally — it is what
+      // drives the re-render. Everything after it is derived work (terminal
+      // teardown, estimator feeding, ETA state) that must never be able to break
+      // the re-render chain (on-device freeze, cause not yet reproduced in tests).
+      const frame = getSyncProgress();
+      setProgress(frame);
+      // Run bookkeeping, taken before the refs move on and outside the try below so
+      // a subscriber throw can never leave a page believing a finished run is
+      // still live. A running frame is what starts a watch; the frames that end one
+      // split into the first (the run ended: tear down and announce) and any that
+      // follow it (the same run's authoritative wording: the text, nothing else).
+      const inFlight = inFlightRunId(frame);
+      if (inFlight !== null) {
+        watchedRunId.current = inFlight;
+        watchedRunEnded.current = false;
+      }
+      const terminal = isTerminalStage(frame.stage);
+      const runEndedNow =
+        terminal && !watchedRunEnded.current && endsWatchedRun(watchedRunId.current, frameRunId(frame));
+      const laterTerminalFrame = terminal && watchedRunEnded.current;
+      if (runEndedNow) watchedRunEnded.current = true;
+      // Carry the fine-detail line so the row survives a unit boundary's anchor
+      // frame (which resets current/total, #1415); drop it the moment the run
+      // ends so the next run starts clean. Kept outside the try below so the
+      // reset can never be skipped by a subscriber throw.
+      //
+      // The carry is refreshed by any running frame that has a message AND a
+      // position: a real fine-detail frame (``total`` > 0) OR a unit-boundary
+      // FETCHING anchor (``total`` 0 but ``totalSteps`` > 0). At the boundary the
+      // anchor's own message ("Fetching <next unit>") REPLACES the previous
+      // unit's carried text, so the fine line names the new unit immediately
+      // instead of lagging on the old one until the next real frame lands a
+      // network RTT later. The initial optimistic "Fetching library…" start (no
+      // total, no totalSteps) is excluded, so it keeps the stage-label spinner;
+      // an empty-message frame never clears the carry (replace, never remove).
+      if (!frame.running) {
+        setCarriedFineDetail(null);
+      } else if (frame.message && (frame.total || frame.totalSteps)) {
+        setCarriedFineDetail(frame.message);
+      }
+      // A terminal frame that is neither verdict — the stored one a mount merely
+      // finds, watching nothing (#1019) — matches no arm and does nothing, which
+      // is the whole of what it should do.
+      try {
+        if (runEndedNow) {
+          endWatchedRun(frame);
+        } else if (laterTerminalFrame && frame.message) {
+          correctTerminalWording(frame.message, frame.stage);
+        } else if (!terminal) {
+          advanceLiveEta(frame);
+        }
+      } catch (e) {
+        logError(`sync-progress subscriber failed: ${e}`);
+      }
+    });
+  }, []);
+
+  // Two-level progress. The main determinate bar tracks COARSE unit progress
+  // but INTERPOLATES within the running unit so a large unit (e.g. 2091 items at
+  // step 2/8) doesn't sit frozen: the bar fills from the step's floor toward the
+  // next notch as the unit is worked. Notch positions come from the plan's
+  // per-unit item weights when measured (#1382), else each unit is an equal
+  // 1/totalSteps slice. 0/0 totalSteps means the run hasn't reached a unit yet →
+  // indeterminate. ``coarseFraction`` is a percentage (0-100), not a fraction.
+  //
+  // While actively working a unit (``fetching``/``applying``) the current unit
+  // is not yet done, so the completed count is ``step - 1``; the terminal-ish
+  // stages (``finalizing``/``done``) carry ``step == totalSteps`` as a
+  // completed count, so they keep the full ``step`` and the bar reads 100%.
+  // The within-unit fill splits the running unit's width into three monotonic
+  // sub-slices — fetch → covers → apply (#1407, ``withinUnitFraction``) — each
+  // filling by its own phase's ``current/total`` within a strictly-higher band
+  // than the phase before. So the fetch and cover frames now DO advance the bar
+  // (within their own sub-slice), never backwards at a phase boundary even
+  // though each phase restarts ``current/total`` from zero. An old backend that
+  // sends no sub-stage falls back to resting at the unit floor during fetch.
+  const step = progress?.step ?? 0;
+  const activeUnit = progress?.stage === "fetching" || progress?.stage === "applying";
+  const completedSteps = activeUnit ? Math.max(0, step - 1) : step;
+  const withinUnit = withinUnitFraction(progress);
+  // Weight the bar by the plan's per-unit item weights (#1382) — the same
+  // skip-aware, delta-corrected weights the countdown uses — so a
+  // predicted-skip unit takes no width and a huge platform takes its real
+  // share — except a run's LEADING zero-weight units, which still refresh
+  // covers and so claim an equal index slice rather than pinning the bar to
+  // empty (#1506). The latched wrapper adds a run-scoped high-water floor so a
+  // mid-run upward weight correction (observeUnitTotal on a mispredicted
+  // trailing skip) can't retract shown width (#1509). Falls back to
+  // equal-per-unit index weighting when no plan is measured (QAM opened mid-run
+  // before any sync_plan, old backend) or the plan can't apportion (unit-count
+  // mismatch, all-zero weights).
+  const weightedFraction = progress?.totalSteps
+    ? latchedCoarseFraction(completedSteps, withinUnit, progress.totalSteps)
+    : null;
+  const coarseFraction = progress?.totalSteps
+    ? Math.max(0, Math.min(100, (weightedFraction ?? (completedSteps + withinUnit) / progress.totalSteps) * 100))
+    : undefined;
+  const currentHasFineDetail = !!(progress?.total && progress.message);
+  // Keep the fine-detail row mounted across unit boundaries: the next unit's
+  // FETCHING anchor frame resets current/total (#1415), so fall back to the last
+  // non-empty fine detail carried by the store subscriber. Cleared when the run
+  // ends, so terminal/idle states never surface a stale line. The bar's own
+  // within-unit fill still reads the live current/total (never the carry), so
+  // this affects only which rows mount, not the bar (#1407).
+  const hasFineDetail = currentHasFineDetail || carriedFineDetail !== null;
+  const fineDetailText = currentHasFineDetail ? formatProgressText(progress) : (carriedFineDetail ?? "");
+
+  // Estimated-time readout for the in-flight run. Prefer the live measured
+  // countdown ("9 min left") once the estimator has a rate; before that, fall
+  // back to the static seed carried on the store as an upper bound ("up to
+  // X min"). Absent both, the row is omitted (honest silence).
+  const staticEtaSeconds = progress?.etaSeconds;
+  let etaText: string | null = null;
+  if (liveEtaDisplay !== null) {
+    etaText = formatEtaCountdown(liveEtaDisplay);
+  } else if (staticEtaSeconds !== undefined) {
+    etaText = `up to ${formatDuration(staticEtaSeconds)}`;
+  }
+
+  return {
+    running: progress?.running ?? false,
+    stage: progress?.stage,
+    stageLabel: stageLabel(progress?.stage),
+    step,
+    totalSteps: progress?.totalSteps ?? 0,
+    withinUnitFraction: withinUnit,
+    coarseFraction,
+    hasFineDetail,
+    fineDetailText,
+    etaText,
+    runId: progress?.runId ?? "",
+  };
+}


### PR DESCRIPTION
The Sync page (#1814) shows a run while it happens: one bar for the whole run,
and under it every unit of the plan with its own state, the running one with its
own bar. Main shows the same run today from numbers derived inside its own
component, so a second page would either re-derive them and drift, or read a
copy. This cut moves the derivation into one hook both pages call, and adds the
per-unit state the page needs. Main renders exactly what it rendered before.

`useSyncRunView` owns what a run looks like: the progress frame and its
subscription, the stage label, the coarse fraction over the plan's per-unit
weights, the position within the running unit, the fine-detail line carried
across a unit boundary, the live-ETA countdown and its teardown, and the
once-per-run bookkeeping that decides when a run has ended. The side effects a
run's end provokes stay the owning page's: Main passes them in, and a second
consumer passes none, so only one page announces a run.

`runUnitsStore` holds one run's work queue: seeded from the plan event, advanced
by each progress frame, and carrying what each unit produced, recorded by the
apply loop as it goes. The rows are bound to the run id the plan carried and a
frame from any other run moves nothing — the preview pass emits unit-scoped
frames of its own over the same work queue without a plan, and without that
binding it would walk the finished run's rows and keep their counts. Rows carry
no live position: that is the frame's to say, so a row changes only when its
state changes or its result grows, and a page that shows no rows subscribes to
none of it. The rows survive a terminal frame, so a cancelled or paused run can
still be read; a plugin reload mid-run loses them, and the store says so.

Main is unchanged: the same DOM, the same run-end ordering, the same render
frequency, and its 251 tests pass untouched.
