### PR TITLE
fix(paths): one spelling for a RetroDECK root reached through a symlink

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,35 +317,46 @@ Format: **invariant** — tier — enforced by.
   `retrodeck.json`, and does no network work despite living on the RomM HTTP adapter), `SystemSupportedExtensionsFn` /
   `SystemKnownFn` (two more questions to the same catalogue, through the same adapter cache), and
   `FirmwareFolderVerdictFn` (lists one core's declared folder and reads every candidate inside it the way the core does
-  — 0.26 s for LRPS2 on the reference machine, the one seam here a cost was measured for). Two other real I/O seams were
-  weighed and kept out — the reasons are in the script's docstring, and neither is an exemption; nor are those two an
-  inventory of what else touches the disk. **"It's only a read" is the reasoning this rule exists to refuse**:
-  `SqliteUnitOfWork.__enter__` issues `BEGIN IMMEDIATE`, so even a read-only UoW takes the write lock. The database is
-  in WAL, so readers are unaffected — but every other **writer** waits on the lock for up to `busy_timeout=5000` and
-  fails with `SQLITE_BUSY` if it is still held then, and `FakeUnitOfWork` shares no connection, so no unit test notices.
-  Six call sites had drifted across the rule before anything looked (#1779), for the reason the check exists: nothing at
-  a call site reveals that an injected seam touches the disk. **The rule and the gate come from reading code — no
-  measurement of how long any of those transactions actually held the lock exists, and nothing here should be read as
-  one.** What the check sees is the deadlock rule's matcher unchanged — an **attribute** call naming a listed seam,
-  lexically inside a `with <...>uow_factory()` block in the same function scope — so it inherits every blind spot of
-  that half: a seam behind a helper one level down, an alias to a local, a factory attribute whose name does not end in
-  `uow_factory`, a nested `def`/`lambda` (which resets the scope by design), a seam **passed as a bound method**
+  — 0.26 s for LRPS2 on the reference machine, the one seam here a cost was measured for), the two path resolvers —
+  `MigrationFileStore.realpath` (one walk per stored RetroDECK-home marker, a directory that may sit on the SD card the
+  marker is pending a migration away from) and `ResolvedPathFn` (the same walk, but on **both** sides of a comparison,
+  so a call site costs what the rows it checks cost, not what it checks them against) — and the `RetroDeckPaths` getters
+  that answer with a root: `bios_path`, `roms_path`, `saves_path`, `states_path` and `retrodeck_home`, five of the
+  Protocol's six path getters, each resolving on every call. The sixth, `config_path`, stays out because it resolves
+  nothing — it is `os.path.join` over the user home, so calling it costs no I/O. One other real I/O seam was weighed and
+  kept out — the reason is in the script's docstring, and it is not an exemption; nor is it an inventory of what else
+  touches the disk. **"It's only a read" is the reasoning this rule exists to refuse**: `SqliteUnitOfWork.__enter__`
+  issues `BEGIN IMMEDIATE`, so even a read-only UoW takes the write lock. The database is in WAL, so readers are
+  unaffected — but every other **writer** waits on the lock for up to `busy_timeout=5000` and fails with `SQLITE_BUSY`
+  if it is still held then, and `FakeUnitOfWork` shares no connection, so no unit test notices. Six call sites had
+  drifted across the rule before anything looked (#1779), for the reason the check exists: nothing at a call site
+  reveals that an injected seam touches the disk. **The rule and the gate come from reading code — no measurement of how
+  long any of those transactions actually held the lock exists, and nothing here should be read as one.** What the check
+  sees is the deadlock rule's matcher unchanged — an **attribute** call naming a listed seam, lexically inside a
+  `with <...>uow_factory()` block in the same function scope — so it inherits every blind spot of that half: a seam
+  behind a helper one level down, an alias to a local, a factory attribute whose name does not end in `uow_factory`, a
+  nested `def`/`lambda` (which resets the scope by design), a seam **passed as a bound method**
   (`run_in_executor(None, self._disc_resolver.enumerate_discs, install)` — an attribute, not a call, and
   `run_in_executor` is exactly how `disc.py` and `cores.py` reach their `_io` bodies; the same shape
   `check_read_only_module.py` records for its own gate), and the hand-maintained list itself, which cannot notice a seam
   whose implementation _grows_ a file read later. Matching only attribute calls is deliberate: the pure
   `domain.disc_selection.enumerate_discs` shares a name with the seam and does no I/O — it is safe because its call site
   imports it bare, not because of the name. The call-shaped blind spot is shared with the deadlock rule and only this
-  family closes it: for its five `__call__`-only seams the list carries the attribute each is bound to
-  (`_resolve_system`, `_sandbox_launcher`, `_system_extensions`, `_system_known`, `_firmware_folder_verdicts`) — by
-  convention rather than by construction, and only while such a name means one thing, which is exactly what keeps
-  `_list_files` out. Three of the five have no method name a consumer could write instead; `SystemResolver` and
-  `SandboxLauncherFn` do, their implementations being `RommHttpAdapter.resolve_system` and
-  `EsFindRulesAdapter.resolve_sandbox_launcher`, which is why `resolve_system` and `resolve_sandbox_launcher` are listed
-  beside their attributes. The deadlock rule's own call-shaped seams stay open. `SystemResolver` is the odd one out for
-  a second reason: the adapter memoises its map for the life of the process, so exactly one call ever opens the file,
-  and the entry earns its place because that one call can land inside a UoW. One `# pragma: no uow-check` covers both
-  families — it suppresses the line, and no seam is in both lists, so where a line does name two seams it silences both
+  family closes it: for each `__call__`-only seam the list carries the attribute it is bound to — by convention rather
+  than by construction, and only while such a name means one thing, which is exactly what keeps `_list_files` out.
+  **Count them by their leading underscore**, which is what marks an entry as a holding attribute rather than a method
+  name: six today (`_resolve_system`, `_sandbox_launcher`, `_system_extensions`, `_system_known`,
+  `_firmware_folder_verdicts`, `_resolve_path`), and the number is re-derivable from `IO_SEAM_METHODS` rather than
+  remembered. Two of those six are listed a second time under their implementation's own method name, for a peer holding
+  the object rather than the bound method — `RommHttpAdapter.resolve_system` beside `_resolve_system`, and
+  `EsFindRulesAdapter.resolve_sandbox_launcher` beside `_sandbox_launcher`. The first pair happens to be the attribute
+  minus its underscore and the second plainly is not, which is the point: a twin exists where the implementation has a
+  method name a peer could write, and it is read off the implementation rather than derived from the attribute. The
+  other four have no such twin. The deadlock rule's own call-shaped seams stay open. `SystemResolver` is the odd one out
+  for a second reason: the adapter memoises its map for the life of the process, so exactly one call ever opens the
+  file, and the entry earns its place because that one call can land inside a UoW. One `# pragma: no uow-check` covers
+  both families — it suppresses the line, and no seam is in both lists, so where a line does name two seams it silences
+  both
 - **Services never call clocks / sleep / uuid / random directly (inject the Protocol)** — check —
   `scripts/check_cosmic_call_bans.sh`
 - **No module in `services/`, `bootstrap/`, `adapters/`, `domain/`, `lib/` or `models/` crosses the ~1000-LOC

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -1512,7 +1512,7 @@ Adapters own all I/O and implement the Protocols defined in `services/protocols/
 | `es_find_rules.py`                                                         | `EsFindRulesAdapter` — ES-DE `es_find_rules.xml`: whether a standalone emulator's binary is installed, and the sandbox component launcher the folder-boot bake execs                                                                                                                                                     |
 | `gavel_native.py`                                                          | `GavelNativeAdapter` — loads the compiled [romm-gavel](https://github.com/danielcopper/romm-gavel) core (`py_modules/native/libgavel-x86_64-linux.so`) via `ctypes`; is itself the `ResolveUploadConflictFn` seam and provides the `ComputeSyncActionFn` seam, the two save-sync decisions (no Python fallback)          |
 | `system_clock.py` / `system_uuid_gen.py` / `asyncio_sleeper.py`            | concrete `Clock` / `UuidGen` / `Sleeper` seams                                                                                                                                                                                                                                                                           |
-| `hostname.py` / `path_probe.py` / `plugin_metadata.py` / `debug_logger.py` | hostname, path-exists probe, `package.json` name/version reader, settings-aware debug logger                                                                                                                                                                                                                             |
+| `hostname.py` / `path_probe.py` / `plugin_metadata.py` / `debug_logger.py` | hostname, the generic path seams (exists, symlink-resolve), `package.json` name/version reader, settings-aware debug logger                                                                                                                                                                                              |
 | `renderer_rss.py` / `renderer_gc.py`                                       | `RendererRssFn` — max `steamwebhelper` `VmRSS` from `/proc`; `RendererGcFn` (`HeapProfiler.collectGarbage`) over the CEF debugger. The session-budget measure + settle seams (ADR-0024). The "free memory" action is a frontend `SteamClient.User.StartRestart`, not a backend adapter                                   |
 | `game_process.py`                                                          | `GameProcessControl` — resolves a flatpak app's live instances via the per-user registry (`info` / `bwrapinfo.json`) plus the `/proc` child walk, reporting each tree's PIDs and argv separately, and signals them. Direct reads + `os.kill`, no subprocess; fail-soft on every read                                     |
 
@@ -1951,8 +1951,8 @@ package, organised topically (consumers always deep-import `from services.protoc
 - **`paths`** — `RetroDeckPaths`, `SystemResolver`, `CoreInfoProvider`, `SandboxLauncherFn`, `CoreResolverFn`,
   `CoreNameProviderFn`, `RetroArchConfigReader`, `RetroArchCoreInfoReader`, `RetroArchSaveSortingProvider`,
   `PlatformCoreReader`.
-- **`infra`** — cross-cutting callable seams: `EventEmitter`, `DebugLogger`, `PathExistsReader`, `HostnameReader`,
-  `PendingSyncReader`, `DownloadQueueCleanup`.
+- **`infra`** — cross-cutting callable seams: `EventEmitter`, `DebugLogger`, `PathExistsReader`, `ResolvedPathFn`,
+  `HostnameReader`, `PendingSyncReader`, `DownloadQueueCleanup`.
 - **`files`** — filesystem seams: `CoverArtFileStore`, `DownloadFileStore`, `FirmwareFileStore`, `MigrationFileStore`,
   `RomFileStore`, `SaveFileStore`, `SgdbArtworkCache`.
 - **`cross_service`** — narrowly-typed multi-method seams one service exposes to another so services stay independent:

--- a/docs/architecture/config-source-parsers.md
+++ b/docs/architecture/config-source-parsers.md
@@ -263,6 +263,33 @@ never raise**: when the file is missing, unreadable, or malformed, each getter f
 `<user_home>/retrodeck/<subdir>`. That fallback is RetroDECK's own default root, so it is correct for a default install
 but **wrong** for an SD-card install where the user pointed RetroDECK at external storage.
 
+Every root is returned **symlink-resolved**, whichever of the two sources answered. The content roots (`roms_path`,
+`saves_path`, `bios_path`, `states_path`) are handed to the path guards as safe roots, and the ROM paths those guards
+are asked about are recorded resolved wherever `lib/path_safety.safe_join` built them — so a root left as
+`retrodeck.json` spells it makes one directory look like two on any system where `/home` is a link to `/var/home`
+(Bazzite, Silverblue, and the other image-based distributions), and uninstalling a downloaded ROM fails with
+`Path is outside its safe root` ([#1838](https://github.com/danielcopper/decky-romm-sync/issues/1838)). `realpath` on a
+path that is not on disk resolves as far as it can instead of raising, so the getters stay best-effort.
+
+`retrodeck_home()` is not a safe root, and it is resolved for a different reason: `MigrationService` stores it and diffs
+the stored value against the live one on every startup to decide whether RetroDECK moved. Resolving one side is not
+enough there, because a marker written before this change still carries the other spelling — so the service resolves
+what it read from `kv_config` before comparing, through a `realpath` seam on `MigrationFileStore`. Two spellings of one
+directory read as "unchanged"; a move away from a home since deleted still reads as a move, because `realpath` follows
+the links in it that still exist and leaves the missing tail as spelled. A marker that survived from before the change
+and turns out to name the live home is dropped on that same pass, because otherwise it would stand until the user
+migrates or dismisses.
+
+The install prune (`StartupHealingService`, via the `ResolvedPathFn` seam) resolves **both** sides before its prefix
+match: the pending-home markers, and each install's own recorded paths. Neither side is reliably one spelling — a
+download is recorded through `safe_join` and so resolved, while a row an older migration relocated carries whatever
+spelling the home had when it ran — and a match that misses prunes a record whose files are still on disk. Resolving the
+recorded path is safe there in a way it is not in the deletion guards: the prune decides what to keep and authorizes
+nothing.
+
+Three user-visible spellings change with this: the `root_missing` banner's "Expected at:" line reports `resolved_home`,
+and the migration-blocked page renders `old_path` and `new_path`, both of which are now the resolved markers.
+
 Silently operating on the wrong root is the failure mode
 [#948](https://github.com/danielcopper/decky-romm-sync/issues/948) addresses. The fix keeps the getters
 silent-and-best-effort but pairs them with a loud health signal that the frontend surfaces as a QAM banner.

--- a/docs/architecture/removed-game-cleanup.md
+++ b/docs/architecture/removed-game-cleanup.md
@@ -194,6 +194,12 @@ ctime, every descendant's identity, and every regular file's hash. Mutation is d
 throughout, and a nested mount transition — including a same-device bind mount — fails closed. A path re-lookup alone
 never authorizes a delete or a quarantine.
 
+The safe root a source is anchored to is matched **symlink-resolved**, so a root named through a link — `/home` is a
+link to `/var/home` on image-based distributions — still contains the paths recorded under its resolved spelling
+([#1838](https://github.com/danielcopper/decky-romm-sync/issues/1838)). The root only: everything below it is compared
+and walked exactly as spelled, because resolving those components would resolve away the very symlinks the no-follow
+walk exists to refuse.
+
 ### What the hashes are for, and where they stop
 
 Why the disciplines are split this way, and what was rejected on the way there, is

--- a/docs/user-guide/retrodeck-path-migration.md
+++ b/docs/user-guide/retrodeck-path-migration.md
@@ -6,8 +6,10 @@ vice versa — the plugin detects the change and helps you migrate your download
 ## How It Works
 
 Every time the plugin starts, it compares the current RetroDECK home path with the path it had stored from your last
-session. If the paths differ, the plugin flags a migration. This typically happens after you use RetroDECK's built-in
-move tool or manually relocate your `retrodeck/` directory.
+session. If they are different **folders**, the plugin flags a migration — two ways of writing one folder are not a
+move, so a system that reaches your home through a link (`/home` is a link to `/var/home` on Bazzite and other
+image-based distributions) does not raise a migration for the spelling alone. This typically happens after you use
+RetroDECK's built-in move tool or manually relocate your `retrodeck/` directory.
 
 The plugin does not move your RetroDECK files — RetroDECK handles that. What the plugin migrates are the files _it_
 manages: downloaded ROMs, BIOS files, and save files that it tracks for sync purposes.

--- a/py_modules/adapters/descriptor_paths.py
+++ b/py_modules/adapters/descriptor_paths.py
@@ -344,6 +344,35 @@ def mount_id_for_fd(fd: int) -> int:
     return _mount_id(fd)
 
 
+def containing_root(absolute_path: str, safe_root: str) -> str | None:
+    """Return the spelling of *safe_root* that *absolute_path* lies below, or ``None``.
+
+    One directory answers to two names when the root itself is reached through a
+    symlink — image-based distributions ship ``/home`` as a link to
+    ``/var/home``. What is tolerated is the ROOT's spelling, because a caller
+    can hand one back rather than derive it: a recovery bundle replays the
+    ``safe_root`` its claim was sealed with, and a bundle sealed before the
+    RetroDECK roots were resolved stored the other spelling (#1838). Both name
+    the directory the caller declared as its root.
+
+    The *path* gets no such tolerance, and must not: it is matched against the
+    root as spelled, so one handed in the other spelling is refused outright.
+
+    Only the ROOT is resolved here. The components below it are left exactly as
+    spelled, because the callers walk them with ``O_NOFOLLOW`` from the root's
+    realpath: resolving them would authorize a traversal through a symlink the
+    walk exists to refuse.
+    """
+    lexical_root = os.path.abspath(safe_root)
+    for candidate in (lexical_root, os.path.realpath(lexical_root)):
+        try:
+            if os.path.commonpath((candidate, absolute_path)) == candidate:
+                return candidate
+        except ValueError:
+            continue
+    return None
+
+
 def _open_parent(path: str, safe_root: str) -> tuple[int, str]:
     parts = _relative_parts(path, safe_root)
     if not parts:
@@ -374,13 +403,13 @@ def _open_directory(path: str, safe_root: str) -> int:
 
 
 def _relative_parts(path: str, safe_root: str) -> list[str]:
-    absolute_root = os.path.abspath(safe_root)
+    # *path* is deliberately never resolved: the components below the root are
+    # walked with O_NOFOLLOW so that a symlink among them is refused, and a
+    # realpath here would resolve away exactly what the guard exists to reject.
     absolute_path = os.path.abspath(path)
-    try:
-        if os.path.commonpath((absolute_root, absolute_path)) != absolute_root:
-            raise ValueError(f"Path is outside its safe root: {path}")
-    except ValueError as exc:
-        raise ValueError(f"Path is outside its safe root: {path}") from exc
+    absolute_root = containing_root(absolute_path, safe_root)
+    if absolute_root is None:
+        raise ValueError(f"Path is outside its safe root: {path}")
     relative = os.path.relpath(absolute_path, absolute_root)
     if relative == ".":
         return []

--- a/py_modules/adapters/migration_file.py
+++ b/py_modules/adapters/migration_file.py
@@ -64,6 +64,10 @@ class MigrationFileAdapter:
         """Return the mtime of *path* as a Unix timestamp."""
         return os.path.getmtime(path)
 
+    def realpath(self, path: str) -> str:
+        """Return *path* with every symlink in it resolved."""
+        return os.path.realpath(path)
+
     def walk_files(self, base_dir: str) -> list[tuple[str, list[str], list[str]]]:
         """Return ``os.walk``-style triples for *base_dir*.
 

--- a/py_modules/adapters/path_probe.py
+++ b/py_modules/adapters/path_probe.py
@@ -1,4 +1,11 @@
-"""Concrete ``PathExistsReader`` adapter — generic filesystem existence probe."""
+"""Generic filesystem path questions services must not ask ``os.path`` directly.
+
+Holds the adapters for the path seams that carry no implication about which
+subtree the caller is reasoning about: whether a path exists, and which
+directory a path names once its symlinks are resolved. Anything that belongs to
+one tree (ROMs, saves, BIOS, a recovery bundle) has its own domain-shaped store
+instead.
+"""
 
 from __future__ import annotations
 
@@ -10,3 +17,10 @@ class PathProbeAdapter:
 
     def exists(self, path: str) -> bool:
         return os.path.exists(path)
+
+
+class ResolvedPathAdapter:
+    """Thin wrapper over ``os.path.realpath`` for the ``ResolvedPathFn`` Protocol."""
+
+    def __call__(self, path: str) -> str:
+        return os.path.realpath(path)

--- a/py_modules/adapters/recovery_bundle.py
+++ b/py_modules/adapters/recovery_bundle.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 
 from adapters.descriptor_paths import (
     claim_source,
+    containing_root,
     identity_for_stat,
     measure_tree,
     mount_id_for_fd,
@@ -590,13 +591,13 @@ class RecoveryBundleAdapter:
 
     @staticmethod
     def _open_regular_beneath(path: str, safe_root: str) -> int:
-        absolute_root = os.path.abspath(safe_root)
+        # *path* is never resolved — the walk below refuses a symlink among its
+        # components, which is only worth anything while they are still spelled
+        # the way the claim recorded them.
         absolute_path = os.path.abspath(path)
-        try:
-            if os.path.commonpath((absolute_root, absolute_path)) != absolute_root:
-                raise ValueError(f"Recovery source is outside its safe root: {path}")
-        except ValueError as exc:
-            raise ValueError(f"Recovery source is outside its safe root: {path}") from exc
+        absolute_root = containing_root(absolute_path, safe_root)
+        if absolute_root is None:
+            raise ValueError(f"Recovery source is outside its safe root: {path}")
         relative = os.path.relpath(absolute_path, absolute_root)
         if relative in {".", ".."} or relative.startswith(".." + os.sep):
             raise ValueError(f"Recovery source is not a file below its safe root: {path}")

--- a/py_modules/adapters/retrodeck_paths.py
+++ b/py_modules/adapters/retrodeck_paths.py
@@ -12,6 +12,25 @@ malformed ``retrodeck.json`` falls back to ``<user_home>/retrodeck/*``.
 On an SD-card install that fallback root is wrong, so the silent
 fallback is paired with :meth:`RetroDeckPathsAdapter.config_health`,
 the loud signal ``main.py`` surfaces to the frontend banner.
+
+Every root is symlink-resolved, whichever of the two sources answered.
+The content roots are handed to the path guards as safe roots, and the
+ROM paths those guards are asked about are recorded resolved wherever
+``lib.path_safety.safe_join`` built them — so a root left as
+``retrodeck.json`` spells it makes one directory look like two on any
+system where ``/home`` is a link to ``/var/home``, and a ROM recorded
+inside the root is refused as outside it (#1838).
+
+The home is not a safe root, and is resolved for its own reason:
+``MigrationService`` diffs it against the home it stored to decide
+whether RetroDECK moved, and two spellings of one directory are not a
+move.
+
+``realpath`` on a path that is not on disk resolves as far as it can and
+normalizes the rest rather than raising, so the getters keep their
+best-effort, never-raises contract. Normalizing is not nothing: the
+home's ``<user_home>/retrodeck/`` fallback loses its trailing separator,
+which is what a prefix match wanted anyway.
 """
 
 from __future__ import annotations
@@ -83,12 +102,13 @@ class RetroDeckPathsAdapter:
             return None
 
     def _get_path(self, key: str, fallback_subdir: str) -> str:
+        """Return the symlink-resolved root for *key*, or its ``~/retrodeck`` fallback."""
         config = self._load_config()
         if config:
             path = config.get("paths", {}).get(key, "")
             if path:
-                return path
-        return os.path.join(self._user_home, "retrodeck", fallback_subdir)
+                return os.path.realpath(path)
+        return os.path.realpath(os.path.join(self._user_home, "retrodeck", fallback_subdir))
 
     def bios_path(self) -> str:
         return self._get_path("bios_path", "bios")

--- a/py_modules/bootstrap/adapters.py
+++ b/py_modules/bootstrap/adapters.py
@@ -32,7 +32,7 @@ from adapters.gavel_native import GavelNativeAdapter
 from adapters.hostname import HostnameAdapter
 from adapters.machine_id import MachineIdAdapter
 from adapters.migration_file import MigrationFileAdapter
-from adapters.path_probe import PathProbeAdapter
+from adapters.path_probe import PathProbeAdapter, ResolvedPathAdapter
 from adapters.persistence import (
     PersistenceAdapter,
     PlatformCoreReaderAdapter,
@@ -90,6 +90,7 @@ if TYPE_CHECKING:
         RecoveryBundleStore,
         RendererGcFn,
         RendererRssFn,
+        ResolvedPathFn,
         ResolveUploadConflictFn,
         RetroArchSaveLayoutProvider,
         RetroArchSavestateLayoutProvider,
@@ -134,6 +135,7 @@ class AdapterBundle:
     rom_file_store: RomFileStore
     save_file_store: SaveFileStore
     path_probe: PathExistsReader
+    resolve_path: ResolvedPathFn
     core_info_provider: CoreInfoProvider
     renderer_rss: RendererRssFn
     renderer_gc: RendererGcFn
@@ -352,6 +354,7 @@ def bootstrap(
     rom_file_store = RomFileAdapter()
     save_file_store = SaveFileAdapter(logger=logger)
     path_probe = PathProbeAdapter()
+    resolve_path = ResolvedPathAdapter()
     renderer_rss = RendererRssAdapter()
     renderer_gc = RendererGcAdapter(logger=logger)
     game_process = GameProcessAdapter()
@@ -398,6 +401,7 @@ def bootstrap(
         rom_file_store=rom_file_store,
         save_file_store=save_file_store,
         path_probe=path_probe,
+        resolve_path=resolve_path,
         core_info_provider=emulator_catalogue,
         renderer_rss=renderer_rss,
         renderer_gc=renderer_gc,

--- a/py_modules/bootstrap/services.py
+++ b/py_modules/bootstrap/services.py
@@ -466,6 +466,7 @@ def wire_services(cfg: WiringConfig) -> dict[str, Any]:
             clock=cfg.runtime.clock,
             retrodeck_paths=cfg.callbacks.retrodeck_paths,
             path_probe=cfg.adapters.path_probe,
+            resolve_path=cfg.adapters.resolve_path,
             uow_factory=cfg.callbacks.uow_factory,
             relaunch_options=relaunch_options_resolver,
         ),

--- a/py_modules/services/migration.py
+++ b/py_modules/services/migration.py
@@ -156,6 +156,15 @@ class MigrationService:
         transition that re-emits ``retrodeck_path_changed`` with the oldest
         pending home as ``old_path`` (so the banner still reads "From: A →
         To: C").
+
+        What the kernel is asked is whether the home MOVED, so the stored marker
+        is resolved before the comparison: a marker written when the roots were
+        handed out unresolved names the same directory the live home does, and
+        answering "changed" there would offer to migrate that directory onto
+        itself (#1838). A real move still reads as one, including a move away
+        from a home since deleted — ``realpath`` follows whichever links in it
+        still exist and leaves the missing tail as spelled, so what it answers
+        with is a directory, and not the live one.
         """
         current_home = self._retrodeck_paths.retrodeck_home()
         if not current_home:
@@ -166,10 +175,12 @@ class MigrationService:
 
         with self._uow_factory() as uow:
             stored_home = uow.kv_config.get(_KV_RETRODECK_HOME) or ""
-            pending = self._read_pending_homes(uow)
+            stored_pending = self._read_pending_homes(uow)
 
-        transition = compute_pending_home_transition(stored_home, current_home, pending)
+        pending = self._resolved_homes(stored_pending)
+        transition = compute_pending_home_transition(self._resolved_home(stored_home), current_home, pending)
         if transition.kind == "unchanged":
+            self._clear_pending_home_never_left(current_home, pending)
             return
         if transition.kind == "first_run":
             with self._uow_factory() as uow:
@@ -191,12 +202,62 @@ class MigrationService:
             self._logger.warning(f"RetroDECK home path changed: {transition.emit_old} -> {transition.emit_new}")
         self._spawn_background_task(self._emit("retrodeck_path_changed", payload))
 
+    def _clear_pending_home_never_left(self, current_home: str, pending: Sequence[str]) -> None:
+        """Drop any pending home that turns out to BE the live home.
+
+        A pending home is one RetroDECK has left; one that names the home it
+        reports now was never left, so there is nothing to migrate out of it.
+        The kernel already excludes the arriving home from the set it writes
+        (``_dedupe_exclude``) — this is that same rule applied on the path that
+        decided nothing moved, which is where such a marker can survive: a
+        migration left pending before the roots were resolved names its old home
+        in the other spelling, and comparing directories now finds it is the
+        live one (#1838). The kernel's own auto-clear cannot reach this shape:
+        it tests the sole pending home only after ``unchanged`` has already
+        returned. So without this the marker would stand until the user migrates
+        or dismisses.
+        """
+        remaining = [home for home in pending if home != current_home]
+        if len(remaining) == len(pending):
+            return
+        self._logger.info(f"Clearing pending migration marker for the live RetroDECK home: {current_home}")
+        with self._uow_factory() as uow:
+            self._write_pending_homes(uow, remaining)
+
+    def _resolved_home(self, home: str) -> str:
+        """Return the directory one stored home marker names, leaving an unset marker unset.
+
+        Never called with a Unit of Work open: resolving is filesystem I/O and a
+        UoW holds the database's write lock (ADR-0006). The unset guard matters
+        because ``realpath("")`` answers with the process's working directory,
+        which is not a home anybody stored.
+        """
+        return self._migration_file_store.realpath(home) if home else ""
+
+    def _resolved_homes(self, homes: Sequence[str]) -> list[str]:
+        """Return each pending-home marker as the directory it names.
+
+        A marker written while the RetroDECK roots were handed out unresolved
+        spells a directory the other way round from every install path recorded
+        under it, and each of this service's consumers compares the two —
+        prefix-matching a stranded file, diffing the live home, counting what a
+        migration would move. None of those comparisons fires across two
+        spellings of one directory (#1838). The destination home is resolved
+        beside them for a second reason: the migration builds each relocated
+        record's new path from it, and a path recorded unresolved is one the
+        guards will later refuse.
+        """
+        return [self._resolved_home(home) for home in homes]
+
     @staticmethod
     def _read_pending_homes(uow) -> list[str]:
-        """Read the pending-home set (oldest→newest) from kv_config.
+        """Read the pending-home set (oldest→newest) from kv_config, as stored.
 
         Reassembles ``[previous, *hops]`` from the ``_previous`` marker and the
-        ``_hops`` JSON array; returns ``[]`` when no migration is pending.
+        ``_hops`` JSON array; returns ``[]`` when no migration is pending. These
+        are the spellings on record, not directories — pass them through
+        :meth:`_resolved_homes` once the UoW is closed before comparing any of
+        them with a path.
         """
         return pending_homes_from_kv(
             uow.kv_config.get(_KV_RETRODECK_HOME_PREVIOUS) or "",
@@ -710,8 +771,10 @@ class MigrationService:
                 and just update state paths.
         """
         with self._uow_factory() as uow:
-            pending = self._read_pending_homes(uow)
-            new_home = uow.kv_config.get(_KV_RETRODECK_HOME) or ""
+            stored_pending = self._read_pending_homes(uow)
+            stored_home = uow.kv_config.get(_KV_RETRODECK_HOME) or ""
+        pending = self._resolved_homes(stored_pending)
+        new_home = self._resolved_home(stored_home)
 
         if not pending or not new_home:
             return {"success": False, "reason": "no_migration_needed", "message": "No path migration needed"}
@@ -776,8 +839,10 @@ class MigrationService:
     async def get_migration_status(self):
         """Return whether a RetroDECK path migration is pending and file counts."""
         with self._uow_factory() as uow:
-            pending = self._read_pending_homes(uow)
-            new_home = uow.kv_config.get(_KV_RETRODECK_HOME) or ""
+            stored_pending = self._read_pending_homes(uow)
+            stored_home = uow.kv_config.get(_KV_RETRODECK_HOME) or ""
+        pending = self._resolved_homes(stored_pending)
+        new_home = self._resolved_home(stored_home)
 
         if not pending or not new_home:
             return {"pending": False}

--- a/py_modules/services/protocols/__init__.py
+++ b/py_modules/services/protocols/__init__.py
@@ -90,6 +90,7 @@ from services.protocols.infra import (
     PendingSyncReader,
     RendererGcFn,
     RendererRssFn,
+    ResolvedPathFn,
     ResolveUploadConflictFn,
 )
 from services.protocols.paths import (
@@ -202,6 +203,7 @@ __all__ = [
     "RendererGcFn",
     "RendererRssFn",
     "ResolveUploadConflictFn",
+    "ResolvedPathFn",
     "RetroArchConfigReader",
     "RetroArchCoreInfoReader",
     "RetroArchSaveLayoutProvider",

--- a/py_modules/services/protocols/files.py
+++ b/py_modules/services/protocols/files.py
@@ -468,6 +468,19 @@ class MigrationFileStore(Protocol):
         """Return the mtime of *path* as a Unix timestamp."""
         ...
 
+    def realpath(self, path: str) -> str:
+        """Return *path* with every symlink in it resolved.
+
+        The home markers are compared as directories, not as strings: one
+        directory answers to two names wherever a root is reached through a
+        symlink, and reading that as a move would offer to migrate a directory
+        onto itself. A path that is not on disk still answers: the links in it
+        that exist are followed and the missing tail is normalized as spelled,
+        so a home the user moved away from and deleted resolves to a directory,
+        and one that is not the live one.
+        """
+        ...
+
     def walk_files(self, base_dir: str) -> list[tuple[str, list[str], list[str]]]:
         """Return ``os.walk``-style ``(dirpath, dirnames, filenames)`` triples for *base_dir*.
 

--- a/py_modules/services/protocols/infra.py
+++ b/py_modules/services/protocols/infra.py
@@ -124,6 +124,21 @@ class PathExistsReader(Protocol):
         ...
 
 
+class ResolvedPathFn(Protocol):
+    """The single spelling of one path — every symlink in it resolved.
+
+    Used where a service compares paths recorded at different times that can
+    spell one directory two ways: a root reached through a symlink (``/home`` is
+    a link to ``/var/home`` on image-based distributions) answers to both names,
+    and a string comparison reads that as two different directories (#1838).
+
+    Both sides of such a comparison go through here, so a consumer's cost scales
+    with the rows it checks and not with the values it checks them against.
+    """
+
+    def __call__(self, path: str) -> str: ...
+
+
 class RendererRssFn(Protocol):
     """Current RSS of the Steam ``SharedJSContext`` renderer, in KB.
 

--- a/py_modules/services/startup_healing.py
+++ b/py_modules/services/startup_healing.py
@@ -19,11 +19,13 @@ from domain.migration_paths import pending_homes_from_kv
 
 if TYPE_CHECKING:
     import logging
+    from collections.abc import Sequence
 
     from services.protocols import (
         Clock,
         PathExistsReader,
         RelaunchOptionsReader,
+        ResolvedPathFn,
         RetroDeckPaths,
         UnitOfWorkFactory,
     )
@@ -34,7 +36,8 @@ class StartupHealingServiceConfig:
     """Frozen wiring bundle handed to ``StartupHealingService.__init__``.
 
     Carries the runtime logger, the clock, the bundled RetroDECK paths
-    provider, the generic path-exists probe, and the SQLite Unit-of-Work
+    provider, the generic path-exists probe, the path resolver that turns a
+    stored home marker into the directory it names, and the SQLite Unit-of-Work
     factory (the transactional seam over the ``rom_installs``, ``sync_runs``,
     and ``kv_config`` repositories — the last holding the pending-migration
     previous home marker). The shared ``relaunch_options`` seam builds each
@@ -48,6 +51,7 @@ class StartupHealingServiceConfig:
     clock: Clock
     retrodeck_paths: RetroDeckPaths
     path_probe: PathExistsReader
+    resolve_path: ResolvedPathFn
     uow_factory: UnitOfWorkFactory
     relaunch_options: RelaunchOptionsReader
 
@@ -60,6 +64,7 @@ class StartupHealingService:
         self._clock = config.clock
         self._retrodeck_paths = config.retrodeck_paths
         self._path_probe = config.path_probe
+        self._resolve_path = config.resolve_path
         self._uow_factory = config.uow_factory
         self._relaunch_options = config.relaunch_options
 
@@ -83,15 +88,16 @@ class StartupHealingService:
 
         with self._uow_factory() as uow:
             installs = list(uow.rom_installs.iter_all())
-            pending_homes = pending_homes_from_kv(
+            stored_homes = pending_homes_from_kv(
                 uow.kv_config.get("retrodeck_home_path_previous") or "",
                 uow.kv_config.get("retrodeck_home_path_hops"),
             )
+        pending_homes = [self._resolve_path(home) for home in stored_homes]
         stale: list[int] = []
         for install in installs:
             file_path = install.file_path
             rom_dir = install.rom_dir
-            if is_pending_migration_path(file_path, rom_dir, pending_homes):
+            if self._under_pending_home(file_path, rom_dir, pending_homes):
                 self._logger.info(f"Skipping prune of {install.rom_id} ({file_path}): pending migration")
                 continue
             if (file_path and self._path_probe.exists(file_path)) or (rom_dir and self._path_probe.exists(rom_dir)):
@@ -103,6 +109,29 @@ class StartupHealingService:
             with self._uow_factory() as uow:
                 for rom_id in stale:
                     uow.rom_installs.delete(rom_id)
+
+    def _under_pending_home(self, file_path: str, rom_dir: str | None, pending_homes: Sequence[str]) -> bool:
+        """Answer whether one install's recorded paths live under a pending home.
+
+        Both sides are resolved before the prefix match, because either can be
+        spelled two ways for one directory: a path recorded through
+        ``lib.path_safety.safe_join`` is resolved, one an older migration
+        relocated carries whatever spelling the home had when it ran
+        (``remap_under_current`` joins that home verbatim), and a marker written
+        before the roots were resolved carries the other spelling again (#1838).
+        A match that misses prunes a record whose files are still on disk, so
+        the question has to be about directories rather than strings.
+
+        Resolving the recorded path is safe here in a way it is not in the
+        deletion guards: this decides what to KEEP and authorizes nothing. The
+        loop already probes each path's existence, so it is no new class of
+        cost.
+        """
+        return is_pending_migration_path(
+            self._resolve_path(file_path) if file_path else file_path,
+            self._resolve_path(rom_dir) if rom_dir else rom_dir,
+            pending_homes,
+        )
 
     def reconcile_orphaned_sync_runs(self) -> None:
         """Transition a ``running`` ``SyncRun`` left by a crash into ``interrupted``.

--- a/scripts/check_uow_seam_nesting.py
+++ b/scripts/check_uow_seam_nesting.py
@@ -73,16 +73,23 @@ own) has no method name to match: the consumer writes
 ``self._candidate_probe(...)``, never the seam's own name. Rule 1 leaves it
 open — the ``current_save_sorting`` / ``has_adoption_candidate`` entries guard
 only call sites that name the method, which is the owning service's own and any
-peer holding the object rather than the bound method. Rule 2's five
-call-shaped seams are closed the cheap way instead: every consumer in
-``services/`` binds each to one attribute — ``self._resolve_system``,
-``self._sandbox_launcher``, ``self._system_extensions``, ``self._system_known``,
-``self._firmware_folder_verdicts`` — and those attribute names are what the
-list carries (``resolve_system`` and ``resolve_sandbox_launcher`` are listed
-beside theirs, being the implementations' real method names,
-``RommHttpAdapter.resolve_system`` and
-``EsFindRulesAdapter.resolve_sandbox_launcher``, for a peer holding the object;
-the other three have no such twin). That is a convention, not a guarantee — a
+peer holding the object rather than the bound method. Rule 2's call-shaped
+seams are closed the cheap way instead: every consumer in ``services/`` binds
+each to one attribute, and that attribute name is what the list carries. **The
+leading underscore is what marks such an entry**, which makes the count
+derivable rather than remembered: the entries in :data:`IO_SEAM_METHODS`
+beginning with ``_`` are exactly the call-shaped seams — six today,
+``_resolve_system``, ``_sandbox_launcher``, ``_system_extensions``,
+``_system_known``, ``_firmware_folder_verdicts`` and ``_resolve_path``. Two of
+those six are listed a second time under their implementation's own method name,
+for a peer that holds the object rather than the bound method:
+``RommHttpAdapter.resolve_system`` beside ``_resolve_system``, and
+``EsFindRulesAdapter.resolve_sandbox_launcher`` beside ``_sandbox_launcher``.
+The first pair happens to be the attribute minus its underscore and the second
+plainly is not, which is the point: a twin exists when the implementation has a
+method name a peer could write, and it has to be read off the implementation
+rather than derived from the attribute. The other four have no such twin.
+That is a convention, not a guarantee — a
 consumer binding one under a different attribute slips past, and it only works
 while the attribute name means one thing. Doing the same for rule 1 means a
 second list of holding attributes to keep in step, and is not built.
@@ -94,10 +101,10 @@ flagged — the safety is in the call site's bare import, not in the name.
 
 Seams considered and left out
 -----------------------------
-These were weighed for :data:`IO_SEAM_METHODS` and kept out. It is a record of
-two decisions, not a survey of what touches the disk. Neither is exempt from the
-rule — a UoW held across either is a breach — and the reason is not that their
-I/O matters less:
+One seam was weighed for :data:`IO_SEAM_METHODS` and kept out. This records that
+decision, and one that was reversed; neither is a survey of what touches the
+disk, and the kept-out one is not exempt from the rule — a UoW held across that
+listing is a breach, and the reason is not that its I/O matters less:
 
 * ``DirectoryFileListerFn`` — a directory listing, and its consumer binds it to
   ``self._list_files``. Its call-shaped siblings are *in* the list, matched by
@@ -106,12 +113,13 @@ I/O matters less:
   it holds — any class might bind it to something unrelated — so an entry would
   key the gate on a coincidence, where ``_system_extensions`` and
   ``_resolve_system`` each mean one thing.
-* ``RetroDeckPaths``'s path getters sit behind a 30-second TTL cache
-  (``adapters/retrodeck_paths.py``), so a call is usually a dict lookup and a
-  ban would fire mostly where nothing is spent — which teaches writers to reach
-  for a pragma instead of looking. The caveat is that only a successfully-read
-  config is ever cached, and the TTL guard tests the cached value first, so on a
-  machine without RetroDECK every getter reopens.
+* ``RetroDeckPaths``'s path getters were kept out on the grounds that a
+  30-second TTL cache made a call usually a dict lookup, so a ban would fire
+  mostly where nothing is spent — which teaches writers to reach for a pragma
+  instead of looking. That argument died with #1838: every getter now resolves
+  its answer, so a call walks the path with ``realpath`` whether or not the
+  config cache hits. They are listed. Adding them moved no code — every call
+  site in ``services/`` already sat outside its UoW.
 
 The escape hatch is a trailing comment on the seam-call line:
 
@@ -225,6 +233,26 @@ IO_SEAM_METHODS: frozenset[str] = frozenset(
         # thing in the tree.
         "_system_extensions",
         "_system_known",
+        # MigrationFileStore.realpath (services/protocols/files.py) — one lstat
+        # per component of a stored home marker, which is a directory that may
+        # sit on the SD card the marker is pending a migration away from.
+        "realpath",
+        # ResolvedPathFn (services/protocols/infra.py) — the same resolution for
+        # a service holding no file store. Both sides of a comparison go through
+        # it, so a call site's cost scales with the rows it checks, not with the
+        # values it checks them against. Call-shaped, so what the list carries is
+        # the attribute its consumers bind it to, as for its siblings above.
+        "_resolve_path",
+        # RetroDeckPaths (services/protocols/paths.py) — every root getter
+        # resolves its answer with realpath (#1838), so a call walks the path
+        # component by component even when the 30-second config cache hits.
+        # These were excluded while they were string algebra over a cached dict;
+        # the docstring records why that no longer holds.
+        "bios_path",
+        "roms_path",
+        "saves_path",
+        "states_path",
+        "retrodeck_home",
     }
 )
 

--- a/tests/adapters/test_descriptor_paths.py
+++ b/tests/adapters/test_descriptor_paths.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 
 from adapters.descriptor_paths import (
     claim_source,
+    containing_root,
     ensure_directory,
     measure_tree,
     remove_claimed,
@@ -51,6 +52,80 @@ def test_intermediate_symlink_never_authorizes_deletion_outside_root(tmp_path):
         claim_source(str(safe / "linked" / "target.srm"), str(safe))
 
     assert target.read_bytes() == b"keep"
+
+
+def test_a_root_reached_through_a_symlink_authorizes_the_files_below_it(tmp_path):
+    """An unresolved root still contains the resolved paths below it.
+
+    The shape a recovery bundle replays: the root arrives in the spelling its
+    claim was sealed with, the path resolved (#1838). The reverse is refused,
+    which the ``containing_root`` assertion below pins.
+    """
+    base = tmp_path.resolve()
+    roms = base / "var" / "home" / "player" / "retrodeck" / "roms" / "ps2"
+    roms.mkdir(parents=True)
+    rom = roms / "388.chd"
+    rom.write_bytes(b"disc")
+    (base / "home").symlink_to(base / "var" / "home", target_is_directory=True)
+    linked_root = str(base / "home" / "player" / "retrodeck" / "roms")
+    # Without this the test would pass on a filesystem that never had the
+    # problem: both spellings must really differ.
+    assert linked_root != os.path.realpath(linked_root)
+
+    assert measure_tree(str(rom), linked_root) == 4
+    # The root's own spelling still answers too — it is what the walk anchors on.
+    assert measure_tree(os.path.join(linked_root, "ps2", "388.chd"), linked_root) == 4
+    # The tolerance runs one way only: the ROOT may be spelled either way, the
+    # path may not. A path through the link under a resolved root is outside it.
+    assert containing_root(os.path.join(linked_root, "ps2"), os.path.realpath(linked_root)) is None
+
+    claim = claim_source(str(rom), linked_root)
+    outcome = remove_claimed(str(rom), linked_root, claim)
+
+    assert outcome["success"]
+    assert outcome["changed"]
+    assert not rom.exists()
+
+
+def test_a_path_that_cannot_be_compared_to_the_root_is_outside_it(tmp_path):
+    """``commonpath`` refuses to mix an absolute root with a relative path — that is a refusal, not a crash."""
+    assert containing_root("not/absolute.chd", str(tmp_path)) is None
+
+
+def test_resolving_the_root_never_resolves_the_path_below_it(tmp_path):
+    """A symlink among the path's own components is refused, symlinked root or not.
+
+    The components below the root are walked with ``O_NOFOLLOW``; resolving the
+    path would resolve away the very links that walk exists to reject, and the
+    inside-the-root case is the quiet one — it authorizes deleting a link's
+    target instead of the link.
+    """
+    base = tmp_path.resolve()
+    safe = base / "var" / "home" / "player" / "roms"
+    real_dir = safe / "ps2"
+    real_dir.mkdir(parents=True)
+    (real_dir / "keep.chd").write_bytes(b"keep")
+    (base / "home").symlink_to(base / "var" / "home", target_is_directory=True)
+    outside = base / "outside"
+    outside.mkdir()
+    (outside / "target.chd").write_bytes(b"keep too")
+    (safe / "escaping").symlink_to(outside, target_is_directory=True)
+    (safe / "inside").symlink_to(real_dir, target_is_directory=True)
+    linked_root = str(base / "home" / "player" / "roms")
+
+    escaping_resolved = str(safe / "escaping" / "target.chd")
+    escaping_linked = os.path.join(linked_root, "escaping", "target.chd")
+    inside_resolved = str(safe / "inside" / "keep.chd")
+
+    with pytest.raises(OSError):
+        claim_source(escaping_resolved, linked_root)
+    with pytest.raises(OSError):
+        claim_source(escaping_linked, linked_root)
+    with pytest.raises(OSError):
+        claim_source(inside_resolved, linked_root)
+
+    assert (outside / "target.chd").read_bytes() == b"keep too"
+    assert (real_dir / "keep.chd").read_bytes() == b"keep"
 
 
 def test_replacement_in_pre_rename_window_is_verified_and_rolled_back(tmp_path, monkeypatch):

--- a/tests/adapters/test_recovery_bundle.py
+++ b/tests/adapters/test_recovery_bundle.py
@@ -163,6 +163,67 @@ def test_rejects_path_escape_symlink_and_duplicate_identity(tmp_path):
         adapter.seal_bundle(bundle_id, snapshot, [], readme, "playtime")
 
 
+def _symlinked_home(tmp_path) -> tuple[Path, Path, str]:
+    """Build ``<base>/home -> <base>/var/home`` and return the base, the real roms dir, and its linked root.
+
+    The shape image-based distributions ship, in which a sealed claim's
+    ``safe_root`` can name the roms root the other way round (#1838).
+    """
+    base = tmp_path.resolve()
+    roms = base / "var" / "home" / "player" / "roms"
+    roms.mkdir(parents=True)
+    (base / "home").symlink_to(base / "var" / "home", target_is_directory=True)
+    linked_root = str(base / "home" / "player" / "roms")
+    assert linked_root != os.path.realpath(linked_root)
+    return base, roms, linked_root
+
+
+def test_seals_and_revalidates_a_source_root_reached_through_a_symlink(tmp_path):
+    _base, roms, linked_root = _symlinked_home(tmp_path)
+    (roms / "disc.bin").write_bytes(b"rom")
+    adapter = _adapter(tmp_path)
+
+    sealed = Path(
+        adapter.seal_bundle(
+            "TestGame_2026-07-24_symlink",
+            _snapshot(),
+            [
+                {
+                    "source_path": str(roms / "disc.bin"),
+                    "safe_root": linked_root,
+                    "kind": "installed_rom",
+                    "rom_id": 7,
+                }
+            ],
+            _readme_context(),
+            "playtime",
+        )
+    )
+
+    assert (sealed / "files" / "000001").read_bytes() == b"rom"
+    assert adapter.validate_sources(str(sealed)) is True
+
+
+def test_a_symlinked_source_root_still_refuses_everything_below_it_that_is_a_link(tmp_path):
+    """Only the root is resolved — a link among the path's own components stays refused."""
+    base, roms, linked_root = _symlinked_home(tmp_path)
+    real_dir = roms / "dc"
+    real_dir.mkdir()
+    (real_dir / "keep.bin").write_bytes(b"keep")
+    outside = base / "outside"
+    outside.mkdir()
+    (outside / "target.bin").write_bytes(b"keep too")
+    (roms / "escaping").symlink_to(outside, target_is_directory=True)
+    (roms / "inside").symlink_to(real_dir, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="outside its safe root"):
+        RecoveryBundleAdapter._open_regular_beneath(str(outside / "target.bin"), linked_root)
+    with pytest.raises(OSError):
+        RecoveryBundleAdapter._open_regular_beneath(str(roms / "escaping" / "target.bin"), linked_root)
+    with pytest.raises(OSError):
+        RecoveryBundleAdapter._open_regular_beneath(str(roms / "inside" / "keep.bin"), linked_root)
+
+
 def test_failed_copy_cleans_staging_without_touching_existing_bundle(tmp_path, monkeypatch):
     safe = tmp_path / "safe"
     safe.mkdir()

--- a/tests/adapters/test_retrodeck_paths.py
+++ b/tests/adapters/test_retrodeck_paths.py
@@ -67,8 +67,12 @@ class TestPathResolution:
         assert adapter.retrodeck_home() == "/custom/home"
 
     def test_retrodeck_home_fallback(self, tmp_path):
+        # The fallback is built with an empty subdir, so it is spelled with a
+        # trailing separator; resolving the root drops it. Nothing wanted the
+        # separator — ``is_pending_migration_path`` appends its own, and a home
+        # ending in one could never match a path below it.
         adapter = _make_adapter(tmp_path)
-        assert adapter.retrodeck_home() == os.path.join(str(tmp_path), "retrodeck", "")
+        assert adapter.retrodeck_home() == os.path.join(str(tmp_path), "retrodeck")
 
     def test_empty_path_uses_fallback(self, tmp_path):
         adapter = _make_adapter(tmp_path, {"paths": {"roms_path": ""}})
@@ -84,6 +88,71 @@ class TestPathResolution:
         (config_dir / "retrodeck.json").write_text("not valid json")
         adapter = RetroDeckPathsAdapter(user_home=str(tmp_path), logger=logging.getLogger("test"))
         assert adapter.bios_path() == os.path.join(str(tmp_path), "retrodeck", "bios")
+
+
+class TestSymlinkResolvedRoots:
+    """#1838: a root reached through a symlink must be spelled the way ``safe_join`` spells it."""
+
+    @staticmethod
+    def _linked_home(tmp_path):
+        """Return ``(user_home_through_the_link, real_retrodeck_dir)`` for a ``/home -> /var/home`` layout."""
+        base = tmp_path.resolve()
+        retrodeck = base / "var" / "home" / "player" / "retrodeck"
+        for subdir in ("bios", "roms", "saves", "states"):
+            (retrodeck / subdir).mkdir(parents=True)
+        (base / "home").symlink_to(base / "var" / "home", target_is_directory=True)
+        linked_home = base / "home" / "player"
+        assert str(linked_home) != os.path.realpath(linked_home)
+        return linked_home, retrodeck
+
+    def test_configured_content_roots_are_resolved(self, tmp_path):
+        linked_home, retrodeck = self._linked_home(tmp_path)
+        linked = linked_home / "retrodeck"
+        adapter = _make_adapter(
+            linked_home,
+            {
+                "paths": {
+                    "bios_path": str(linked / "bios"),
+                    "roms_path": str(linked / "roms"),
+                    "saves_path": str(linked / "saves"),
+                    "states_path": str(linked / "states"),
+                }
+            },
+        )
+
+        assert adapter.bios_path() == str(retrodeck / "bios")
+        assert adapter.roms_path() == str(retrodeck / "roms")
+        assert adapter.saves_path() == str(retrodeck / "saves")
+        assert adapter.states_path() == str(retrodeck / "states")
+
+    def test_fallback_content_roots_are_resolved(self, tmp_path):
+        linked_home, retrodeck = self._linked_home(tmp_path)
+        adapter = _make_adapter(linked_home)
+
+        assert adapter.bios_path() == str(retrodeck / "bios")
+        assert adapter.roms_path() == str(retrodeck / "roms")
+        assert adapter.saves_path() == str(retrodeck / "saves")
+        assert adapter.states_path() == str(retrodeck / "states")
+
+    def test_a_root_that_is_not_on_disk_resolves_as_far_as_it_can(self, tmp_path):
+        """``realpath`` never raises on a missing tail, so the getters stay best-effort."""
+        linked_home, retrodeck = self._linked_home(tmp_path)
+        adapter = _make_adapter(
+            linked_home, {"paths": {"roms_path": str(linked_home / "retrodeck" / "not-created-yet")}}
+        )
+
+        assert adapter.roms_path() == str(retrodeck / "not-created-yet")
+
+    def test_the_home_is_resolved_like_every_other_root(self, tmp_path):
+        """The home is the marker ``MigrationService`` diffs, so it too must name a directory.
+
+        Left unresolved it would be compared against a stored spelling of the
+        same directory and read as a move.
+        """
+        linked_home, retrodeck = self._linked_home(tmp_path)
+        adapter = _make_adapter(linked_home, {"paths": {"rd_home_path": str(linked_home / "retrodeck")}})
+
+        assert adapter.retrodeck_home() == str(retrodeck)
 
 
 class TestTTLCache:

--- a/tests/fakes/fake_migration_file_store.py
+++ b/tests/fakes/fake_migration_file_store.py
@@ -25,6 +25,9 @@ class FakeMigrationFileStore:
     - ``walk_returns`` — explicit ``{base_dir: triples}`` override for
       ``walk_files``; when absent, triples are synthesised from the
       ``files`` and ``dirs`` snapshot.
+    - ``links`` — ``{link spelling: target spelling}`` for ``realpath``,
+      applied to a path's prefix so one entry stages a whole symlinked
+      tree.
     """
 
     def __init__(self, files: dict[str, bytes] | None = None) -> None:
@@ -36,6 +39,7 @@ class FakeMigrationFileStore:
         self.get_mtime_failures: set[str] = set()
         self.mtimes: dict[str, float] = {}
         self.walk_returns: dict[str, list[tuple[str, list[str], list[str]]]] | None = None
+        self.links: dict[str, str] = {}
         self.move_calls: list[tuple[str, str]] = []
         self.rename_calls: list[tuple[str, str]] = []
 
@@ -81,6 +85,20 @@ class FakeMigrationFileStore:
         if src not in self.files:
             raise FileNotFoundError(src)
         self.files[dst] = self.files.pop(src)
+
+    def realpath(self, path: str) -> str:
+        """Resolve *path*'s prefix through ``links``, the way a symlinked root does.
+
+        One entry stages a whole tree: ``{"/home": "/var/home"}`` resolves
+        ``/home/deck/retrodeck`` to ``/var/home/deck/retrodeck``. A path no entry
+        covers answers as itself, including one that is no longer on disk.
+        """
+        for link, target in self.links.items():
+            if path == link:
+                return target
+            if path.startswith(link + "/"):
+                return target + path[len(link) :]
+        return path
 
     def get_mtime(self, path: str) -> float:
         if path in self.get_mtime_failures:

--- a/tests/fakes/fake_resolved_path.py
+++ b/tests/fakes/fake_resolved_path.py
@@ -1,0 +1,26 @@
+"""In-memory ``ResolvedPathFn`` implementation for service tests."""
+
+from __future__ import annotations
+
+
+class FakeResolvedPath:
+    """In-memory ``ResolvedPathFn`` for tests.
+
+    Backed by a ``dict[str, str]`` of link spelling → target spelling, applied
+    to a path's prefix so one entry stages a whole tree the way the real symlink
+    does: ``{"/home": "/var/home"}`` resolves ``/home/deck/retrodeck`` to
+    ``/var/home/deck/retrodeck``. A path no entry covers answers as itself,
+    which is what ``os.path.realpath`` does for a location with no link in it —
+    including one that is no longer on disk.
+    """
+
+    def __init__(self, links: dict[str, str] | None = None) -> None:
+        self.links: dict[str, str] = dict(links) if links else {}
+
+    def __call__(self, path: str) -> str:
+        for link, target in self.links.items():
+            if path == link:
+                return target
+            if path.startswith(link + "/"):
+                return target + path[len(link) :]
+        return path

--- a/tests/scripts/test_check_uow_seam_nesting.py
+++ b/tests/scripts/test_check_uow_seam_nesting.py
@@ -274,6 +274,37 @@ class TestIoSeamsViolations:
         assert len(findings) == 1
         assert "enumerate_discs" in findings[0]
 
+    @pytest.mark.parametrize("getter", ["bios_path", "roms_path", "saves_path", "states_path", "retrodeck_home"])
+    def test_every_retrodeck_root_getter_inside_uow_is_flagged(self, getter: str):
+        # Each getter resolves its answer, so a call walks the path even on a
+        # config-cache hit — the reason they stopped being an exclusion.
+        findings = check.scan_source(
+            "class S:\n"
+            "    def go(self):\n"
+            "        with self._uow_factory() as uow:\n"
+            f"            root = self._retrodeck_paths.{getter}()\n"
+            "        return root\n",
+            "svc.py",
+        )
+        assert len(findings) == 1
+        assert getter in findings[0]
+        assert "file-I/O seam" in findings[0]
+
+    def test_realpath_inside_uow_is_flagged(self):
+        # The shape the home markers invite: read a marker out of kv_config and
+        # resolve it without leaving the transaction first.
+        findings = check.scan_source(
+            "class S:\n"
+            "    def detect(self):\n"
+            "        with self._uow_factory() as uow:\n"
+            "            stored = self._migration_file_store.realpath(uow.kv_config.get('home'))\n"
+            "        return stored\n",
+            "svc.py",
+        )
+        assert len(findings) == 1
+        assert "realpath" in findings[0]
+        assert "file-I/O seam" in findings[0]
+
     @pytest.mark.parametrize(
         "method",
         ["get_active_core", "get_default_emulator", "get_emulator_options"],
@@ -295,7 +326,14 @@ class TestIoSeamsViolations:
 
     @pytest.mark.parametrize(
         "attribute",
-        ["_resolve_system", "_sandbox_launcher", "_system_extensions", "_system_known"],
+        [
+            "_resolve_system",
+            "_sandbox_launcher",
+            "_system_extensions",
+            "_system_known",
+            "_firmware_folder_verdicts",
+            "_resolve_path",
+        ],
     )
     def test_call_shaped_seams_are_matched_by_their_holding_attribute(self, attribute: str):
         # These Protocols are __call__-only, so no consumer ever writes a method

--- a/tests/services/test_migration.py
+++ b/tests/services/test_migration.py
@@ -291,6 +291,140 @@ class TestPathChangeDetection:
         assert loop.tasks == []
         assert plugin._migration_service._emit.calls == []
 
+    def test_two_spellings_of_one_home_are_not_a_move(self, plugin, tmp_path):
+        """#1838: a marker naming the live home through a symlink is the same directory.
+
+        A home stored before the roots were resolved is spelled the way
+        ``retrodeck.json`` spelled it. Reading that as a move would raise the
+        migration banner and offer to relocate a directory onto itself — whose
+        Overwrite branch deletes the destination first.
+        """
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
+
+        base = tmp_path.resolve()
+        real_home = base / "var" / "home" / "player" / "retrodeck"
+        real_home.mkdir(parents=True)
+        (base / "home").symlink_to(base / "var" / "home", target_is_directory=True)
+        stored_home = str(base / "home" / "player" / "retrodeck")
+        assert stored_home != str(real_home)
+
+        with plugin._uow as uow:
+            uow.kv_config.set("retrodeck_home_path", stored_home)
+        loop = _RecordingLoop()
+        plugin._migration_service._loop = loop
+        plugin._migration_service._retrodeck_paths = FakeRetroDeckPaths(home=str(real_home))
+
+        plugin._migration_service.detect_retrodeck_path_change()
+
+        assert loop.tasks == []
+        assert plugin._migration_service._emit.calls == []
+        with plugin._uow as uow:
+            assert uow.kv_config.get("retrodeck_home_path_previous") is None
+            assert uow.kv_config.get("retrodeck_home_path_hops") is None
+            # Nothing moved, so nothing is written — the marker keeps the
+            # spelling it was stored with and is resolved again next startup.
+            assert uow.kv_config.get("retrodeck_home_path") == stored_home
+
+    def test_a_pending_marker_naming_the_live_home_is_cleared(self, plugin, tmp_path):
+        """A marker naming the home RetroDECK is already on is dropped.
+
+        Otherwise it stands until the user migrates or dismisses, over a home
+        that was never left.
+        """
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
+
+        base = tmp_path.resolve()
+        real_home = base / "var" / "home" / "player" / "retrodeck"
+        real_home.mkdir(parents=True)
+        (base / "home").symlink_to(base / "var" / "home", target_is_directory=True)
+        linked_home = str(base / "home" / "player" / "retrodeck")
+
+        with plugin._uow as uow:
+            uow.kv_config.set("retrodeck_home_path", linked_home)
+            uow.kv_config.set("retrodeck_home_path_previous", linked_home)
+        loop = _RecordingLoop()
+        plugin._migration_service._loop = loop
+        plugin._migration_service._retrodeck_paths = FakeRetroDeckPaths(home=str(real_home))
+
+        plugin._migration_service.detect_retrodeck_path_change()
+
+        with plugin._uow as uow:
+            assert uow.kv_config.get("retrodeck_home_path_previous") is None
+            assert uow.kv_config.get("retrodeck_home_path_hops") is None
+        assert plugin._migration_service.is_retrodeck_migration_pending() is False
+        assert loop.tasks == []
+
+    def test_a_pending_hop_that_was_really_left_survives_the_clear(self, plugin, tmp_path):
+        """Only the marker naming the live home is dropped; a genuine hop stays pending."""
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
+
+        home = str(tmp_path / "retrodeck")
+        os.makedirs(home, exist_ok=True)
+        with plugin._uow as uow:
+            uow.kv_config.set("retrodeck_home_path", home)
+            uow.kv_config.set("retrodeck_home_path_previous", home)
+            uow.kv_config.set("retrodeck_home_path_hops", json.dumps([str(tmp_path / "sd-card" / "retrodeck")]))
+        plugin._migration_service._loop = _RecordingLoop()
+        plugin._migration_service._retrodeck_paths = FakeRetroDeckPaths(home=home)
+
+        plugin._migration_service.detect_retrodeck_path_change()
+
+        with plugin._uow as uow:
+            assert uow.kv_config.get("retrodeck_home_path_previous") == str(tmp_path / "sd-card" / "retrodeck")
+            assert uow.kv_config.get("retrodeck_home_path_hops") is None
+
+    async def test_a_home_that_really_moved_is_still_a_change(self, plugin, tmp_path):
+        """Comparing directories must not swallow a real move, including one already gone.
+
+        The gone home sits under a symlinked prefix, so ``realpath`` really does
+        rewrite it — it follows the links that still exist and leaves the
+        missing tail as spelled. What it answers with is still a different
+        directory from the one RetroDECK reports now, which is what makes this a
+        move rather than a spelling.
+        """
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
+
+        base = tmp_path.resolve()
+        (base / "var" / "home" / "player").mkdir(parents=True)
+        (base / "home").symlink_to(base / "var" / "home", target_is_directory=True)
+        gone_home = str(base / "home" / "player" / "sd-card" / "retrodeck")
+        new_home = str(base / "internal" / "retrodeck")
+        os.makedirs(new_home, exist_ok=True)
+        assert not os.path.exists(gone_home)
+        # The marker really is rewritten by resolving, and still is not the live home.
+        resolved_gone = os.path.realpath(gone_home)
+        assert resolved_gone != gone_home
+        assert resolved_gone != new_home
+
+        with plugin._uow as uow:
+            uow.kv_config.set("retrodeck_home_path", gone_home)
+        plugin._migration_service._retrodeck_paths = FakeRetroDeckPaths(home=new_home)
+
+        plugin._migration_service.detect_retrodeck_path_change()
+        await asyncio.sleep(0)
+
+        with plugin._uow as uow:
+            assert uow.kv_config.get("retrodeck_home_path") == new_home
+            # What is recorded as pending is the directory the marker named,
+            # not the spelling it was stored under.
+            assert uow.kv_config.get("retrodeck_home_path_previous") == resolved_gone
+        event, args = plugin._migration_service._emit.calls[0]
+        assert event == "retrodeck_path_changed"
+        assert args[0]["old_path"] == resolved_gone
+        assert args[0]["new_path"] == new_home
+
     async def test_path_change_emits_event(self, plugin, tmp_path):
         """Path changed — stores both old and new, emits event."""
         import decky
@@ -504,6 +638,73 @@ class TestMigrateRetroDeckFiles:
             assert install.file_path == new_rom
             # Single-file ROM owns no folder before or after migration.
             assert install.rom_dir is None
+
+    @pytest.mark.asyncio
+    async def test_a_pending_home_that_is_the_live_home_moves_and_destroys_nothing(self, plugin, tmp_path):
+        """Acting on such a marker must not treat the live home as a move source.
+
+        Source and destination would be the same path, and Overwrite removes the
+        destination before moving. What prevents it is the sweep dropping any
+        pending home equal to the live one — a comparison that only holds
+        because both sides are resolved.
+        """
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
+
+        base = tmp_path.resolve()
+        rom = base / "var" / "home" / "player" / "retrodeck" / "roms" / "n64" / "zelda.z64"
+        rom.parent.mkdir(parents=True)
+        rom.write_text("rom data")
+        (base / "home").symlink_to(base / "var" / "home", target_is_directory=True)
+        linked_home = str(base / "home" / "player" / "retrodeck")
+
+        with plugin._uow as uow:
+            uow.kv_config.set("retrodeck_home_path", linked_home)
+            uow.kv_config.set("retrodeck_home_path_previous", linked_home)
+        _seed_install(plugin._uow, 1, file_path=str(rom), system="n64")
+
+        result = await plugin.migrate_retrodeck_files("overwrite")
+
+        assert result["success"] is True
+        assert result["roms_moved"] == 0
+        assert rom.read_text() == "rom data"
+
+    @pytest.mark.asyncio
+    async def test_migrating_into_a_symlinked_home_records_the_resolved_path(self, plugin, tmp_path):
+        """#1838: both markers name directories, so what is recorded is the resolved path.
+
+        A migration left pending across the upgrade carries markers spelled the
+        way ``retrodeck.json`` spelled them. The new path each relocated record
+        gets is built from the destination marker, and a path recorded through a
+        symlink is one the uninstall guard later refuses.
+        """
+        import decky
+
+        decky.DECKY_USER_HOME = str(tmp_path)
+        plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
+
+        base = tmp_path.resolve()
+        old_rom = base / "old" / "roms" / "n64" / "zelda.z64"
+        old_rom.parent.mkdir(parents=True)
+        old_rom.write_text("rom data")
+        (base / "new" / "retrodeck").mkdir(parents=True)
+        (base / "home").symlink_to(base, target_is_directory=True)
+        linked_new_home = str(base / "home" / "new" / "retrodeck")
+        assert linked_new_home != os.path.realpath(linked_new_home)
+
+        with plugin._uow as uow:
+            uow.kv_config.set("retrodeck_home_path_previous", str(base / "old"))
+            uow.kv_config.set("retrodeck_home_path", linked_new_home)
+        _seed_install(plugin._uow, 1, file_path=str(old_rom), system="n64")
+
+        result = await plugin.migrate_retrodeck_files()
+
+        assert result["success"] is True
+        assert result["roms_moved"] == 1
+        with plugin._uow as uow:
+            assert uow.rom_installs.get(1).file_path == str(base / "new" / "retrodeck" / "roms" / "n64" / "zelda.z64")
 
     @pytest.mark.asyncio
     async def test_migration_records_applied_launch_options_for_bound_rom(self, plugin, tmp_path):

--- a/tests/services/test_rom_removal.py
+++ b/tests/services/test_rom_removal.py
@@ -388,6 +388,54 @@ class TestDeleteRomFiles:
         assert "identity changed" in result["message"]
         assert (rom_dir / "disc.bin").read_bytes() == b"replacement"
 
+    @pytest.mark.parametrize("multi_file", [False, True], ids=["single-file", "rom-dir"])
+    def test_uninstalls_when_the_roms_root_is_reached_through_a_symlink(self, tmp_path, logger, multi_file):
+        """#1838: the roms root and the install record spell one directory two ways.
+
+        Image-based distributions (Bazzite, Silverblue) ship ``/home`` as a link
+        to ``/var/home``. The root is handed in the spelling ``retrodeck.json``
+        used — what an install row recorded before the roots were resolved is
+        matched against — so the uninstall must still go through. Run against
+        the real ``RomFileAdapter``, since a fake store cannot have this problem.
+        """
+        base = tmp_path.resolve()
+        system = base / "var" / "home" / "player" / "retrodeck" / "roms" / "ps2"
+        system.mkdir(parents=True)
+        (base / "home").symlink_to(base / "var" / "home", target_is_directory=True)
+        linked_roms = str(base / "home" / "player" / "retrodeck" / "roms")
+        assert linked_roms != os.path.realpath(linked_roms)
+        rom_dir = system / "Game" if multi_file else None
+        if rom_dir is not None:
+            rom_dir.mkdir()
+        rom_path = (rom_dir or system) / "388.chd"
+        rom_path.write_bytes(b"disc")
+        uow = FakeUnitOfWork()
+        _seed_install(
+            uow,
+            _make_install(1, file_path=str(rom_path), rom_dir=str(rom_dir) if rom_dir else None, system="ps2"),
+            platform_slug="ps2",
+        )
+        real_service = RomRemovalService(
+            config=RomRemovalServiceConfig(
+                logger=logger,
+                loop=asyncio.new_event_loop(),
+                clock=FakeClock(),
+                emit=RecordingEmitter(),
+                rom_file_store=RomFileAdapter(),
+                retrodeck_paths=FakeRetroDeckPaths(roms=linked_roms),
+                download_queue_cleanup=None,
+                uow_factory=FakeUnitOfWorkFactory(uow),
+            )
+        )
+
+        result = real_service.delete_rom_files(1)
+
+        assert result["success"] is True, result["message"]
+        assert result["changed"] is True
+        assert not rom_path.exists()
+        # The shared per-system directory is never the thing removed.
+        assert system.is_dir()
+
 
 class TestRemoveRom:
     @pytest.mark.asyncio

--- a/tests/services/test_startup_healing.py
+++ b/tests/services/test_startup_healing.py
@@ -8,6 +8,7 @@ import logging
 import pytest
 from fakes.fake_path_exists_reader import FakePathExistsReader
 from fakes.fake_relaunch_options_resolver import FakeRelaunchOptionsResolver
+from fakes.fake_resolved_path import FakeResolvedPath
 from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
 from fakes.fake_unit_of_work import FakeUnitOfWork, FakeUnitOfWorkFactory
 from fakes.system_time import FakeClock
@@ -66,6 +67,7 @@ def _make_service(
     logger: logging.Logger,
     retrodeck_home: str = _RETRODECK_HOME,
     path_probe: FakePathExistsReader | None = None,
+    resolve_path: FakeResolvedPath | None = None,
     uow: FakeUnitOfWork | None = None,
     clock: FakeClock | None = None,
     relaunch_options: FakeRelaunchOptionsResolver | None = None,
@@ -77,6 +79,7 @@ def _make_service(
             clock=clock if clock is not None else FakeClock(),
             retrodeck_paths=FakeRetroDeckPaths(home=retrodeck_home),
             path_probe=probe,
+            resolve_path=resolve_path if resolve_path is not None else FakeResolvedPath(),
             uow_factory=FakeUnitOfWorkFactory(uow) if uow is not None else FakeUnitOfWorkFactory(),
             relaunch_options=relaunch_options if relaunch_options is not None else FakeRelaunchOptionsResolver(),
         ),
@@ -167,6 +170,53 @@ class TestPruneStaleInstalledRoms:
             service.prune_stale_installed_roms()
         assert uow.rom_installs.get(1) is not None
         assert any("Skipping prune" in rec.message and "/hop/retrodeck" in rec.message for rec in caplog.records)
+
+    def test_preserve_entry_under_a_pending_home_spelled_through_a_symlink(self, logger, caplog):
+        """#1838: the marker and the install path name one directory two ways.
+
+        A pending home recorded before the RetroDECK roots were resolved is
+        spelled ``/home/...``, while every install under it was recorded through
+        ``safe_join`` as ``/var/home/...``. The prefix match never fires across
+        the two, and the install this rule exists to protect is pruned instead.
+        """
+        uow = FakeUnitOfWork()
+        _seed_install(uow, 1, file_path="/var/home/player/old-retrodeck/roms/n64/zelda.z64")
+        with uow:
+            uow.kv_config.set("retrodeck_home_path_previous", "/home/player/old-retrodeck")
+        service = _make_service(logger=logger, resolve_path=FakeResolvedPath({"/home": "/var/home"}), uow=uow)
+        with caplog.at_level(logging.INFO):
+            service.prune_stale_installed_roms()
+        assert uow.rom_installs.get(1) is not None
+        assert any("Skipping prune" in rec.message for rec in caplog.records)
+
+    def test_preserve_entry_a_migration_recorded_under_the_other_spelling(self, logger, caplog):
+        """A row an older migration relocated carries the home's spelling of the day.
+
+        ``remap_under_current`` joins the home the migration ran under verbatim,
+        so such a row is not resolved the way a ``safe_join`` download is — here
+        the marker is the resolved one and the row is not. Resolving only the
+        marker would miss it and prune a record whose files are still on disk.
+        """
+        uow = FakeUnitOfWork()
+        _seed_install(uow, 1, file_path="/home/player/old-retrodeck/roms/n64/zelda.z64")
+        with uow:
+            uow.kv_config.set("retrodeck_home_path_previous", "/var/home/player/old-retrodeck")
+        service = _make_service(logger=logger, resolve_path=FakeResolvedPath({"/home": "/var/home"}), uow=uow)
+        with caplog.at_level(logging.INFO):
+            service.prune_stale_installed_roms()
+        assert uow.rom_installs.get(1) is not None
+        assert any("Skipping prune" in rec.message for rec in caplog.records)
+
+    def test_preserve_rom_dir_entry_recorded_under_the_other_spelling(self, logger):
+        """The same for a folder-backed ROM, whose ``rom_dir`` is the matched path."""
+        uow = FakeUnitOfWork()
+        rom_dir = "/home/player/old-retrodeck/roms/psx/FF7"
+        _seed_install(uow, 1, file_path=f"{rom_dir}/FF7.m3u", rom_dir=rom_dir)
+        with uow:
+            uow.kv_config.set("retrodeck_home_path_previous", "/var/home/player/old-retrodeck")
+        service = _make_service(logger=logger, resolve_path=FakeResolvedPath({"/home": "/var/home"}), uow=uow)
+        service.prune_stale_installed_roms()
+        assert uow.rom_installs.get(1) is not None
 
     def test_no_prune_does_not_write(self, logger):
         """When no record is pruned, no write UoW is opened."""

--- a/tests/test_atlas_machine_vectors.py
+++ b/tests/test_atlas_machine_vectors.py
@@ -171,6 +171,19 @@ def _rewrite_home(text: str, home: str, fake_home: str) -> str:
     return text.replace(home, fake_home)
 
 
+def _as_the_plugin_spells_it(path: str) -> str:
+    """Resolve *path* the way the plugin resolves its RetroDECK roots (#1838).
+
+    A vector's non-home root is a real absolute path — ``/mnt/sd/retrodeck`` —
+    and on an image-based host that prefix can itself be a symlink (SteamOS
+    resolves ``/mnt`` to ``/var/mnt``). The adapter answers with the resolved
+    spelling, so the two sides are compared as directories rather than as
+    strings; on a host without such a link this is a no-op and the comparison
+    is unchanged.
+    """
+    return os.path.realpath(path)
+
+
 def _materialize(files: dict[str, str], home: str, fake_home: str) -> None:
     """Write the vector's ``{path: content}`` file tree under the fake home."""
     for raw_path, raw_content in files.items():
@@ -235,7 +248,7 @@ def _check_full(
     expected_dir = expected_dir.replace("<rom_stem>", _ROM_STEM)
     if core_name is not None:
         expected_dir = expected_dir.replace("<core>", core_name)
-    expected_dir = _rewrite_home(expected_dir, home, fake_home)
+    expected_dir = _as_the_plugin_spells_it(_rewrite_home(expected_dir, home, fake_home))
 
     assert actual_dir == expected_dir, (
         f"placement dir drift on {vector['name']!r}: kernel {actual_dir!r} != atlas {expected_dir!r}"

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -29,6 +29,7 @@ from fakes.fake_platform_core_reader import FakePlatformCoreReader
 from fakes.fake_plugin_metadata_reader import FakePluginMetadataReader
 from fakes.fake_renderer_gc import FakeRendererGc
 from fakes.fake_renderer_rss import FakeRendererRss
+from fakes.fake_resolved_path import FakeResolvedPath
 from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
 from fakes.fake_rom_file_store import FakeRomFileStore
 from fakes.fake_save_file_store import FakeSaveFileStore
@@ -253,6 +254,7 @@ class TestWireServices:
             "rom_file_store": FakeRomFileStore(),
             "save_file_store": FakeSaveFileStore(),
             "path_probe": FakePathExistsReader(),
+            "resolve_path": FakeResolvedPath(),
             "renderer_rss": FakeRendererRss(),
             "renderer_gc": FakeRendererGc(),
             "game_process": FakeGameProcessControlAdapter(),
@@ -315,6 +317,7 @@ class TestWireServices:
                 rom_file_store=deps["rom_file_store"],
                 save_file_store=deps["save_file_store"],
                 path_probe=deps["path_probe"],
+                resolve_path=deps["resolve_path"],
                 core_info_provider=deps["core_info_provider"],
                 renderer_rss=deps["renderer_rss"],
                 renderer_gc=deps["renderer_gc"],

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -11,6 +11,7 @@ from fakes.fake_path_exists_reader import FakePathExistsReader
 from fakes.fake_relaunch_options_resolver import FakeRelaunchOptionsResolver
 from fakes.fake_renderer_gc import FakeRendererGc
 from fakes.fake_renderer_rss import FakeRendererRss
+from fakes.fake_resolved_path import FakeResolvedPath
 from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
 from fakes.fake_settings_persister import FakeSettingsPersister
 from fakes.fake_sgdb_artwork_cache import FakeSgdbArtworkCache
@@ -197,6 +198,7 @@ def plugin():
             clock=FakeClock(),
             retrodeck_paths=p._retrodeck_paths,
             path_probe=FakePathExistsReader(),
+            resolve_path=FakeResolvedPath(),
             uow_factory=FakeUnitOfWorkFactory(),
             relaunch_options=FakeRelaunchOptionsResolver(),
         ),
@@ -1129,6 +1131,7 @@ class TestMainStartupOrdering:
                 rom_file_store=MagicMock(),
                 save_file_store=MagicMock(),
                 path_probe=MagicMock(),
+                resolve_path=MagicMock(),
                 core_info_provider=MagicMock(),
                 renderer_rss=FakeRendererRss(),
                 renderer_gc=FakeRendererGc(),


### PR DESCRIPTION
Uninstalling a downloaded ROM failed with "Path is outside its safe root"
on image-based distributions, where /home is a symlink to /var/home. The
two path producers disagreed: the download recorded the install through
safe_join, which resolves, while retrodeck.json handed the roms root out
verbatim. is_safe_rom_path realpaths both sides and passed; the
descriptor-relative claim taken immediately after compared them lexically
and refused.

Every RetroDECK root is now returned symlink-resolved, so those two
producers speak one spelling. The guards additionally accept a ROOT in
either spelling, because a caller can hand one back rather than derive
it: a recovery bundle replays the safe_root its claim was sealed with,
and a bundle sealed before this change stored the other one. The path
below that root gets no such tolerance and must not — it is matched as
spelled. What the guards resolve is the root they anchor to, which is
the root _open_directory already opened, so until now the parts were
computed against one root and walked from another.

The path is never resolved for the walk either: its components are
traversed with O_NOFOLLOW so a symlink among them is refused, and
resolving them would authorize a deletion through one.

Resolving the home alone would have been worse than the bug. It is the
marker MigrationService diffs on every startup, so the newly resolved
value would read as a move away from the stored one, and the offered
migration would relocate a directory onto itself — its Overwrite branch
removes the destination before moving the source. So the comparison now
asks whether the home MOVED rather than whether its spelling changed:
the stored marker is resolved before the diff, through a realpath seam on
MigrationFileStore. A move away from a home since deleted still reads as
a move, because realpath follows the links in it that still exist and
leaves the missing tail as spelled. A marker that survived from before
the change and turns out to name the live home is dropped on that same
pass, because otherwise it would stand until the user migrates or
dismisses.

The install prune resolves both sides before its prefix match — the
pending-home markers, through a ResolvedPathFn seam, and each install's
own recorded paths. Neither side is reliably one spelling: a download is
recorded resolved, while a row an older migration relocated carries the
home's spelling of the day, and a match that misses prunes a record whose
files are still on disk. The migration resolves its destination home for
the same reason, so each relocated record is written in the spelling the
guards accept. Resolving is filesystem I/O, so every call sits outside
the Unit of Work that read the markers.

Both new seams are registered with the gate that enforces that, and so
are the five RetroDECK root getters: they were excluded from it on the
grounds that a config cache made a call almost free, and resolving ended
that. No call site had to move.

The atlas machine vectors compare a placement against a root the plugin
resolves, so the expectation is now resolved the same way: on a host
where /mnt is a link to /var/mnt, the vector and the kernel spell one
directory two ways.

Fixes #1838

