### PR TITLE
fix(qam): make four unreachable notices focus stops, and catch the next one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -646,11 +646,14 @@ Format: **invariant** — tier — enforced by.
   (`src/components/RomMGameInfoPanel.test.tsx`); the store side and every new write site on either are prompt-only,
   because a checker scoped to the store's own function bodies would be green on the case this rule was written for. The
   reasons behind the two writer mechanisms live at `writerForRom` and `RomBinding` — do not restate them here
-- **Every row a reader must be able to reach on a wide QAM page is a row Steam can focus — a toggle, a button, or a
+- **Every row a reader must be able to reach on a QAM page is a row Steam can focus — a toggle, a button, or a
   `Focusable` carrying an activate handler, including a table row with no action of its own, so the reader can walk the
-  table** — prompt-only — nothing checks it, and the frontend suite cannot see it: happy-dom has no nav tree, so a page
-  whose rows are unreachable renders exactly like one whose rows are not, and a mouse-driven dev loop never meets the
-  problem either. A region scrolls only by moving focus — Steam's plain `ScrollPanel` binds no gamepad direction — so an
+  table** — check + prompt-only — `tender/qam-focusable-row` checks the narrow syntactic slice where an `@decky/ui`
+  `Focusable` in the QAM module map has no self-focus prop, static focusable descendant, opaque child, or unknown
+  spread; focus order, runtime reachability, edge revelation, scrolling geometry, and controller behaviour remain
+  prompt-only. The frontend suite cannot see those runtime properties: happy-dom has no nav tree, so a page whose rows
+  are unreachable renders exactly like one whose rows are not, and a mouse-driven dev loop never meets the problem
+  either. A region scrolls only by moving focus — Steam's plain `ScrollPanel` binds no gamepad direction — so an
   unreachable row is also an unscrollable one, and everything below the fold is simply out of reach with a controller.
   The trap is that a bare `Focusable` is a container rather than a focus stop: the base panel sets `focusable` only from
   a caller prop or an `onActivate`/`onOKButton`, and `GetFocusable()` answers `"none"` for a node with neither and no

--- a/docs/architecture/qam-panel.md
+++ b/docs/architecture/qam-panel.md
@@ -125,11 +125,12 @@ rather than taking it. Plain text that only accompanies a row, a hint under a gr
 need not be reachable itself. This is what focus-driven scrolling costs: content nobody can focus cannot be scrolled to.
 
 The repository ESLint rule `tender/qam-focusable-row` checks one syntactic slice of that rule in the QAM modules listed
-above. A `Focusable` imported from `@decky/ui` must declare `onActivate`, `onOKButton`, or `focusable`, contain a static
-focus stop, or contain a child/spread whose focusability cannot be established statically. This catches an action-less
-row written as a static wrapper while leaving structural containers and opaque children alone. It does not check focus
-order, runtime reachability, edge revelation, scrolling geometry, or controller behaviour; those parts remain a device
-and review invariant.
+above. A `Focusable` imported from `@decky/ui` must declare `onActivate` or `onOKButton`, contain a static focus stop,
+or contain a child/spread whose focusability cannot be established statically. The matcher also recognises the
+underlying control's `focusable` prop, but `@decky/ui` does not expose that prop in `FocusableProps`, so authored
+TypeScript rows use an activate handler. This catches an action-less row written as a static wrapper while leaving
+structural containers and opaque children alone. It does not check focus order, runtime reachability, edge revelation,
+scrolling geometry, or controller behaviour; those parts remain a device and review invariant.
 
 **The one place a page cannot buy its way out of that is the content OUTSIDE its focusable rows**, and the frame handles
 it rather than each page: a heading, a counts line or a column header sitting over the topmost row, and a legend, a

--- a/docs/architecture/qam-panel.md
+++ b/docs/architecture/qam-panel.md
@@ -120,10 +120,16 @@ the rows inside it take focus directly and Steam scrolls the focused row into vi
 
 **Every row a reader must be able to reach is a focusable row.** A toggle, a button, or — where a table row carries no
 action of its own, so the reader can still walk the table — a `Focusable` with an `onActivate` handler. The handler is
-what makes it a stop: `FocusableProps` exposes no `focusable` prop, an activate handler is what sets one, and a bare
-`Focusable` is a container that passes focus on to its children rather than taking it. Plain text that only accompanies
-a row, a hint under a group, scrolls with its neighbours and need not be reachable itself. This is what focus-driven
-scrolling costs: content nobody can focus cannot be scrolled to.
+what makes the current action-less rows stops; a bare `Focusable` is a container that passes focus on to its children
+rather than taking it. Plain text that only accompanies a row, a hint under a group, scrolls with its neighbours and
+need not be reachable itself. This is what focus-driven scrolling costs: content nobody can focus cannot be scrolled to.
+
+The repository ESLint rule `tender/qam-focusable-row` checks one syntactic slice of that rule in the QAM modules listed
+above. A `Focusable` imported from `@decky/ui` must declare `onActivate`, `onOKButton`, or `focusable`, contain a static
+focus stop, or contain a child/spread whose focusability cannot be established statically. This catches an action-less
+row written as a static wrapper while leaving structural containers and opaque children alone. It does not check focus
+order, runtime reachability, edge revelation, scrolling geometry, or controller behaviour; those parts remain a device
+and review invariant.
 
 **The one place a page cannot buy its way out of that is the content OUTSIDE its focusable rows**, and the frame handles
 it rather than each page: a heading, a counts line or a column header sitting over the topmost row, and a legend, a

--- a/eslint-rules/qam-focusable-row.js
+++ b/eslint-rules/qam-focusable-row.js
@@ -1,0 +1,83 @@
+const SELF_FOCUS_PROPS = new Set(["focusable", "onActivate", "onOKButton"]);
+const NATIVE_FOCUS_ELEMENTS = new Set(["button", "input", "select", "textarea"]);
+
+function attributeName(attribute) {
+  return attribute.type === "JSXAttribute" && attribute.name.type === "JSXIdentifier" ? attribute.name.name : null;
+}
+
+function hasUnknownSpread(openingElement) {
+  return openingElement.attributes.some((attribute) => attribute.type === "JSXSpreadAttribute");
+}
+
+function hasSelfFocusProp(openingElement) {
+  return openingElement.attributes.some((attribute) => {
+    const name = attributeName(attribute);
+    return name !== null && SELF_FOCUS_PROPS.has(name);
+  });
+}
+
+function isNativeFocusElement(openingElement) {
+  if (openingElement.name.type !== "JSXIdentifier") return false;
+  const name = openingElement.name.name;
+  if (NATIVE_FOCUS_ELEMENTS.has(name)) return true;
+  if (name === "a") return openingElement.attributes.some((attribute) => attributeName(attribute) === "href");
+  return openingElement.attributes.some((attribute) => attributeName(attribute) === "tabIndex");
+}
+
+function childMayContainFocus(child, focusableBindings) {
+  if (child.type === "JSXText") return false;
+  if (child.type === "JSXSpreadChild") return true;
+  if (child.type === "JSXExpressionContainer") return child.expression.type !== "JSXEmptyExpression";
+  if (child.type === "JSXFragment") {
+    return child.children.some((nested) => childMayContainFocus(nested, focusableBindings));
+  }
+
+  const opening = child.openingElement;
+  if (hasUnknownSpread(opening) || hasSelfFocusProp(opening) || isNativeFocusElement(opening)) return true;
+
+  if (opening.name.type !== "JSXIdentifier") return true;
+  const name = opening.name.name;
+  if (name[0] === name[0]?.toUpperCase() && !focusableBindings.has(name)) return true;
+
+  return child.children.some((nested) => childMayContainFocus(nested, focusableBindings));
+}
+
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "require statically empty QAM Focusable rows to declare themselves as focus stops",
+    },
+    schema: [],
+    messages: {
+      unreachableRow:
+        "This QAM Focusable is neither a declared focus stop nor a container with a statically identifiable focusable descendant.",
+    },
+  },
+  create(context) {
+    const focusableBindings = new Set();
+
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value !== "@decky/ui") return;
+        for (const specifier of node.specifiers) {
+          if (
+            specifier.type === "ImportSpecifier" &&
+            specifier.imported.type === "Identifier" &&
+            specifier.imported.name === "Focusable"
+          ) {
+            focusableBindings.add(specifier.local.name);
+          }
+        }
+      },
+      JSXElement(node) {
+        const opening = node.openingElement;
+        if (opening.name.type !== "JSXIdentifier" || !focusableBindings.has(opening.name.name)) return;
+        if (hasUnknownSpread(opening) || hasSelfFocusProp(opening)) return;
+        if (node.children.some((child) => childMayContainFocus(child, focusableBindings))) return;
+
+        context.report({ node: opening, messageId: "unreachableRow" });
+      },
+    };
+  },
+};

--- a/eslint-rules/qam-focusable-row.js
+++ b/eslint-rules/qam-focusable-row.js
@@ -10,6 +10,7 @@ function unwrapExpression(expression) {
     expression.type === "ChainExpression" ||
     expression.type === "TSAsExpression" ||
     expression.type === "TSNonNullExpression" ||
+    expression.type === "TSSatisfiesExpression" ||
     expression.type === "TSTypeAssertion"
   ) {
     expression = expression.expression;
@@ -53,9 +54,14 @@ function isNativeFocusElement(openingElement) {
 
 function expressionMayContainFocus(expression, isDeckyFocusable) {
   expression = unwrapExpression(expression);
-  if (expression.type === "Literal" || expression.type === "ObjectExpression") return false;
-  if (expression.type === "TemplateLiteral") {
-    return expression.expressions.some((nested) => expressionMayContainFocus(nested, isDeckyFocusable));
+  // A template literal coerces every substitution to text, so an opaque one cannot
+  // put a focusable node in the child position — unlike an opaque identifier, which can.
+  if (
+    expression.type === "Literal" ||
+    expression.type === "ObjectExpression" ||
+    expression.type === "TemplateLiteral"
+  ) {
+    return false;
   }
   if (expression.type === "JSXElement" || expression.type === "JSXFragment") {
     return childMayContainFocus(expression, isDeckyFocusable);

--- a/eslint-rules/qam-focusable-row.js
+++ b/eslint-rules/qam-focusable-row.js
@@ -5,14 +5,41 @@ function attributeName(attribute) {
   return attribute.type === "JSXAttribute" && attribute.name.type === "JSXIdentifier" ? attribute.name.name : null;
 }
 
-function hasUnknownSpread(openingElement) {
-  return openingElement.attributes.some((attribute) => attribute.type === "JSXSpreadAttribute");
+function unwrapExpression(expression) {
+  while (
+    expression.type === "ChainExpression" ||
+    expression.type === "TSAsExpression" ||
+    expression.type === "TSNonNullExpression" ||
+    expression.type === "TSTypeAssertion"
+  ) {
+    expression = expression.expression;
+  }
+  return expression;
 }
 
-function hasSelfFocusProp(openingElement) {
+function propertyName(property) {
+  if (property.computed && property.key.type !== "Literal") return null;
+  if (property.key.type === "Identifier") return property.key.name;
+  if (property.key.type === "Literal" && typeof property.key.value === "string") return property.key.value;
+  return null;
+}
+
+function spreadMayProvideFocus(argument) {
+  const expression = unwrapExpression(argument);
+  if (expression.type !== "ObjectExpression") return true;
+
+  return expression.properties.some((property) => {
+    if (property.type === "SpreadElement") return spreadMayProvideFocus(property.argument);
+    const name = propertyName(property);
+    return name === null || SELF_FOCUS_PROPS.has(name);
+  });
+}
+
+function hasPossibleSelfFocus(openingElement) {
   return openingElement.attributes.some((attribute) => {
     const name = attributeName(attribute);
-    return name !== null && SELF_FOCUS_PROPS.has(name);
+    if (name !== null) return SELF_FOCUS_PROPS.has(name);
+    return attribute.type === "JSXSpreadAttribute" && spreadMayProvideFocus(attribute.argument);
   });
 }
 
@@ -24,22 +51,66 @@ function isNativeFocusElement(openingElement) {
   return openingElement.attributes.some((attribute) => attributeName(attribute) === "tabIndex");
 }
 
-function childMayContainFocus(child, focusableBindings) {
+function expressionMayContainFocus(expression, isDeckyFocusable) {
+  expression = unwrapExpression(expression);
+  if (expression.type === "Literal" || expression.type === "ObjectExpression") return false;
+  if (expression.type === "TemplateLiteral") {
+    return expression.expressions.some((nested) => expressionMayContainFocus(nested, isDeckyFocusable));
+  }
+  if (expression.type === "JSXElement" || expression.type === "JSXFragment") {
+    return childMayContainFocus(expression, isDeckyFocusable);
+  }
+  if (expression.type === "ArrayExpression") {
+    return expression.elements.some(
+      (element) =>
+        element !== null &&
+        (element.type === "SpreadElement" || expressionMayContainFocus(element, isDeckyFocusable)),
+    );
+  }
+  if (expression.type === "ConditionalExpression") {
+    return (
+      expressionMayContainFocus(expression.consequent, isDeckyFocusable) ||
+      expressionMayContainFocus(expression.alternate, isDeckyFocusable)
+    );
+  }
+  if (expression.type === "SequenceExpression") {
+    const last = expression.expressions.at(-1);
+    return last === undefined || expressionMayContainFocus(last, isDeckyFocusable);
+  }
+  if (expression.type === "BinaryExpression" || expression.type === "UnaryExpression") return false;
+  return true;
+}
+
+function childMayContainFocus(child, isDeckyFocusable) {
   if (child.type === "JSXText") return false;
   if (child.type === "JSXSpreadChild") return true;
-  if (child.type === "JSXExpressionContainer") return child.expression.type !== "JSXEmptyExpression";
+  if (child.type === "JSXExpressionContainer") {
+    return (
+      child.expression.type !== "JSXEmptyExpression" && expressionMayContainFocus(child.expression, isDeckyFocusable)
+    );
+  }
   if (child.type === "JSXFragment") {
-    return child.children.some((nested) => childMayContainFocus(nested, focusableBindings));
+    return child.children.some((nested) => childMayContainFocus(nested, isDeckyFocusable));
   }
 
   const opening = child.openingElement;
-  if (hasUnknownSpread(opening) || hasSelfFocusProp(opening) || isNativeFocusElement(opening)) return true;
+  if (hasPossibleSelfFocus(opening) || isNativeFocusElement(opening)) return true;
 
   if (opening.name.type !== "JSXIdentifier") return true;
   const name = opening.name.name;
-  if (name[0] === name[0]?.toUpperCase() && !focusableBindings.has(name)) return true;
+  if (name[0] === name[0]?.toUpperCase() && !isDeckyFocusable(opening)) return true;
 
-  return child.children.some((nested) => childMayContainFocus(nested, focusableBindings));
+  return child.children.some((nested) => childMayContainFocus(nested, isDeckyFocusable));
+}
+
+function resolveVariable(sourceCode, node, name) {
+  let scope = sourceCode.getScope(node);
+  while (scope !== null) {
+    const variable = scope.set.get(name);
+    if (variable !== undefined) return variable;
+    scope = scope.upper;
+  }
+  return undefined;
 }
 
 export default {
@@ -55,7 +126,12 @@ export default {
     },
   },
   create(context) {
+    const sourceCode = context.sourceCode;
     const focusableBindings = new Set();
+    const isDeckyFocusable = (openingElement) => {
+      if (openingElement.name.type !== "JSXIdentifier") return false;
+      return focusableBindings.has(resolveVariable(sourceCode, openingElement, openingElement.name.name));
+    };
 
     return {
       ImportDeclaration(node) {
@@ -66,15 +142,15 @@ export default {
             specifier.imported.type === "Identifier" &&
             specifier.imported.name === "Focusable"
           ) {
-            focusableBindings.add(specifier.local.name);
+            for (const variable of sourceCode.getDeclaredVariables(specifier)) focusableBindings.add(variable);
           }
         }
       },
       JSXElement(node) {
         const opening = node.openingElement;
-        if (opening.name.type !== "JSXIdentifier" || !focusableBindings.has(opening.name.name)) return;
-        if (hasUnknownSpread(opening) || hasSelfFocusProp(opening)) return;
-        if (node.children.some((child) => childMayContainFocus(child, focusableBindings))) return;
+        if (!isDeckyFocusable(opening)) return;
+        if (hasPossibleSelfFocus(opening)) return;
+        if (node.children.some((child) => childMayContainFocus(child, isDeckyFocusable))) return;
 
         context.report({ node: opening, messageId: "unreachableRow" });
       },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,7 @@ import importX, { createNodeResolver } from "eslint-plugin-import-x";
 import { createTypeScriptImportResolver } from "eslint-import-resolver-typescript";
 import eslintConfigPrettier from "eslint-config-prettier";
 import globals from "globals";
+import qamFocusableRow from "./eslint-rules/qam-focusable-row.js";
 
 export default tseslint.config(
   // `.venv` (local uv/mise Python env) and `site` (local mkdocs build output) are
@@ -80,6 +81,22 @@ export default tseslint.config(
           ],
         },
       ],
+    },
+  },
+  {
+    files: [
+      "src/index.tsx",
+      "src/components/{MainPage,SyncPage,LibraryPage,SettingsPage,DangerZone,RemovedGamesCleanup,DownloadQueue,SessionBudgetBanner}.tsx",
+      "src/components/{qam,sync,library,settings}/**/*.tsx",
+    ],
+    ignores: ["src/**/*.test.tsx", "src/components/**/*Modal.tsx"],
+    plugins: {
+      tender: {
+        rules: { "qam-focusable-row": qamFocusableRow },
+      },
+    },
+    rules: {
+      "tender/qam-focusable-row": "error",
     },
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -86,7 +86,8 @@ export default tseslint.config(
   {
     files: [
       "src/index.tsx",
-      "src/components/{MainPage,SyncPage,LibraryPage,SettingsPage,DangerZone,RemovedGamesCleanup,DownloadQueue,SessionBudgetBanner}.tsx",
+      "src/components/{MainPage,SyncPage,LibraryPage,SettingsPage,DangerZone,RemovedGamesCleanup,DownloadQueue}.tsx",
+      "src/components/{SessionBudgetBanner,MigrationBlockedPage,SettingsResetBanner,PlaytimeScopeBanner,DownloadProgressRow,LoadingRow}.tsx",
       "src/components/{qam,sync,library,settings}/**/*.tsx",
     ],
     ignores: ["src/**/*.test.tsx", "src/components/**/*Modal.tsx"],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -90,6 +90,10 @@ export default tseslint.config(
       "src/components/{SessionBudgetBanner,MigrationBlockedPage,SettingsResetBanner,PlaytimeScopeBanner,DownloadProgressRow,LoadingRow}.tsx",
       "src/components/{qam,sync,library,settings}/**/*.tsx",
     ],
+    // A test renders no row a reader walks, and a modal is not a panel row at all —
+    // it mounts in Steam's `ModalRoot`, outside the region that scrolls by focus.
+    // Neither exemption is load-bearing today: with both removed the rule still
+    // reports nothing across `src/**/*.tsx`.
     ignores: ["src/**/*.test.tsx", "src/components/**/*Modal.tsx"],
     plugins: {
       tender: {

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -596,9 +596,9 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         {retrodeckBanner && (
           <PanelSectionRow>
             {/* WarningCard is shared with the game-detail context, so it carries no
-                focusable child of its own — wrap it here (QAM-only) so gamepad focus
-                can reach it. */}
-            <Focusable>
+                focus contract of its own. This QAM-only wrapper's no-op activation
+                makes the notice itself a stop for focus-driven scrolling. */}
+            <Focusable onActivate={() => {}}>
               <WarningCard title={retrodeckBanner.title} message={retrodeckBanner.message} compact />
             </Focusable>
           </PanelSectionRow>
@@ -753,7 +753,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         {saveSortMigration.pending && (
           <>
             <PanelSectionRow>
-              <Focusable>
+              <Focusable onActivate={() => {}}>
                 <div
                   style={{
                     padding: "8px 12px",
@@ -784,7 +784,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
         {lastRunPaused && (
           <>
             <PanelSectionRow>
-              <Focusable>
+              <Focusable onActivate={() => {}}>
                 <div
                   data-testid="sync-paused-notice"
                   style={{

--- a/src/components/SessionBudgetBanner.tsx
+++ b/src/components/SessionBudgetBanner.tsx
@@ -45,10 +45,9 @@ export function memoryLevelColor(rssKb: number, warnKb: number, ceilingKb: numbe
 function bannerCard(accent: string, background: string, testId: string, title: string, body: string): ReactNode {
   return (
     <PanelSectionRow>
-      {/* Focusable so Steam's gamepad focus engine can reach and scroll the banner
-          into view — this component is QAM-only. The card div keeps the testId +
-          styling; the wrapper adds only the focus highlight. */}
-      <Focusable>
+      {/* This component is QAM-only. The no-op activation makes the banner a
+          focus stop for scrolling; the card div keeps the testId and styling. */}
+      <Focusable onActivate={() => {}}>
         <div
           data-testid={testId}
           style={{

--- a/src/eslintQamFocusable.test.ts
+++ b/src/eslintQamFocusable.test.ts
@@ -25,6 +25,7 @@ const FIXTURES: [dir: string, name: string, source: string][] = [
 export const Activate = () => <Focusable onActivate={() => {}}><div>Reachable</div></Focusable>;
 export const OkButton = () => <Focusable onOKButton={() => {}}><div>Reachable</div></Focusable>;
 export const Explicit = () => <Focusable focusable={true}><div>Reachable</div></Focusable>;
+export const StaticSpread = () => <Focusable {...{ onActivate: () => {} }}><div>Reachable</div></Focusable>;
 export const Descendant = () => <Focusable><div><Focusable onActivate={() => {}}>Reachable</Focusable></div></Focusable>;
 `,
   ],
@@ -41,6 +42,23 @@ export const Spread = (props: { onActivate?: () => void }) => <Focusable {...pro
     QAM_FIXTURE_DIR,
     "localFocusable.tsx",
     "const Focusable = ({ children }: { children: string }) => <div>{children}</div>;\nexport const Local = () => <Focusable>Unrelated</Focusable>;\n",
+  ],
+  [
+    QAM_FIXTURE_DIR,
+    "shadowedFocusable.tsx",
+    `import type { ComponentType, PropsWithChildren } from "react";
+import { Focusable } from "@decky/ui";
+export const Imported = () => <Focusable onActivate={() => {}}>Reachable</Focusable>;
+export const Local = ({ Focusable }: { Focusable: ComponentType<PropsWithChildren> }) => <Focusable>Unrelated</Focusable>;
+`,
+  ],
+  [
+    QAM_FIXTURE_DIR,
+    "staticExpressions.tsx",
+    `import { Focusable } from "@decky/ui";
+export const Literal = () => <Focusable>{"Unreadable"}</Focusable>;
+export const StaticSpread = () => <Focusable {...{ className: "row" }}><div>Unreadable</div></Focusable>;
+`,
   ],
   [
     OFF_SCOPE_FIXTURE_DIR,
@@ -79,7 +97,7 @@ describe("QAM Focusable row rule", () => {
     expect(await ruleMessages(path.join(QAM_FIXTURE_DIR, "aliasedBadRow.tsx"))).toEqual([RULE_ID]);
   });
 
-  it("accepts every self-focus prop and a focusable descendant through wrappers", async () => {
+  it("accepts activation props, the lower-level focusable syntax, and a focusable descendant", async () => {
     expect(await ruleMessages(path.join(QAM_FIXTURE_DIR, "validRows.tsx"))).toEqual([]);
   });
 
@@ -89,15 +107,38 @@ describe("QAM Focusable row rule", () => {
 
   it("ignores an unrelated local component named Focusable", async () => {
     expect(await ruleMessages(path.join(QAM_FIXTURE_DIR, "localFocusable.tsx"))).toEqual([]);
+    expect(await ruleMessages(path.join(QAM_FIXTURE_DIR, "shadowedFocusable.tsx"))).toEqual([]);
+  });
+
+  it("reports statically known non-focusable expressions and spreads", async () => {
+    expect(await ruleMessages(path.join(QAM_FIXTURE_DIR, "staticExpressions.tsx"))).toEqual([RULE_ID, RULE_ID]);
   });
 
   it("does not impose the QAM rule on game-detail components", async () => {
     expect(await ruleMessages(path.join(OFF_SCOPE_FIXTURE_DIR, "gameDetailRoute.tsx"))).toEqual([]);
   });
 
-  it("covers narrow QAM pages without reaching game-detail routes", async () => {
-    expect(await configuredRule(path.join(process.cwd(), "src", "components", "MainPage.tsx"))).toEqual([2]);
-    expect(await configuredRule(path.join(process.cwd(), "src", "components", "DownloadQueue.tsx"))).toEqual([2]);
+  it("covers every QAM page root and shared QAM-only module without reaching game-detail routes", async () => {
+    const qamFiles = [
+      "MainPage.tsx",
+      "SyncPage.tsx",
+      "LibraryPage.tsx",
+      "SettingsPage.tsx",
+      "DangerZone.tsx",
+      "RemovedGamesCleanup.tsx",
+      "DownloadQueue.tsx",
+      "SessionBudgetBanner.tsx",
+      "MigrationBlockedPage.tsx",
+      "SettingsResetBanner.tsx",
+      "PlaytimeScopeBanner.tsx",
+      "DownloadProgressRow.tsx",
+      "LoadingRow.tsx",
+    ];
+    await Promise.all(
+      qamFiles.map(async (file) => {
+        expect(await configuredRule(path.join(process.cwd(), "src", "components", file))).toEqual([2]);
+      }),
+    );
     expect(await configuredRule(path.join(process.cwd(), "src", "components", "CustomPlayButton.tsx"))).toBeUndefined();
   });
 }, 60_000);

--- a/src/eslintQamFocusable.test.ts
+++ b/src/eslintQamFocusable.test.ts
@@ -56,8 +56,11 @@ export const Local = ({ Focusable }: { Focusable: ComponentType<PropsWithChildre
     QAM_FIXTURE_DIR,
     "staticExpressions.tsx",
     `import { Focusable } from "@decky/ui";
+const value = "row";
 export const Literal = () => <Focusable>{"Unreadable"}</Focusable>;
 export const StaticSpread = () => <Focusable {...{ className: "row" }}><div>Unreadable</div></Focusable>;
+export const Template = () => <Focusable>{\`Unreadable \${value}\`}</Focusable>;
+export const Satisfies = () => <Focusable {...({ className: value } satisfies Record<string, string>)}><div>Unreadable</div></Focusable>;
 `,
   ],
   [
@@ -111,7 +114,12 @@ describe("QAM Focusable row rule", () => {
   });
 
   it("reports statically known non-focusable expressions and spreads", async () => {
-    expect(await ruleMessages(path.join(QAM_FIXTURE_DIR, "staticExpressions.tsx"))).toEqual([RULE_ID, RULE_ID]);
+    expect(await ruleMessages(path.join(QAM_FIXTURE_DIR, "staticExpressions.tsx"))).toEqual([
+      RULE_ID,
+      RULE_ID,
+      RULE_ID,
+      RULE_ID,
+    ]);
   });
 
   it("does not impose the QAM rule on game-detail components", async () => {

--- a/src/eslintQamFocusable.test.ts
+++ b/src/eslintQamFocusable.test.ts
@@ -1,0 +1,103 @@
+import { ESLint } from "eslint";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const QAM_FIXTURE_DIR = path.join(process.cwd(), "src", "components", "qam", "__eslint_fixtures__");
+const OFF_SCOPE_FIXTURE_DIR = path.join(process.cwd(), "src", "components", "__eslint_fixtures__");
+const RULE_ID = "tender/qam-focusable-row";
+
+const FIXTURES: [dir: string, name: string, source: string][] = [
+  [
+    QAM_FIXTURE_DIR,
+    "badRow.tsx",
+    'import { Focusable } from "@decky/ui";\nexport const BadRow = () => <Focusable><div>Unreadable</div></Focusable>;\n',
+  ],
+  [
+    QAM_FIXTURE_DIR,
+    "aliasedBadRow.tsx",
+    'import { Focusable as DeckyFocusable } from "@decky/ui";\nexport const BadRow = () => <DeckyFocusable><span>Unreadable</span></DeckyFocusable>;\n',
+  ],
+  [
+    QAM_FIXTURE_DIR,
+    "validRows.tsx",
+    `import { Focusable } from "@decky/ui";
+export const Activate = () => <Focusable onActivate={() => {}}><div>Reachable</div></Focusable>;
+export const OkButton = () => <Focusable onOKButton={() => {}}><div>Reachable</div></Focusable>;
+export const Explicit = () => <Focusable focusable={true}><div>Reachable</div></Focusable>;
+export const Descendant = () => <Focusable><div><Focusable onActivate={() => {}}>Reachable</Focusable></div></Focusable>;
+`,
+  ],
+  [
+    QAM_FIXTURE_DIR,
+    "conservativeRows.tsx",
+    `import type { ReactNode } from "react";
+import { Focusable } from "@decky/ui";
+export const Dynamic = ({ children }: { children: ReactNode }) => <Focusable>{children}</Focusable>;
+export const Spread = (props: { onActivate?: () => void }) => <Focusable {...props}><div>Maybe reachable</div></Focusable>;
+`,
+  ],
+  [
+    QAM_FIXTURE_DIR,
+    "localFocusable.tsx",
+    "const Focusable = ({ children }: { children: string }) => <div>{children}</div>;\nexport const Local = () => <Focusable>Unrelated</Focusable>;\n",
+  ],
+  [
+    OFF_SCOPE_FIXTURE_DIR,
+    "gameDetailRoute.tsx",
+    'import { Focusable } from "@decky/ui";\nexport const GameDetail = () => <Focusable><div>Outside QAM</div></Focusable>;\n',
+  ],
+];
+
+async function ruleMessages(file: string): Promise<string[]> {
+  const results = await new ESLint({ cwd: process.cwd() }).lintFiles([file]);
+  return results.flatMap((result) => result.messages.map((message) => message.ruleId ?? "<fatal>"));
+}
+
+async function configuredRule(file: string): Promise<unknown> {
+  const config = await new ESLint({ cwd: process.cwd() }).calculateConfigForFile(file);
+  return config?.rules?.[RULE_ID];
+}
+
+describe("QAM Focusable row rule", () => {
+  beforeAll(async () => {
+    await mkdir(QAM_FIXTURE_DIR, { recursive: true });
+    await mkdir(OFF_SCOPE_FIXTURE_DIR, { recursive: true });
+    await Promise.all(FIXTURES.map(([dir, name, source]) => writeFile(path.join(dir, name), source, "utf8")));
+  });
+
+  afterAll(async () => {
+    await rm(QAM_FIXTURE_DIR, { recursive: true, force: true });
+    await rm(OFF_SCOPE_FIXTURE_DIR, { recursive: true, force: true });
+  });
+
+  it("reports a static row without a focus stop", async () => {
+    expect(await ruleMessages(path.join(QAM_FIXTURE_DIR, "badRow.tsx"))).toEqual([RULE_ID]);
+  });
+
+  it("tracks an aliased Decky Focusable import", async () => {
+    expect(await ruleMessages(path.join(QAM_FIXTURE_DIR, "aliasedBadRow.tsx"))).toEqual([RULE_ID]);
+  });
+
+  it("accepts every self-focus prop and a focusable descendant through wrappers", async () => {
+    expect(await ruleMessages(path.join(QAM_FIXTURE_DIR, "validRows.tsx"))).toEqual([]);
+  });
+
+  it("accepts dynamic children and unknown spreads conservatively", async () => {
+    expect(await ruleMessages(path.join(QAM_FIXTURE_DIR, "conservativeRows.tsx"))).toEqual([]);
+  });
+
+  it("ignores an unrelated local component named Focusable", async () => {
+    expect(await ruleMessages(path.join(QAM_FIXTURE_DIR, "localFocusable.tsx"))).toEqual([]);
+  });
+
+  it("does not impose the QAM rule on game-detail components", async () => {
+    expect(await ruleMessages(path.join(OFF_SCOPE_FIXTURE_DIR, "gameDetailRoute.tsx"))).toEqual([]);
+  });
+
+  it("covers narrow QAM pages without reaching game-detail routes", async () => {
+    expect(await configuredRule(path.join(process.cwd(), "src", "components", "MainPage.tsx"))).toEqual([2]);
+    expect(await configuredRule(path.join(process.cwd(), "src", "components", "DownloadQueue.tsx"))).toEqual([2]);
+    expect(await configuredRule(path.join(process.cwd(), "src", "components", "CustomPlayButton.tsx"))).toBeUndefined();
+  });
+}, 60_000);


### PR DESCRIPTION
Three notices on Main and the session-budget banner were wrapped in a bare `Focusable` so gamepad focus could reach
them. It could not: the base panel makes a node a focus stop only from a `focusable` prop or an
`onActivate`/`onOKButton` handler, and `GetFocusable()` answers `"none"` for a node with neither and no focusable
child. A region scrolls only by moving focus, so those four notices were unscrollable as well — everything below them
was out of reach with a controller. They now carry a no-op activation, the shape the Platforms detail row already uses
for a row with no action of its own, and the comments above them say what the wrapper actually does rather than what it
was meant to do.

The wrong version and the right version differ by one prop and look identical in review, and nothing here could tell
them apart: happy-dom has no nav tree, so a page whose rows are unreachable renders exactly like one whose rows are
not, and a mouse-driven dev loop never meets the problem. `tender/qam-focusable-row` now reports a `Focusable`
imported from `@decky/ui` that carries no self-focus prop and holds no statically identifiable focusable descendant.
It runs over the QAM module map — the page roots, the QAM-only shared modules, and the `qam`, `sync`, `library` and
`settings` trees — and not over game-detail routes, where `Focusable` is legitimately a layout container and the rule
would force no-op handlers on it. Opaque children and unknown spreads are left alone; a template child and a
`satisfies`-wrapped object spread are not opaque, and are reported.

The rule proves itself against known-bad fixtures linted through the real flat config, the way the three
import-direction rules already do. A focus rule that silently stopped reporting would be worse than no rule, because
the register would then claim a tier it does not have.

The register entry stays `prompt-only` and gains a sentence naming the slice a check now carries. Focus order, entry
focus, edge revelation, and whether the panel and the reader agree on which element is topmost are runtime properties
of the real panel and remain device-only.

Closes #1842
