### PR TITLE
docs(install): distribute through Decky's install-from-URL

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,7 +69,7 @@ body:
     attributes:
       label: Log excerpt
       description: |
-        Plugin logs live at `~/homebrew/logs/decky-romm-sync/`. Set log level to "debug" in plugin settings for full output. Decky Loader logs are in `~/homebrew/services/PluginLoader/`.
+        Plugin logs live at `~/homebrew/logs/romm-tender/` or `~/homebrew/logs/decky-romm-sync/` — older installs use the second name; if both are there, take the one with recent files. Set log level to "debug" in plugin settings for full output. Decky Loader's own log goes to the journal: `journalctl -u plugin_loader`.
       render: text
     validations:
       required: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,8 +147,19 @@ jobs:
           # names its output after the package. Renaming therefore means copying
           # — into RUNNER_TEMP, because /tmp/output belongs to the container that
           # produced the zip and is not writable here.
+          # The name must be exactly "Tender.zip", for the update path rather than
+          # the install. decky_loader's installFromURL takes the plugin name from
+          # the URL's last path segment, and PluginBrowser._install spends it on
+          # its "was this already installed?" lookup — find_plugin_folder(), an
+          # exact match against each installed plugin.json's "name", "Tender" here.
+          # A lower-cased name misses, so the previous copy is never uninstalled:
+          # the new zip unpacks over it, stale files survive, and "Tender" is
+          # appended to Decky's pluginOrder again. The install itself still
+          # succeeds — Install-from-URL sends no version, so the backend's default
+          # of "dev" applies, and on that path _install re-reads the name out of
+          # the zip's own plugin.json before unpacking.
           BUILT_ZIP=$(ls /tmp/output/*.zip | head -1)
-          DEST="$RUNNER_TEMP/tender.zip"
+          DEST="$RUNNER_TEMP/Tender.zip"
           cp "$BUILT_ZIP" "$DEST"
           gh release upload "$TAG" \
             "$DEST" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# decky-romm-sync — Decky Loader Plugin
+# Tender — Decky Loader Plugin
 
 ## What This Is
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,4 +1,4 @@
-# CONTEXT.md — decky-romm-sync domain glossary
+# CONTEXT.md — Tender domain glossary
 
 This file is a glossary. It defines the canonical meaning of project-specific terms so that conversations, issues, PRs,
 and code stay aligned. It is _not_ a spec or design doc — implementation docs live in `docs/architecture/`, and
@@ -77,7 +77,7 @@ longer held the save-sync toggles or `device_name` (those moved to `settings.jso
 
 ### Cutover
 
-The hard cut from JSON state files to SQLite ([#784](https://github.com/danielcopper/decky-romm-sync/issues/784)) has
+The hard cut from JSON state files to SQLite ([#784](https://github.com/danielcopper/romm-tender/issues/784)) has
 landed. "Hard" means **SQLite started empty** — the JSON state was not migrated into it, and the JSON-era domain classes
 (`SaveSyncState`, `PluginState`) and `domain/save_state.py` were deleted in the same wave. Bucket-1 config
 (`settings.json`) and the change-detection markers were unaffected; only the relational save/library/playtime state was
@@ -157,9 +157,8 @@ Single-file vs multi-file is **read from `rom_dir` presence** — never re-deriv
 stored as a separate boolean ([ADR-0008](docs/adr/0008-rom-install-launch-file-and-rom-dir.md)). Migration moves
 `rom_dir` whole when set, else the file; uninstall removes `rom_dir` whole when set, else the file. A future per-file
 `RomFile[]` model — one row per physical file, each tagged with a RomM `category` (`game` / `dlc` / `update` / `mod` /
-…) — is the planned shape for the multi-file features in
-[#140](https://github.com/danielcopper/decky-romm-sync/issues/140) /
-[#129](https://github.com/danielcopper/decky-romm-sync/issues/129); it is an additive 1:N child of `rom_installs`
+…) — is the planned shape for the multi-file features in [#140](https://github.com/danielcopper/romm-tender/issues/140)
+/ [#129](https://github.com/danielcopper/romm-tender/issues/129); it is an additive 1:N child of `rom_installs`
 (deferred until those land), and `file_path` + `rom_dir` are its forward-compatible projection.
 
 ### Launchable install / no launch target
@@ -168,7 +167,7 @@ A downloaded ROM whose recorded **launch file** is something the system cannot a
 is still sealed inside the package), a bare disc track `.bin`. `detect_launch_file` ends in "largest file by size", so a
 download none of its format rules recognise still yields a `file_path`; `RomInstall.launchable` records whether that
 path is a real launch target, decided once at download-complete against the system's live ES-DE accept-list
-([#1652](https://github.com/danielcopper/decky-romm-sync/issues/1652)).
+([#1652](https://github.com/danielcopper/romm-tender/issues/1652)).
 
 "No launch target" is a statement about the **launch command**, never about the download. The files stay on disk, the
 install row is written, and uninstall works normally — installing the package by hand in the emulator is the documented

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ _Named after the railway car behind a steam locomotive, or the boat that shuttle
 > **Pre-1.0 (v0.x).** The feature set isn't complete yet. Save sync covers standard cartridge saves; the memory-card
 > systems — PlayStation, PS2, Dreamcast, GameCube, PSP, 3DS — don't sync their saves yet, and the
 > [support matrix](https://danielcopper.github.io/romm-tender/user-guide/save-sync-support-matrix/) has the per-system
-> detail. The [Decky Store](https://plugins.deckbrew.xyz/) listing comes with v1.0; until then it's a manual install.
+> detail.
 
 ---
 
@@ -85,26 +85,32 @@ _Named after the railway car behind a steam locomotive, or the boat that shuttle
 
 ## Installation
 
-<details>
-<summary><b>From the Decky Store</b> — not available yet</summary>
+**Not on the Decky store.** The store doesn't accept plugins whose code is written with AI assistance, and Tender's is —
+see _How this is built_ above. Install it from the URL below.
 
-> ⚠️ **Not available yet.** The plugin will be submitted to the [Decky Store](https://plugins.deckbrew.xyz/) with the
-> **v1.0** release. Until then, use the manual install below.
+```text
+https://github.com/danielcopper/romm-tender/releases/latest/download/Tender.zip
+```
 
-Once published, install it straight from Decky's built-in store — open the Quick Access Menu → **Decky** → store icon,
-search for **Tender**, and install. No Developer Mode required.
+<details open>
+<summary><b>Install from URL</b> — the recommended way</summary>
+
+Needs **Developer mode** in Decky Loader (Decky tab → gear icon → **General → Other** → toggle **Developer mode**).
+
+1. Decky settings → **Developer** tab → **Install Plugin from URL**
+2. Paste the URL above and install
+
+That URL always resolves to the newest release, so pasting it again is also how you update.
 
 </details>
 
-<details open>
-<summary><b>From ZIP or URL</b> — the current method</summary>
+<details>
+<summary><b>Install from ZIP</b></summary>
 
-This is the current method while v1.0 is in progress. It requires **Developer Mode** in Decky Loader (Decky settings →
-gear icon → toggle **Developer Mode**).
+Also needs **Developer mode**.
 
-1. Download the latest `tender.zip` from the [releases page](https://github.com/danielcopper/romm-tender/releases)
-2. In Decky settings → **Developer** tab → **Install Plugin from ZIP** (or **from URL** with the
-   [latest release link](https://github.com/danielcopper/romm-tender/releases/latest/download/tender.zip))
+1. Download the plugin's `.zip` asset from the [releases page](https://github.com/danielcopper/romm-tender/releases)
+2. Decky settings → **Developer** tab → **Install Plugin from ZIP File**
 
 </details>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ Only the latest release receives security fixes.
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in decky-romm-sync, please report it responsibly:
+If you discover a security vulnerability in Tender, please report it responsibly:
 
 1. **Do NOT open a public GitHub issue.**
 2. Use [GitHub Security Advisories](https://github.com/danielcopper/romm-tender/security/advisories/new) to report

--- a/docs/contributing/frontend-dev-loop.md
+++ b/docs/contributing/frontend-dev-loop.md
@@ -16,9 +16,10 @@ Three pieces line up:
   events on exactly two files per plugin: `dist/index.js` and `main.py`. On a match it reloads the plugin in place —
   backend subprocess restart plus a cache-busted frontend re-import (the plugin unmounts cleanly first, so router
   patches are removed and re-applied).
-- **The watcher is gated on a `debug` flag.** Hot reload only applies to plugins carrying `"debug"` in the `flags` array
-  of `plugin.json`. `mise run deploy` injects the flag into the **deployed** `plugin.json` only — it is never committed
-  to the repo copy, because the Decky plugin store rejects plugins that ship it.
+- **Reloading is gated on a `debug` flag.** The watcher itself runs on every device, but it only re-loads plugins
+  carrying `"debug"` in the `flags` array of `plugin.json`. `mise run deploy` injects the flag into the **deployed**
+  `plugin.json` only — it is never committed to the repo copy, because a release that shipped it would make every user's
+  device restart the plugin whenever its `dist/index.js` or `main.py` changed.
 
 ## One-time setup
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,8 +14,7 @@ library into Steam as Non-Steam shortcuts. Games launch through [RetroDECK](http
 
     The feature set isn't complete yet. Save sync covers standard cartridge saves; the memory-card systems —
     PlayStation, PS2, Dreamcast, GameCube, PSP, 3DS — don't sync their saves yet
-    ([support matrix](user-guide/save-sync-support-matrix.md)). The Decky Store listing comes with v1.0; until then
-    it's a manual install.
+    ([support matrix](user-guide/save-sync-support-matrix.md)).
 
 !!! info "How this is built"
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -27,28 +27,34 @@ Before installing the plugin, you need:
 
 ## Installation
 
-### From Decky's "Install Plugin From URL"
+**Not on the Decky store.** The store doesn't accept plugins whose code is written with AI assistance, and Tender's is —
+see [How this is built](../index.md). Install it from the URL below.
+
+### From Decky's "Install Plugin from URL"
 
 1. Open the Quick Access Menu (QAM) in Gaming Mode by pressing the **...** button
 2. Go to the Decky Loader tab (the plug icon) and open settings (gear icon)
-3. Under **General → Other**, enable **Developer Mode** — a new **Developer** tab appears in the sidebar
-4. Open the **Developer** tab and select **Install Plugin From URL**
+3. Under **General → Other**, enable **Developer mode** — a new **Developer** tab appears in the sidebar
+4. Open the **Developer** tab and select **Install Plugin from URL**
 5. Enter the direct URL to the release zip
 
-   This one always points at the newest release, so it needs no version number:
+   This one always points at the newest release, so it needs no version number — and pasting it again later is how you
+   update:
 
    ```text
-   https://github.com/danielcopper/romm-tender/releases/latest/download/tender.zip
+   https://github.com/danielcopper/romm-tender/releases/latest/download/Tender.zip
    ```
 
    To pin a specific version instead, name its tag:
 
    ```text
-   https://github.com/danielcopper/romm-tender/releases/download/tender-v{VERSION}/tender.zip
+   https://github.com/danielcopper/romm-tender/releases/download/tender-v{VERSION}/Tender.zip
    ```
 
-   Releases published before the rename use the older `decky-romm-sync-v{VERSION}/decky-romm-sync.zip` form; their links
-   keep working unchanged.
+   Every release from `tender-v0.31.0` on carries this asset — `tender-v0.31.0` itself published it as `tender.zip`, and
+   GitHub matches release-asset names case-insensitively, so the URL above still finds it. Most of the
+   `decky-romm-sync-v{VERSION}` releases before it published `decky-romm-sync.zip`; name that tag and that file for
+   those. Four have no asset at all: the three earliest and `v0.2.0`.
 
 6. Decky downloads and installs the plugin automatically — no restart needed
 
@@ -61,7 +67,7 @@ Any direct URL to the zip file works (GitHub releases, a self-hosted mirror, etc
 
 ### Manual installation (alternative)
 
-1. Download `tender.zip` from the [releases page](https://github.com/danielcopper/romm-tender/releases)
+1. Download the plugin's `.zip` asset from the [releases page](https://github.com/danielcopper/romm-tender/releases)
 2. Extract the zip to `~/homebrew/plugins/` on your device (via SSH, file manager, or USB)
 3. Restart Decky Loader — either reboot, or run `sudo systemctl restart plugin_loader` via SSH
 4. The plugin appears in your QAM under the Decky tab

--- a/mise.toml
+++ b/mise.toml
@@ -122,11 +122,14 @@ rsync -a --delete py_modules/ "$DEST/py_modules/"
 cp -f main.py plugin.json package.json "$DEST/"
 # Every local deploy is a dev deploy — release zips are packaged in CI
 # (release.yml builds with the Decky CLI straight from the repo checkout), so
-# this deployed copy never feeds a release. Injecting "debug" into the DEPLOYED
-# plugin.json turns on decky-loader's built-in hot-reload watcher for this
-# plugin (the watcher only acts on debug-flagged plugins). Never commit the
-# flag to the repo plugin.json — the Decky plugin store rejects plugins that
-# ship it. Idempotent: re-deploys don't duplicate the flag.
+# this deployed copy never feeds a release. decky-loader's file watcher runs on
+# every device — LIVE_RELOAD defaults to on and the shipped unit file sets no
+# value — but Loader.import_plugin re-loads only plugins carrying "debug" in
+# flags, and skips every other one. Injecting the flag into the DEPLOYED
+# plugin.json is what opts this plugin in. Never commit it to the repo
+# plugin.json: a release that shipped it would have every user's device restart
+# the plugin's backend and re-import its frontend whenever its dist/index.js
+# or main.py changed. Idempotent: re-deploys don't duplicate the flag.
 python3 - "$DEST/plugin.json" <<'PYEOF'
 import json
 import sys

--- a/plugin.json
+++ b/plugin.json
@@ -3,15 +3,5 @@
   "version": "0.31.0",
   "author": "danielcopper",
   "flags": [],
-  "api_version": 1,
-  "publish": {
-    "tags": [
-      "romm",
-      "rom-manager",
-      "retrodeck",
-      "emulation"
-    ],
-    "description": "Sync your self-hosted RomM library to Steam. Games appear as native shortcuts with cover art, metadata, and launch via RetroDECK. Includes ROM downloads, BIOS management, save file sync, and SteamGridDB artwork.",
-    "image": "https://raw.githubusercontent.com/danielcopper/romm-tender/main/assets/store_image.png"
-  }
+  "api_version": 1
 }

--- a/scripts/logo/README.md
+++ b/scripts/logo/README.md
@@ -26,10 +26,11 @@ look at a change before it lands.
 | `lockup.svg`, `lockup.png` (900px)                        | `assets/` — the banner at rest, light ground        |
 | `lockup-dark.svg`, `lockup-dark.png`                      | `assets/` — the banner at rest, dark ground         |
 | `lockup-animated.gif`, `lockup-animated-dark.gif` (600px) | `assets/` — the README banner                       |
-| `store_image.png` (1024px)                                | `assets/` — the Decky store pulls this one by URL   |
+| `store_image.png` (1024px)                                | `assets/` — the square mark, for previews and links |
 
-Everything ships twice except the lockup, which lands once: it is the README's banner, and the docs site draws its own
-header from the bare mark.
+Everything ships twice except the lockup and `store_image.png`, which land once. The lockup is the README's banner, and
+the docs site draws its own header from the bare mark; nothing renders `store_image.png` at all, so `assets/` is the
+only place it needs to be.
 
 Each lockup ships in two variants because one cannot serve both grounds: the mark's ink falls to roughly 1.3:1 against
 GitHub's dark canvas, so the dark variant sets the wordmark in the disc's blue instead. The README chooses between them

--- a/scripts/logo/build.py
+++ b/scripts/logo/build.py
@@ -182,7 +182,9 @@ INSTALL = {
     "lockup-animated.gif": ("assets/lockup-animated.gif",),
     "lockup-animated-dark.gif": ("assets/lockup-animated-dark.gif",),
 }
-# The Decky store pulls this one straight off the default branch by URL.
+# A 1024px square of the bare mark. Nothing renders it — no page, no manifest —
+# it is the copy to hand out wherever a link preview or a listing wants one
+# square image.
 STORE_IMAGE = ("logo-1024.png", "assets/store_image.png")
 
 


### PR DESCRIPTION
The Decky store does not accept plugins whose code is written with AI
assistance, and this one's is, so the store listing the README promised for
v1.0 is never coming. Install from URL takes its place, and the release asset
is renamed to Tender.zip for it.

The name matters on the update path rather than the install. Decky derives the
plugin name from the URL's last path segment and spends it on its "was this
already installed?" lookup — an exact match against each installed plugin.json's
"name". Lower-cased, that lookup misses: the previous copy is never uninstalled,
the new zip unpacks over it, stale files survive, and the plugin is appended to
Decky's pluginOrder a second time. The install itself succeeds either way,
because Install-from-URL sends no version and on that path the loader re-reads
the name out of the zip's own plugin.json before unpacking.

The README and the docs drop the store promise and document the URL route,
including that the same URL is how you update. GitHub matches release-asset
names case-insensitively, so the pinned-version URL reaches tender-v0.31.0's
lower-cased asset too; most of the older decky-romm-sync-v* releases published
the zip under the old name, and getting-started says how to reach those.

plugin.json loses its publish block: tags, description and image existed only
for the store submission and no other consumer reads them. assets/store_image.png
stays as the square mark render, with its description in the logo README
corrected to what it is now for.

Stale references to the old project name are corrected where they described the
present: the CLAUDE.md and CONTEXT.md titles, CONTEXT.md's issue links, the
SECURITY.md reporting line, and the bug-report template's log path, which now
names both folder names because both exist in the wild. That template also stops
pointing at a directory for Decky's own log — the loader configures no file
handler, so its output goes to the journal. ADRs and the changelog keep the old
name as frozen history.

The debug-flag warnings in mise.toml and the frontend dev-loop guide gave the
store's submission rules as their reason. The reason that still binds is a
different one: the loader's file watcher runs on every device regardless, and
the flag is what opts a plugin in to being re-loaded — backend restart plus
frontend re-import — whenever its dist/index.js or main.py changes.

