### PR TITLE
feat(qam): a Settings page of five sections, and one table for every pane

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -875,6 +875,22 @@ Format: **invariant** — tier — enforced by.
   the suite is blind to it for the same reason — a page whose only control is a library's length below the point it
   opens at renders exactly like one whose control is a press away. Detail: `docs/architecture/qam-panel.md`, "Building
   blocks"
+- **A list-and-detail page opens on the row it was opened WITH, not on its first row — because on that layout focus
+  selects, so entry focus landing anywhere selects what it lands on** — test + prompt-only — `ListDetail.test.tsx` pins
+  the mark and that it moves with the selection, `WidePage.test.tsx` pins that the frame asks for the declared stop, and
+  both use a **non-first** row deliberately. **The rule spans three modules and nothing joins them**:
+  `utils/entryFocus.ts` owns `ENTRY_STOP_ATTR` and `pageEntryStop`, `qam/WidePage.tsx` places entry focus through it
+  rather than through `firstBodyStop`, and `qam/ListDetail.tsx` marks its selected row — plus whatever page passes a
+  starting selection at all, `SettingsPage` today. A fourth wide page that opens on a non-first row and forgets the mark
+  selects its first row instead, and every test still passes. **The end to end is unreachable here**: happy-dom performs
+  no layout and does not reproduce Steam's focus resolution, so what the suite pins is the declaration and the finder,
+  never the press. Only a controller confirms it. **What hid this for a whole review round is the shape of the failure,
+  not its size**: Main has three notices that name a section, and the one naming the FIRST section keeps working, so a
+  reader checking Open Connections sees the feature working while Open Controller and Open Save Sync both land on
+  Connections. A check that exercises the first row proves nothing about the rule. The mark sits on a
+  `display: contents` wrapper AROUND each row rather than on the row, and that is load-bearing rather than stylistic:
+  `pageEntryStop` calls `firstBodyStop(declared)`, which searches DESCENDANTS — a mark on the row itself finds no
+  candidate inside it, falls back to the first row, and ships the defect under a comment saying it does not
 
 When a change applies a guard / sanitize / backup / grouping pattern, sweep for sibling sites of the same pattern — the
 register is what that sweep checks against.

--- a/docs/architecture/qam-panel.md
+++ b/docs/architecture/qam-panel.md
@@ -179,7 +179,7 @@ does not say it owns its regions. A tabbed body gets none from the frame, and ne
 | Main            | 348   | notices, status, the conditional slot, the download summary, the menu                                         | as described                                                                      |
 | Sync            | 854   | preview as a table, the run as a plan, Skip preview, Force Full Sync, Steam memory, session budget, last runs | as described; the import choice (#1364) is the one thing still to come            |
 | Library         | 854   | Platforms as list and detail (sync, core, BIOS files, removal); Collections as filter and list                | Platforms is built; Collections still carries the narrow page's controls and list |
-| Settings        | 854   | five sections, list and detail                                                                                | narrow; eight sections stacked                                                    |
+| Settings        | 854   | five sections, list and detail                                                                                | as described; RetroAchievements has no sign-in to hold yet (#1627)                |
 | Data Management | 854   | five library-wide operations, list and detail                                                                 | narrow; opens the cleanup in a modal                                              |
 | Downloads       | 348   | the queue with its controls                                                                                   | unchanged                                                                         |
 
@@ -188,22 +188,26 @@ BIOS files are in Library › Platforms, and the value, the router branch and th
 
 The Sync page opens from the menu, from the conditional slot while there is something in it, and from **Open Sync** on
 the paused-run notice; Downloads opens from **View All** in the download summary, which is shown only while the queue is
-not empty. A notice can carry a door of its own — **Go to Settings** on the save-sorting notice is the other one — but a
-notice and the slot are both there only while their condition is, so the menu is the navigation a reader can go looking
-for. Every page but Main opens with a **Back** chip, which returns to Main. The chip shares its line with the page title
-— one row, not the three a full-width button plus a title line used to cost, which on the Deck's body is most of what a
-detail pane has to spend. Back is also on **B**, and the binding lives in the panel's router (`src/index.tsx`) rather
-than on a page: one `Focusable` with `onCancelButton` wraps the mounted content **only while `page` is not `main`**, so
-every sub-page — wide and narrow — answers B from wherever focus sits, and Main answers nothing, so Decky's own B still
-leaves the plugin. That condition is what makes taking B safe: the escape route is never removed, it is exactly as far
-away as the user walked in, and the last press is never swallowed. Steam already prints "B ZURÜCK" in its footer legend,
-which this makes true rather than misleading, so no legend entry of ours is needed. The chip stays as the discoverable
-half and as the mouse path, and it carries **Steam's own B glyph** — drawn for the controller in the user's hands, so it
-is ○ on a PlayStation pad and the swapped face button under a Nintendo layout. `@decky/ui` does not re-export that
-component, so `src/utils/deckyUiInternals.ts` reaches it by a module probe and types it as possibly absent; the chip
-falls back to its chevron the day the probe misses. The button number it passes is Steam's own action-button enum
-(`A=0, B=1, X=2, Y=3`), **not** `@decky/ui`'s `GamepadButton`, where 1 is A — the two disagree on every value, and the
-wrong one draws the wrong glyph without failing.
+not empty. A notice can carry a door of its own, and three of them name a Settings SECTION rather than the page — **Open
+Controller**, **Open Save Sync**, **Open Connections** — but a notice and the slot are both there only while their
+condition is, so the menu is the navigation a reader can go looking for. A target is a page id, or
+`{ page: "settings", section }` for those three (`src/types/navigation.ts`); the section rides on the page rather than
+beside it, so no target can pair a section with a page that has none, and the router (`src/index.tsx`) stays the only
+thing that decides what is mounted. A navigation naming no section opens Settings on its first, exactly as the menu's
+own entry does. Every page but Main opens with a **Back** chip, which returns to Main. The chip shares its line with the
+page title — one row, not the three a full-width button plus a title line used to cost, which on the Deck's body is most
+of what a detail pane has to spend. Back is also on **B**, and the binding lives in the panel's router (`src/index.tsx`)
+rather than on a page: one `Focusable` with `onCancelButton` wraps the mounted content **only while `page` is not
+`main`**, so every sub-page — wide and narrow — answers B from wherever focus sits, and Main answers nothing, so Decky's
+own B still leaves the plugin. That condition is what makes taking B safe: the escape route is never removed, it is
+exactly as far away as the user walked in, and the last press is never swallowed. Steam already prints "B ZURÜCK" in its
+footer legend, which this makes true rather than misleading, so no legend entry of ours is needed. The chip stays as the
+discoverable half and as the mouse path, and it carries **Steam's own B glyph** — drawn for the controller in the user's
+hands, so it is ○ on a PlayStation pad and the swapped face button under a Nintendo layout. `@decky/ui` does not
+re-export that component, so `src/utils/deckyUiInternals.ts` reaches it by a module probe and types it as possibly
+absent; the chip falls back to its chevron the day the probe misses. The button number it passes is Steam's own
+action-button enum (`A=0, B=1, X=2, Y=3`), **not** `@decky/ui`'s `GamepadButton`, where 1 is A — the two disagree on
+every value, and the wrong one draws the wrong glyph without failing.
 
 **A tabbed wide page has to get out of the way for that to work.** Steam's tabbed page renders its content pane as
 `onCancelButton: !cancelSkipTabHeader && <focus the tab row>` (`chunk~2dcc5aaf7.js`), so without the flag the first B
@@ -260,11 +264,12 @@ screen, so a button-first rule would open the panel wherever the day's condition
 dropped for the same reason, back when its argument was that a narrow page is one column of Steam's own full-width rows
 where the first button IS the first row — true of Main only while Main had a Sync button near the top.
 
-**Settings, Data Management and Downloads are unmoved**, and declare nothing: each leads with its Back button, which is
-both the first stop and the first button, so the router's default already opens them there. Whatever the rule, the root
-it searches is the plugin's own content and nothing above it — Decky renders its panel title and the back arrow beside
-it outside that box, 34 px above it (`WidePage`'s `ancestorOverhang` measures the gap) — so no rule here could reach
-Decky's own chrome. The declaration, the finder, the shared set of shapes and the `.focus()` + `gpfocus` pair are
+**Data Management and Downloads are unmoved**, and declare nothing: each leads with its Back button, which is both the
+first stop and the first button, so the router's default already opens them there. Settings left that group when it
+became a wide page — the frame owns its entry focus now, and lands it on the first section row. Whatever the rule, the
+root it searches is the plugin's own content and nothing above it — Decky renders its panel title and the back arrow
+beside it outside that box, 34 px above it (`WidePage`'s `ancestorOverhang` measures the gap) — so no rule here could
+reach Decky's own chrome. The declaration, the finder, the shared set of shapes and the `.focus()` + `gpfocus` pair are
 `src/utils/entryFocus.ts`. It is a second attribute rather than a second use of the wide frame's `OWNS_ENTRY_FOCUS_ATTR`
 because the two say opposite things: that one tells the router to place nothing, this one tells it where.
 
@@ -338,6 +343,10 @@ preview (a row per platform; New, Updated, Removed), registered devices, cleanup
 facts were folded into a field's label and description, which is why #1803's third axis had no slot on the rows the
 System page drew; the platform detail's BIOS table is where that column now sits.
 
+**Registered devices is still the folded shape**, and deliberately so for now: it is one group inside a Save Sync pane
+whose every other row is a Steam `Field`, and a lone grid there would be the only content on the page in a second visual
+language. It becomes a table when the Settings panes are written against the pane primitives the platform detail uses.
+
 **A cell clips; it never overflows.** A grid track sized `minmax(0, 1fr)` shrinks under its content and the content then
 spills across the track beside it — on the Deck a platform name and its note ran into the New column's digit. The clip
 (`overflow: hidden`, `text-overflow: ellipsis`, `white-space: nowrap`, `min-width: 0`) belongs on the **cell**, because
@@ -368,10 +377,13 @@ modal opened from the notice; that modal _is_ the home, not an exception to the 
 | Save-file sorting changed                   | text, **Open Save Sync**                      | Settings › Save Sync, which holds Migrate and Dismiss |
 | Sync paused on the session budget           | text, **Open Sync**                           | Sync, which holds Restart Steam now and Resume        |
 
-Today the `input_driver` fix has a button on Main and another in Settings, the save-sort card exists on both pages, the
-session-budget card with **Restart Steam now** sits on Main, and the playtime notice has Dismiss but no jump. The two
-full-page states — a version error and a pending RetroDECK migration — are not notices; they replace the page, and
-exactly one condition is carried inside them (below).
+Every row of that table is what the panel does today. The two full-page states — a version error and a pending RetroDECK
+migration — are not notices; they replace the page, and exactly one condition is carried inside them (below).
+
+The playtime notice is the one that carries **two** buttons, and they sit side by side on one row rather than on two
+full-width ones: Main is the narrow page, and a notice costing three rows pushes the status block it sits above off the
+screen. Its jump is not an answer either — only a fresh sign-in ends the condition, so **Open Connections** leaves it
+standing and **Dismiss** remains the way to put it away for this view.
 
 **The two data-location conditions are one card in one component** (`src/components/DataLocationNotice.tsx`), because
 they are two outcomes of the same start-up step and only ever one of them stands. The choice's modal
@@ -1038,20 +1050,37 @@ with them.
 
 ## Settings
 
-Wide, list and detail: the sections on the left, the focused section on the right. Five sections instead of today's
-eight — the save-sort migration becomes a notice with its actions inside Save Sync, Registered Devices moves into Save
-Sync, and SteamGridDB joins the other external services under Connections.
+Wide, untabbed, list and detail: the sections on the left, the focused section on the right. Five sections, where the
+narrow page stacked eight — the save-sort migration is a notice with its actions inside Save Sync, Registered Devices
+sits under Save Sync, and SteamGridDB joins the other external service under Connections.
 
-| Section       | Holds                                                                                                                                                                                                                                                                                                      |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Connections   | the services the plugin talks to: RomM (URL, account, Sign out, Allow insecure SSL), RetroAchievements (account and sign-in state; #1627 left the badge's home open between the game page, the retired System page and global settings — it lands here), SteamGridDB (the API key). Home of every sign-in. |
-| Save Sync     | the toggle, device, before-launch and after-exit, default slot, history limit, Sync all now; the registered devices as a table; home of the save-sort migration                                                                                                                                            |
-| Controller    | Steam Input mode, Apply to all shortcuts, the `input_driver` fix. Home of the fix.                                                                                                                                                                                                                         |
-| Steam Library | preferred region, collection games in platform groups, collection types in Steam names — today's **Library** section, renamed because a Library page now exists: the page is the RomM side (what is synced), the section is the Steam side (which version, in which groups, under which name)              |
-| Advanced      | log level                                                                                                                                                                                                                                                                                                  |
+| Section       | Holds                                                                                                                                                                                                                                                                                                   |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Connections   | the services the plugin talks to: RomM (URL, account, Sign out, Allow insecure SSL) and SteamGridDB (the API key), one group each, titled by service. Home of every sign-in.                                                                                                                            |
+| Save Sync     | the save-sort migration first, as the condition asking to be answered; then the toggle, device, before-launch and after-exit, default slot, history limit, Sync all now; then the registered devices                                                                                                    |
+| Controller    | Steam Input mode, Apply to all shortcuts, the `input_driver` fix. Home of the fix.                                                                                                                                                                                                                      |
+| Steam Library | preferred region, collection games in platform groups, collection types in Steam names — the narrow page's **Library** section, renamed because a Library page now exists: the page is the RomM side (what is synced), the section is the Steam side (which version, in which groups, under which name) |
+| Advanced      | log level                                                                                                                                                                                                                                                                                               |
+
+**RetroAchievements is not here, and Connections is still its home.** The plugin has no RetroAchievements account and no
+sign-in for it — building one is #1627, which also left the badge's home open between the game page, the retired System
+page and global settings. The section holds the two services that exist rather than a placeholder for the one that does
+not.
+
+The section rows carry no control of their own, so the list is built with `selectOnActivate`: the activate handler that
+adds is what makes a row a focus stop, and without it the list is neither walkable nor scrollable. Every read-only row
+in a detail pane — a sign-in result, the registered device rows, the row naming this device — is `focusable` for the
+same reason, since a pane scrolls only by moving focus and a group with no stop in it cannot be reached at all. The
+exceptions are the lines the region reveals on its own: content above the pane's first stop or below its last
+(`ScrollRegion`'s `revealEdge`), which is why the migration card carries no handler.
 
 Text input stays in modals — RomM URL, account, API key, default slot — because the on-screen keyboard needs the room.
-The sticky pending URL and the unguarded Apply-to-all double press (#1020) are fixed in the rewrite.
+
+Two failures the narrow page carried are fixed here (#1020). A refused URL no longer sticks: the pending edit exists to
+carry a value across the remount that closing the modal can cause, so it is cleared whichever way the attempt ends, and
+the next open of the page shows the URL that was saved rather than the one that was rejected. And **Apply to all
+shortcuts** refuses a second press while a run is in flight — the guard is in the handler rather than only on the
+button, because a disabled control still reports a press on the device, and the button says which state it is in.
 
 ## Data Management
 
@@ -1084,8 +1113,8 @@ menu entry.
 | Delete BIOS files                  | Library › Platforms    | Library › Platforms                          |
 | Remove one platform's shortcuts    | Library › Platforms    | Library › Platforms                          |
 | Delete one platform's save files   | Library › Platforms    | Library › Platforms                          |
-| Fix the RetroArch `input_driver`   | Main **and** Settings  | Settings › Controller; Main shows the notice |
-| Migrate the save-file sorting      | Settings; Main links   | Settings › Save Sync; Main shows the notice  |
+| Fix the RetroArch `input_driver`   | Settings › Controller  | Settings › Controller; Main shows the notice |
+| Migrate the save-file sorting      | Settings › Save Sync   | Settings › Save Sync; Main shows the notice  |
 | Pause or cancel a download         | Downloads              | Downloads                                    |
 | Clean up removed RomM games        | Data Management, modal | Data Management, as a page                   |
 
@@ -1107,7 +1136,7 @@ The pages land in this order under #1808, each with the open work that already s
    import choice (#1364) is the one thing the page leaves space for.
 4. **Settings** ([#1816](https://github.com/danielcopper/romm-tender/issues/1816)) — the sections, Steam Library, the
    homes for the `input_driver` fix and the save-sort migration with their notices on Main. Carries #1020's URL and
-   double-press fixes.
+   double-press fixes. **Landed**, in one PR; RetroAchievements has no sign-in for Connections to hold until #1627.
 5. **Data Management** ([#1817](https://github.com/danielcopper/romm-tender/issues/1817)) — the operations, the cleanup
    as a pane. After Library, which removes the platform modal.
 

--- a/docs/architecture/qam-panel.md
+++ b/docs/architecture/qam-panel.md
@@ -293,10 +293,11 @@ follow, because Steam draws them only while gamepad focus is within the tabbed p
 **Entry focus belongs to the frame, on every wide page.** `WidePage` marks its root as placing its own, so the panel's
 router leaves the page alone rather than placing focus of its own, which would land on the Back chip above the body.
 Where Steam's tabbed page renders, its `autoFocusContents` does the placing; everywhere else — an untabbed page, and a
-tabbed one whose `Tabs` probe missed — the frame focuses the first stop inside the body itself, on the same 50 ms delay
-the router uses, because Steam's navigation resolves a focus pointer it retained across the page swap after the mount.
-Opening a page is the frame's moment and its only one: a page whose body changes while it stays open answers for that
-swap itself, by the same rule and under a condition of its own — the Sync page's left column is the one that does.
+tabbed one whose `Tabs` probe missed — the frame places focus inside the body itself, by the router's own rule and on
+the same 50 ms delay: the area the body declared, or its first stop where it declared none. The delay is there because
+Steam's navigation resolves a focus pointer it retained across the page swap after the mount. Opening a page is the
+frame's moment and its only one: a page whose body changes while it stays open answers for that swap itself, by the same
+rule and under a condition of its own — the Sync page's left column is the one that does.
 
 **The stop it picks is the first enabled focus stop in document order that contains no focus stop at all** — one rule,
 both widths. Document order rather than "the first button", because a page's first button is not its first row, and it
@@ -315,25 +316,36 @@ inner stop is disabled is stepped over, which no body's first column produces to
 enabled stop that is free of stops inside it — nothing is placed and the page keeps whatever Steam's retained pointer
 resolves to.
 
-**The narrow pages the router covers take the same rule, unless the page names somewhere better.** A page marks the area
-entry focus belongs in (`ENTRY_STOP_ATTR`) and the router picks the stop inside it with the same rule, so what a
-declaration changes is WHERE the rule is applied and never which element it picks. **Main is the only page that declares
-one**, on the menu's **Sync** entry: its three status rows act on nothing, so opening on the first of them — Connection,
-which is where the panel opened before — spends the reader's first press on a move to what they came for. The
-declaration is what makes that stable. Main's first BUTTON is not the menu whenever a notice carrying an action is on
-screen, so a button-first rule would open the panel wherever the day's conditions put one; that rule was tried and
-dropped for the same reason, back when its argument was that a narrow page is one column of Steam's own full-width rows
-where the first button IS the first row — true of Main only while Main had a Sync button near the top.
+**Every page takes the same rule, unless it names somewhere better.** A page marks the area entry focus belongs in
+(`ENTRY_STOP_ATTR`) and whichever placer opens it — the router, or the frame — picks the stop inside that area with the
+same rule, so what a declaration changes is WHERE the rule is applied and never which element it picks. **Two things
+declare, for two different reasons.** Main declares on the menu's **Sync** entry: its three status rows act on nothing,
+so opening on the first of them — Connection, which is where the panel opened before — spends the reader's first press
+on a move to what they came for. The declaration is what makes that stable. Main's first BUTTON is not the menu whenever
+a notice carrying an action is on screen, so a button-first rule would open the panel wherever the day's conditions put
+one; that rule was tried and dropped for the same reason, back when its argument was that a narrow page is one column of
+Steam's own full-width rows where the first button IS the first row — true of Main only while Main had a Sync button
+near the top.
+
+**A list-and-detail page declares on its SELECTED row**, and there the declaration is not a preference about where to
+land but what makes the page keep the state it was opened with: focus selects on that layout, so entry focus landing on
+the first row selects the first row. Settings is opened on a named section by three of Main's notices, and before the
+row was declared each of those jumps mounted the right section and then had it overwritten about 50 ms later — Open
+Controller landed on Connections. A list opened with no section named loses nothing: it either selects its own first
+row, which is what the fallback would have picked, or selects nothing and so declares nothing (the Library page's
+platforms, which additionally are tabbed, so Steam places that focus and the frame places none).
 
 **Data Management and Downloads are unmoved**, and declare nothing: each leads with its Back button, which is both the
-first stop and the first button, so the router's default already opens them there. Settings left that group when it
-became a wide page — the frame owns its entry focus now, and lands it on the first section row. Whatever the rule, the
-root it searches is the plugin's own content and nothing above it — Decky renders its panel title and the back arrow
-beside it outside that box, 34 px above it (the same inset whose bottom `WidePage`'s `ancestorOverhang` measures) — so
-no rule here could reach Decky's own chrome. The declaration, the finder, the shared set of shapes and the `.focus()` +
+first stop and the first button, so the router's default already opens them there. Whatever the rule, the root it
+searches is the plugin's own content and nothing above it — Decky renders its panel title and the back arrow beside it
+outside that box, 34 px above it (the same inset whose bottom `WidePage`'s `ancestorOverhang` measures) — so no rule
+here could reach Decky's own chrome. The declaration, the finder, the shared set of shapes and the `.focus()` +
 `gpfocus` pair are `src/utils/entryFocus.ts`. It is a second attribute rather than a second use of the wide frame's
-`OWNS_ENTRY_FOCUS_ATTR` because the two say opposite things: that one tells the router to place nothing, this one tells
-it where.
+`OWNS_ENTRY_FOCUS_ATTR` because the two answer different questions: that one says WHO places entry focus — it tells the
+router to place none, because the frame places its own — and this one says WHERE, for whichever of them places it. **So
+a wide page carries both**, Settings being one: the root says "I place my own" and the list's selected row says "here".
+The router never reaches the second, because it looks for `OWNS_ENTRY_FOCUS_ATTR` first and, finding it, sets no timer
+at all.
 
 **A tab's content is the page's business, not the frame's.** The frame wraps an untabbed body in a `ScrollRegion` and a
 tabbed one in nothing: Steam's tabbed page already wraps each tab's content in this same plain scroll panel, so a region

--- a/docs/architecture/qam-panel.md
+++ b/docs/architecture/qam-panel.md
@@ -343,10 +343,6 @@ preview (a row per platform; New, Updated, Removed), registered devices, cleanup
 facts were folded into a field's label and description, which is why #1803's third axis had no slot on the rows the
 System page drew; the platform detail's BIOS table is where that column now sits.
 
-**Registered devices is still the folded shape**, and deliberately so for now: it is one group inside a Save Sync pane
-whose every other row is a Steam `Field`, and a lone grid there would be the only content on the page in a second visual
-language. It becomes a table when the Settings panes are written against the pane primitives the platform detail uses.
-
 **A cell clips; it never overflows.** A grid track sized `minmax(0, 1fr)` shrinks under its content and the content then
 spills across the track beside it — on the Deck a platform name and its note ran into the New column's digit. The clip
 (`overflow: hidden`, `text-overflow: ellipsis`, `white-space: nowrap`, `min-width: 0`) belongs on the **cell**, because
@@ -1057,10 +1053,14 @@ sits under Save Sync, and SteamGridDB joins the other external service under Con
 | Section       | Holds                                                                                                                                                                                                                                                                                                   |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Connections   | the services the plugin talks to: RomM (URL, account, Sign out, Allow insecure SSL) and SteamGridDB (the API key), one group each, titled by service. Home of every sign-in.                                                                                                                            |
-| Save Sync     | the save-sort migration first, as the condition asking to be answered; then the toggle, device, before-launch and after-exit, default slot, history limit, Sync all now; then the registered devices                                                                                                    |
+| Save Sync     | the save-sort migration first, as the condition asking to be answered; then the toggle, device, before-launch and after-exit, default slot, history limit, Sync all now; then the registered devices as a table                                                                                         |
 | Controller    | Steam Input mode, Apply to all shortcuts, the `input_driver` fix. Home of the fix.                                                                                                                                                                                                                      |
 | Steam Library | preferred region, collection games in platform groups, collection types in Steam names — the narrow page's **Library** section, renamed because a Library page now exists: the page is the RomM side (what is synced), the section is the Steam side (which version, in which groups, under which name) |
 | Advanced      | log level                                                                                                                                                                                                                                                                                               |
+
+The registered devices are the one thing on the page with more than two facts per row, so they are a table — Device,
+Client, Last seen. The layout study it was chosen from is
+[device-list-layouts.html](../assets/device-list-layouts.html).
 
 **RetroAchievements is not here, and Connections is still its home.** The plugin has no RetroAchievements account and no
 sign-in for it — building one is #1627, which also left the badge's home open between the game page, the retired System
@@ -1069,10 +1069,12 @@ not.
 
 The section rows carry no control of their own, so the list is built with `selectOnActivate`: the activate handler that
 adds is what makes a row a focus stop, and without it the list is neither walkable nor scrollable. Every read-only row
-in a detail pane — a sign-in result, the registered device rows, the row naming this device — is `focusable` for the
-same reason, since a pane scrolls only by moving focus and a group with no stop in it cannot be reached at all. The
-exceptions are the lines the region reveals on its own: content above the pane's first stop or below its last
-(`ScrollRegion`'s `revealEdge`), which is why the migration card carries no handler.
+in a detail pane — a sign-in result, each row of the registered-devices table, the row naming this device — is a stop
+for the same reason, since a pane scrolls only by moving focus and a group with no stop in it cannot be reached at all.
+Two kinds of line are not, and for two different reasons. Content the region reveals on its own — above the pane's first
+stop or below its last (`ScrollRegion`'s `revealEdge`) — needs none, which is why the migration card carries no handler.
+And the devices table's **column header** carries none under the Tables rule: the names accompany the rows below them
+and a stop there would be a step that leads nowhere.
 
 Text input stays in modals — RomM URL, account, API key, default slot — because the on-screen keyboard needs the room.
 
@@ -1169,6 +1171,15 @@ store screenshots (#830) are taken after.
   forgets; and it draws both of the left column's button rows under their tables, where the shipped page puts them
   above, because on a controller a button is reached by walking focus onto it one table row at a time. Like the
   Platforms study, it is a record of a choice rather than a description of the page.
+- The layout study the registered-devices table was chosen from:
+  [device-list-layouts.html](../assets/device-list-layouts.html) — three layouts for that one block at the Deck's
+  measured width, everything else on the page held identical so the comparison is about the block alone: today's folded
+  rows, a three-column table with a header, and a two-column middle keeping the Steam `Field` shape with Last seen
+  right-aligned. The table is what shipped, on the axis the Deck is short of — one row per device instead of two, and
+  eight devices costing nine rows rather than sixteen — and the platform and the shortened id are dropped with it. It
+  records its own objection: the table is the only content on that pane with column headers, which ends when the
+  remaining Settings panes are written against the same pane primitives the Platforms detail uses. Like the studies
+  above it is a record of a choice, not a description of the page.
 - The static prototype the decisions were made on: [qam-prototype.html](../assets/qam-prototype.html), a single
   self-contained page kept in `docs/assets/`. Every page at device size with numbered notes; its example data is
   invented, and it reflects the decisions as of this page's first version. Redrawn to the Deck's real 854 × 534 CSS px —

--- a/docs/architecture/qam-panel.md
+++ b/docs/architecture/qam-panel.md
@@ -112,7 +112,10 @@ much more to scroll, and nothing re-measures. It reached a device as a page that
 Measured live in the QAM over the mounted page, at panel offsets 0 / 200 / 500 / 634 px, `window.innerHeight - top`
 answers 648 / 848 / 1148 / 1283 — and so does `scroller.getBoundingClientRect().bottom - top`, because the panel's rect
 bottom is 764.3 against an `innerHeight` of 764. **Bounding to the panel instead of the window is therefore not the
-fix**; it changes no number at any offset. The layout-relative form answers 648 at all four. What makes a non-zero
+fix**; it changes no number at any offset. The layout-relative form answers 648 at all four. Those four come from an
+earlier round, before the Back row and the title shared a line, so the body sat at offset 102 where it now sits at 89.8
+— which is why they are 12 short of the 660 above rather than the height of the gap this frame no longer keeps. What the
+passage is about survives the difference: the same form answers the same number at every offset. What makes a non-zero
 offset reachable at all is that `QAMPanel` resets the panel's scroll inside a `requestAnimationFrame`, a frame after the
 page's own layout effect has already measured.
 
@@ -124,8 +127,8 @@ overhang (`ancestorOverhang`, summed over each ancestor up to the scroller) and 
 margin on the page root** rather than taking it out of the height: a margin changes what the box claims after itself,
 not where it paints, so the ancestors end where the scroller's box does and nothing on the page moves. The height and
 that pull-up are one measured value applied in one render, because **each half alone is measurably useless**: applied
-live to the running panel, the height without the margin overflows the scroller (`scrollHeight` 788 against a
-`clientHeight` of 750 — 38 px of scroll, which is what takes the Back row off the top), and the margin without the
+live to the running panel, the height without the margin overflows the scroller (`scrollHeight` 800 against a
+`clientHeight` of 750 — 50 px of scroll, which is what takes the Back row off the top), and the margin without the
 height moves nothing a reader sees, the page still ending on the same line with the same band under it.
 
 **What makes the pull-up cancel anything is a structural assumption, and it is worth stating on its own**, because the
@@ -143,11 +146,11 @@ the reader meets as the Back row leaving the top. The check is one reading: the 
 should equal the body's own with the margin applied, and sit an overhang below it without.
 
 Buying the room instead of cancelling it is what the first cut did, and it cost the bottom of every wide page: the body
-gave up 50 px of its own so the wrapper's empty 50 would fit, which left the wrapper ending at the panel's box and our
-content a further 50 px above that — an empty band across Settings, Library and Sync, with content that would have
-fitted clipped out of the difference. Measured live — on Settings when it was reported, and again on Library, which
-answers the same because the scroller is the panel's rather than the page's — the scroller's box ran to y=764.3
-(`clientHeight` 750, unscrollable) while the page root ended at y=702.
+gave up 50 px of its own so the wrapper's empty 50 would fit, which left the wrapper ending 12 px short of the panel's
+box — the gap the frame kept — and our content a further 50 px above that — an empty band across Settings, Library and
+Sync, with content that would have fitted clipped out of the difference. Measured live — on Settings when it was
+reported, and again on Library, which answers the same because the scroller is the panel's rather than the page's — the
+scroller's box ran to y=764.3 (`clientHeight` 750, unscrollable) while the page root ended at y=702.
 
 **Two further gaps stood under a wide page after that, and neither was earned.** The first was ours: the frame kept 12
 px of breathing room off its own measurement, which is why a page ended at y=752 inside a panel whose box runs to 764.3.

--- a/docs/architecture/qam-panel.md
+++ b/docs/architecture/qam-panel.md
@@ -113,6 +113,30 @@ fix**; it changes no number at any offset. The layout-relative form answers 648 
 offset reachable at all is that `QAMPanel` resets the panel's scroll inside a `requestAnimationFrame`, a frame after the
 page's own layout effect has already measured.
 
+**The height alone is not the whole fit, because the frame's own ancestors hang below it.** Decky wraps a plugin's
+content in a box that sits 34 px below the panel top — its plugin title — and takes `height: 100%` of a parent it is
+already inset within, so its bottom lands 50 px past our content's. Nothing of ours is painted in those 50 px, but the
+panel scrolls by them, and a scroll of that size takes the frame's Back row off the top. `WidePage` measures the
+overhang (`ancestorOverhang`, summed over each ancestor up to the scroller) and **cancels it with a negative bottom
+margin on the page root** rather than taking it out of the height: a margin changes what the box claims after itself,
+not where it paints, so the ancestors end where the scroller's box does and nothing on the page moves. The height and
+that pull-up are one measured value applied in one render, because **each half alone is measurably useless**: applied
+live to the running panel, the height without the margin overflows the scroller (`scrollHeight` 788 against a
+`clientHeight` of 750 — 38 px of scroll, which is what takes the Back row off the top), and the margin without the
+height moves nothing a reader sees, the page still ending on the same line with the same band under it.
+
+Buying the room instead of cancelling it is what the first cut did, and it cost the bottom of every wide page: the body
+gave up 50 px of its own so the wrapper's empty 50 would fit, which left the wrapper ending a gap above the panel's box
+and our content a further 50 px above that — an empty band across Settings, Library and Sync, with content that would
+have fitted clipped out of the difference. Measured live — on Settings when it was reported, and again on Library, which
+answers the same because the scroller is the panel's rather than the page's — the scroller's box ran to y=764.3
+(`clientHeight` 750, unscrollable) while the page root ended at y=702. The 12 px that remain under the page are
+`BODY_BOTTOM_GAP` and are deliberate — breathing room, not overhang, and not a knob for absorbing leftover scroll.
+
+**No test here can see any of that.** happy-dom performs no layout, so `WidePage.test.tsx` pins the arithmetic — the
+height, and that the pull-up equals whatever overhang was measured — and nothing more. That the panel does not scroll,
+and that the band is gone, is a device observation each time.
+
 A region scrolls the way the rest of the QAM scrolls: by moving focus. Every scrolling region goes through
 `ScrollRegion`, which renders Steam's plain `ScrollPanel` — the container the QAM's own tab panel is built from, and the
 one Steam's tabbed page wraps each tab's content in. It is an `overflow-y: auto` box that takes no focus of its own, so
@@ -268,10 +292,11 @@ where the first button IS the first row — true of Main only while Main had a S
 first stop and the first button, so the router's default already opens them there. Settings left that group when it
 became a wide page — the frame owns its entry focus now, and lands it on the first section row. Whatever the rule, the
 root it searches is the plugin's own content and nothing above it — Decky renders its panel title and the back arrow
-beside it outside that box, 34 px above it (`WidePage`'s `ancestorOverhang` measures the gap) — so no rule here could
-reach Decky's own chrome. The declaration, the finder, the shared set of shapes and the `.focus()` + `gpfocus` pair are
-`src/utils/entryFocus.ts`. It is a second attribute rather than a second use of the wide frame's `OWNS_ENTRY_FOCUS_ATTR`
-because the two say opposite things: that one tells the router to place nothing, this one tells it where.
+beside it outside that box, 34 px above it (the same inset whose bottom `WidePage`'s `ancestorOverhang` measures) — so
+no rule here could reach Decky's own chrome. The declaration, the finder, the shared set of shapes and the `.focus()` +
+`gpfocus` pair are `src/utils/entryFocus.ts`. It is a second attribute rather than a second use of the wide frame's
+`OWNS_ENTRY_FOCUS_ATTR` because the two say opposite things: that one tells the router to place nothing, this one tells
+it where.
 
 **A tab's content is the page's business, not the frame's.** The frame wraps an untabbed body in a `ScrollRegion` and a
 tabbed one in nothing: Steam's tabbed page already wraps each tab's content in this same plain scroll panel, so a region

--- a/docs/architecture/qam-panel.md
+++ b/docs/architecture/qam-panel.md
@@ -21,7 +21,7 @@ without restating it. The width mechanism's decision record is
 | `src/index.tsx` (`QAMPanel`)                                  | The router: one `Page` value, one mounted page, a module-level `currentPage` that survives a QAM remount                                                            |
 | `src/types/navigation.ts`                                     | The `Page` union — every page the router can land on                                                                                                                |
 | `src/components/MainPage.tsx`                                 | Main                                                                                                                                                                |
-| `src/components/SyncPage.tsx`, `src/components/sync/`         | Sync — the frame and its three left-column bodies, plus `useSyncPage` (its reads and actions) and the table pieces both its tables are built from                   |
+| `src/components/SyncPage.tsx`, `src/components/sync/`         | Sync — the frame and its three left-column bodies, plus `useSyncPage` (its reads and actions) and the register both its tables are set in                           |
 | `src/components/LibraryPage.tsx`                              | Library — the frame, the two tabs and their state                                                                                                                   |
 | `src/components/SettingsPage.tsx`, `src/components/settings/` | Settings and its sections                                                                                                                                           |
 | `src/components/DangerZone.tsx`, `RemovedGamesCleanup.tsx`    | Data Management                                                                                                                                                     |
@@ -339,9 +339,21 @@ pair now runs 79.9 → 335.9.
 ### Tables
 
 Anything with more than two facts per row is a table with a header row: BIOS files (File, On disk, Contents), the
-preview (a row per platform; New, Updated, Removed), registered devices, cleanup candidates, collections. Today those
-facts were folded into a field's label and description, which is why #1803's third axis had no slot on the rows the
+preview (a row per platform; New, Updated, Removed), registered devices, cleanup candidates, collections. Those facts
+were once folded into a field's label and description, which is why #1803's third axis had no slot on the rows the
 System page drew; the platform detail's BIOS table is where that column now sits.
+
+**There is one table, and a page passes the register it is set in** (`PaneTableHeader` / `PaneTableRow` in
+`src/components/qam/pane.tsx`). The shape is shared — a grid of a page's own columns, an 8 px gutter between them, the
+header's names in the secondary size and colour, a row that is a focus stop, a cell that clips — and what a page varies
+is the type size, the leading, the row and header padding, and whether a hairline sits under the column names. That is a
+`TableRegister`, and the default is what a pane uses unless it says otherwise. It is one component rather than three
+because three drifted: the same header was written three times, and only one of the three clipped its cells.
+
+A row is a focus stop **unless one of its own cells carries a control** — the BIOS table's action column is the case,
+and there the button is already the stop, so a second one on the wrapper would put a dead step in front of every one of
+them. A cell opts out of the clip for the same kind of reason: a cell of glyphs has nothing to ellipsise, and a cell
+holding a button must not hide the overflow its focus ring is drawn in.
 
 **A cell clips; it never overflows.** A grid track sized `minmax(0, 1fr)` shrinks under its content and the content then
 spills across the track beside it — on the Deck a platform name and its note ran into the New column's digit. The clip
@@ -648,8 +660,10 @@ only place sixteen units of plan do not stand between the reader and it, exactly
 list is a scrolling region of its own**, taking what is left of the column under the bar and that button: a plan of
 seventeen units is taller than the Deck's column, and without it the running unit walks out of sight below the fold.
 Nothing moves focus during a run, so the page scrolls that region itself and puts the running row in the middle of it,
-clamped to the list's own ends. Both tables' rows are set in one flat, small register, held in one place
-(`paneTable.tsx`) so that stays a decision rather than a drift.
+clamped to the list's own ends. Both tables are the pane's own table (§ Tables) set in one flat, small register —
+`SYNC_TABLE_REGISTER` in `paneTable.tsx`, which is also where the numeric-column split and the pieces that are not
+tables at all live. Holding the register in one place is still what keeps it a decision rather than a drift; what
+changed is that it is now a value this page passes rather than a second table it owns.
 
 **Focus lands on Cancel Sync when this body takes the column**, by the swap rule above: what it picks is the first stop
 holding no stop of its own, and every unit row below is a stop too, so what puts it on the button is the button being
@@ -1059,8 +1073,8 @@ sits under Save Sync, and SteamGridDB joins the other external service under Con
 | Advanced      | log level                                                                                                                                                                                                                                                                                               |
 
 The registered devices are the one thing on the page with more than two facts per row, so they are a table — Device,
-Client, Last seen. The layout study it was chosen from is
-[device-list-layouts.html](../assets/device-list-layouts.html).
+Client, Last seen — drawn with § Tables' shared one at the pane's default register. The layout study it was chosen from
+is [device-list-layouts.html](../assets/device-list-layouts.html).
 
 **RetroAchievements is not here, and Connections is still its home.** The plugin has no RetroAchievements account and no
 sign-in for it — building one is #1627, which also left the badge's home open between the game page, the retired System
@@ -1177,9 +1191,11 @@ store screenshots (#830) are taken after.
   rows, a three-column table with a header, and a two-column middle keeping the Steam `Field` shape with Last seen
   right-aligned. The table is what shipped, on the axis the Deck is short of — one row per device instead of two, and
   eight devices costing nine rows rather than sixteen — and the platform and the shortened id are dropped with it. It
-  records its own objection: the table is the only content on that pane with column headers, which ends when the
-  remaining Settings panes are written against the same pane primitives the Platforms detail uses. Like the studies
-  above it is a record of a choice, not a description of the page.
+  records its own objection, and half of it has since been answered: the table is no longer an implementation of its own
+  — it is § Tables' shared one, the same component the BIOS files and the preview draw. What still stands is what the
+  study actually says: it remains the only content on that pane with column headers, and that ends when the rows around
+  it are written against the pane primitives too, which is not done. Like the studies above it is a record of a choice,
+  not a description of the page.
 - The static prototype the decisions were made on: [qam-prototype.html](../assets/qam-prototype.html), a single
   self-contained page kept in `docs/assets/`. Every page at device size with numbered notes; its example data is
   invented, and it reflects the decisions as of this page's first version. Redrawn to the Deck's real 854 × 534 CSS px —

--- a/docs/architecture/qam-panel.md
+++ b/docs/architecture/qam-panel.md
@@ -95,8 +95,11 @@ literal `"https://steamloopback.host"` — which is what `window.origin` is in t
 
 Steam's tabbed page fills its parent instead of growing, and nothing in the QAM chain provides a height. A wide page
 therefore measures the space left below its header and takes that as its height; its regions scroll inside it. A
-`min-height` is not enough — it clips. Under Decky's title bar, the frame's Back row, its title and a tab bar, that
-leaves a body of roughly 260 px inside the 454 px view.
+`min-height` is not enough — it clips. What is left after Decky's own title bar and the frame's Back-and-title row is
+the panel's `clientHeight` less the body's offset within it, so it follows the view rather than any recorded number:
+measured through CEF on the dev window's 764 px view, with the change below applied to the running panel, that is a body
+of **660 px** ending flush with the panel's box. A tabbed page spends 58 px of it on Steam's tab row, which is drawn
+over the top of the content pane rather than above it.
 
 **That measurement has to be free of the scrolling panel's own offset, and only a layout-relative one is**: the body's
 position inside the scroller's content — its viewport top minus the scroller's, plus the scroller's `scrollTop` —
@@ -115,8 +118,8 @@ page's own layout effect has already measured.
 
 **The height alone is not the whole fit, because the frame's own ancestors hang below it.** Decky wraps a plugin's
 content in a box that sits 34 px below the panel top — its plugin title — and takes `height: 100%` of a parent it is
-already inset within, so its bottom lands 50 px past our content's. Nothing of ours is painted in those 50 px, but the
-panel scrolls by them, and a scroll of that size takes the frame's Back row off the top. `WidePage` measures the
+already inset within, so its bottom lands **50 px past that parent's**. Nothing of ours is painted in those 50 px, but
+the panel scrolls by them, and a scroll of that size takes the frame's Back row off the top. `WidePage` measures the
 overhang (`ancestorOverhang`, summed over each ancestor up to the scroller) and **cancels it with a negative bottom
 margin on the page root** rather than taking it out of the height: a margin changes what the box claims after itself,
 not where it paints, so the ancestors end where the scroller's box does and nothing on the page moves. The height and
@@ -125,17 +128,48 @@ live to the running panel, the height without the margin overflows the scroller 
 `clientHeight` of 750 — 38 px of scroll, which is what takes the Back row off the top), and the margin without the
 height moves nothing a reader sees, the page still ending on the same line with the same band under it.
 
+**What makes the pull-up cancel anything is a structural assumption, and it is worth stating on its own**, because the
+overhang is measured against a PARENT and the margin is applied to our root. The boxes between our root and the scroller
+are content-sized: the wrapper's bottom is our body's plus its own inset, at every body height. So pulling our root's
+margin box up carries those bottoms up with it, and the chain stops claiming exactly the overhang the margin names. The
+assumption is a SHAPE rather than a value — every number is re-measured, so a Decky release that merely overhangs by a
+different amount is already handled — and it holds because the overhang is the wrapper's own inset and padding rather
+than anything derived from what we put inside. It was checked at several body heights in two panel geometries.
+
+**If it ever stops holding, this is what it looks like.** A wrapper pinned to a height of its own — a future Decky or
+Steam nesting the plugin differently — would not follow our body up: growing the body would overflow the wrapper instead
+of the wrapper's parent, the margin would cancel nothing that was in the way, and the panel would scroll again, which
+the reader meets as the Back row leaving the top. The check is one reading: the lowest ancestor bottom in the chain
+should equal the body's own with the margin applied, and sit an overhang below it without.
+
 Buying the room instead of cancelling it is what the first cut did, and it cost the bottom of every wide page: the body
-gave up 50 px of its own so the wrapper's empty 50 would fit, which left the wrapper ending a gap above the panel's box
-and our content a further 50 px above that — an empty band across Settings, Library and Sync, with content that would
-have fitted clipped out of the difference. Measured live — on Settings when it was reported, and again on Library, which
+gave up 50 px of its own so the wrapper's empty 50 would fit, which left the wrapper ending at the panel's box and our
+content a further 50 px above that — an empty band across Settings, Library and Sync, with content that would have
+fitted clipped out of the difference. Measured live — on Settings when it was reported, and again on Library, which
 answers the same because the scroller is the panel's rather than the page's — the scroller's box ran to y=764.3
-(`clientHeight` 750, unscrollable) while the page root ended at y=702. The 12 px that remain under the page are
-`BODY_BOTTOM_GAP` and are deliberate — breathing room, not overhang, and not a knob for absorbing leftover scroll.
+(`clientHeight` 750, unscrollable) while the page root ended at y=702.
+
+**Two further gaps stood under a wide page after that, and neither was earned.** The first was ours: the frame kept 12
+px of breathing room off its own measurement, which is why a page ended at y=752 inside a panel whose box runs to 764.3.
+A QAM panel of Steam's own, measured in the same document, runs its content to its box with a gap of 0, so the constant
+went rather than being set to zero — room under a page belongs to that page's layout, where it can be seen and adjusted,
+not to a number the frame takes off every page's height. The second is Steam's, and it is **cancelled by an override
+rather than absorbed**: a tabbed page's content scroller carries `padding-bottom: 40px` (rule
+`._1X4dtbZ_AMX_DXT-SGiK01`), and that scroller sits inside the box `WidePage` measured and handed the tab as its height
+— so on Library the content stopped at y=712 inside a body of ours that ran to 752, a 40 px reserve taken out of a
+height the frame had already paid for. An untabbed page renders no such scroller and keeps none of it, which is why
+Library read as having a deeper band than Settings and Sync — the difference that was reported and could not be
+explained. The injected sheet zeroes the padding for a wide page of ours (`qamExpansion.ts`, written against the
+readable `_TabContentsScroll` rather than the hashed class, and degrading to Steam's padding if either name goes). With
+both gaps gone, Library's body measured 660 px and its content ran to y=764.0 against a panel box of 764.3,
+`scrollHeight` still equal to `clientHeight`. What the reader gets is 52 px on the tab's own scrolling region — the box
+the rows live in — measured on Library at 161.8 → 712 before and 161.8 → 764 after, a `clientHeight` of 550 against 602
+over the same 1570 px of content.
 
 **No test here can see any of that.** happy-dom performs no layout, so `WidePage.test.tsx` pins the arithmetic — the
-height, and that the pull-up equals whatever overhang was measured — and nothing more. That the panel does not scroll,
-and that the band is gone, is a device observation each time.
+height, and that the pull-up equals whatever overhang was measured — and `qamExpansion.test.tsx` pins that the override
+is in the sheet and scoped to our root. That the panel does not scroll, and that the band is gone, is a device
+observation each time.
 
 A region scrolls the way the rest of the QAM scrolls: by moving focus. Every scrolling region goes through
 `ScrollRegion`, which renders Steam's plain `ScrollPanel` — the container the QAM's own tab panel is built from, and the

--- a/docs/assets/device-list-layouts.html
+++ b/docs/assets/device-list-layouts.html
@@ -1,0 +1,430 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Tender Device List Layouts</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&family=Noto+Sans:wght@400;500;600;700&display=swap">
+<style>
+  :root {
+    --bg: #eef0f3; --surface: #ffffff; --ink: #1b2027; --muted: #5b6470; --line: #d5d9df;
+    --line-strong: #b9c0c9; --mark: #c4731a; --mark-ink: #ffffff; --chip: #e3e7ec;
+    --chip-on: #1b2027; --chip-on-ink: #ffffff; --rec: #2b6a3e; --rec-bg: #e6f2ea;
+    --font-ui: "IBM Plex Sans", "Segoe UI", system-ui, sans-serif;
+    --font-mono: "IBM Plex Mono", "SFMono-Regular", Menlo, Consolas, monospace;
+    --font-mock: "Motiva Sans", "Noto Sans", "Segoe UI", Roboto, system-ui, sans-serif;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --bg: #12151a; --surface: #1a1e25; --ink: #e4e8ee; --muted: #9aa3ae; --line: #2a3038;
+      --line-strong: #3a424c; --mark: #d98a2e; --mark-ink: #12151a; --chip: #262c35;
+      --chip-on: #e4e8ee; --chip-on-ink: #12151a; --rec: #8fd3a5; --rec-bg: #1c2f23;
+    }
+  }
+  :root[data-theme="dark"] {
+    --bg: #12151a; --surface: #1a1e25; --ink: #e4e8ee; --muted: #9aa3ae; --line: #2a3038;
+    --line-strong: #3a424c; --mark: #d98a2e; --mark-ink: #12151a; --chip: #262c35;
+    --chip-on: #e4e8ee; --chip-on-ink: #12151a; --rec: #8fd3a5; --rec-bg: #1c2f23;
+  }
+
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--ink); font: 15px/1.5 var(--font-ui); }
+  button { font: inherit; color: inherit; }
+  button:focus-visible { outline: 2px solid var(--mark); outline-offset: 2px; }
+  @media (prefers-reduced-motion: reduce) { * { animation: none !important; transition: none !important; } }
+
+  .top { display: flex; flex-wrap: wrap; align-items: center; gap: 14px 28px; padding: 18px 28px;
+         border-bottom: 1px solid var(--line); background: var(--surface); position: sticky; top: 0; z-index: 5; }
+  .top h1 { margin: 0; font-size: 17px; font-weight: 600; }
+  .top h1 small { font-family: var(--font-mono); font-weight: 400; color: var(--muted); margin-left: 10px; font-size: 12px; }
+  .switch { display: flex; align-items: center; gap: 8px; }
+  .switch .lab { font-family: var(--font-mono); font-size: 12px; color: var(--muted); letter-spacing: .04em; }
+  .chip { border: 1px solid var(--line-strong); background: var(--chip); border-radius: 3px; padding: 4px 10px; font-size: 13px; cursor: pointer; }
+  .chip[aria-pressed="true"] { background: var(--chip-on); color: var(--chip-on-ink); border-color: var(--chip-on); }
+  .chip .rec { font-family: var(--font-mono); font-size: 10px; margin-left: 6px; color: var(--rec); letter-spacing: .06em; }
+  .chip[aria-pressed="true"] .rec { color: inherit; opacity: .75; }
+
+  main { padding: 26px 28px 80px; max-width: 1180px; }
+  h2 { margin: 0 0 4px; font-size: 22px; font-weight: 600; text-wrap: balance; }
+  .sub { margin: 0 0 18px; color: var(--muted); max-width: 74ch; }
+  h3 { margin: 0 0 8px; font-size: 13px; font-family: var(--font-mono); letter-spacing: .06em;
+       text-transform: uppercase; color: var(--muted); font-weight: 500; }
+
+  .stage { position: relative; overflow: hidden; border: 1px solid var(--line); border-radius: 4px; background: #0e1116; }
+  .caption { display: flex; flex-wrap: wrap; gap: 6px 18px; margin: 8px 0 26px; font-family: var(--font-mono); font-size: 12px; color: var(--muted); }
+  .variant { display: none; }
+  .variant.on { display: block; }
+
+  .notes { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 18px 36px; margin-bottom: 26px; }
+  .notes ol { margin: 0; padding: 0; list-style: none; display: grid; gap: 10px; }
+  .notes ol > li { display: grid; grid-template-columns: 22px 1fr; gap: 10px; max-width: 62ch; }
+  .notes ol > li p { margin: 0; }
+  .notes ul { margin: 0; padding-left: 18px; max-width: 62ch; display: grid; gap: 6px; }
+  .mk { width: 20px; height: 20px; border-radius: 50%; background: var(--mark); color: var(--mark-ink);
+        font: 600 11px/20px var(--font-mono); text-align: center; margin-top: 2px; }
+  .recbox { border-left: 3px solid var(--rec); background: var(--rec-bg); padding: 10px 14px; border-radius: 0 3px 3px 0; max-width: 66ch; margin-bottom: 26px; }
+  .recbox b { color: var(--rec); font-family: var(--font-mono); font-size: 11px; letter-spacing: .08em;
+              text-transform: uppercase; display: block; margin-bottom: 4px; font-weight: 500; }
+
+  .facts { background: var(--surface); border: 1px solid var(--line); border-radius: 4px; padding: 16px 20px; margin-bottom: 26px; max-width: 900px; }
+  .facts dl { margin: 0; display: grid; grid-template-columns: max-content 1fr; gap: 8px 20px; }
+  .facts dt { font-family: var(--font-mono); font-size: 12px; color: var(--muted); }
+  .facts dd { margin: 0; max-width: 70ch; }
+
+  .cmpwrap { overflow-x: auto; margin-bottom: 26px; }
+  .cmp { width: 100%; border-collapse: collapse; background: var(--surface); border: 1px solid var(--line); font-size: 14px; min-width: 640px; }
+  .cmp th, .cmp td { text-align: left; padding: 9px 12px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  .cmp th { font-family: var(--font-mono); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; color: var(--muted); font-weight: 500; }
+  .cmp td.y { color: var(--rec); } .cmp td.n { color: #b3401e; }
+  @media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) .cmp td.n { color: #e58f70; } }
+  :root[data-theme="dark"] .cmp td.n { color: #e58f70; }
+
+  /* ---------- the Steam mock ---------- */
+  .deck { position: absolute; top: 0; left: 0; transform-origin: 0 0; overflow: hidden;
+          background: radial-gradient(900px 520px at 24% 20%, #262c39, #0e1116 70%);
+          --p: #23262e; --p2: #1a1d23; --t: #dcdedf; --mu: #8b929a; --ln: rgba(255,255,255,.07);
+          --ln2: rgba(255,255,255,.14); --blue: #1a9fff; --ok: #59bf40; --warn: #f0a030; --dng: #e8686a;
+          --fill: rgba(255,255,255,.08); --fill2: rgba(255,255,255,.14);
+          font-family: var(--font-mock); color: var(--t); font-size: 14px; line-height: 1.35; }
+  .deck::before { content: ""; position: absolute; top: 0; left: 0; right: 0; height: 80px; background: #0b0d11; }
+  .deck::after { content: "95 %   13:28"; position: absolute; top: 28px; right: 24px; font: 600 15px/1 var(--font-mock); color: #dcdedf; }
+  .bgtile { position: absolute; border-radius: 6px; background: rgba(255,255,255,.035); }
+  .qam { position: absolute; top: 80px; right: 0; bottom: 0; width: 854px; display: flex; box-shadow: -12px 0 40px rgba(0,0,0,.45); }
+  .rail { width: 48px; background: var(--p2); display: flex; flex-direction: column; align-items: center; padding-top: 14px; gap: 16px; flex: none; }
+  .rail i { width: 18px; height: 18px; border: 2px solid #5a6270; border-radius: 4px; display: block; }
+  .rail i.c { border-radius: 50%; }
+  .rail i.on { border-color: #fff; background: rgba(255,255,255,.15); }
+  .content { flex: 1; min-width: 0; background: var(--p); display: flex; flex-direction: column; overflow: hidden; }
+  .dtitle { height: 34px; flex: none; display: flex; align-items: center; gap: 8px; padding: 0 16px; font-weight: 600; font-size: 15px; border-bottom: 1px solid var(--ln); color: #fff; }
+  .dtitle .ar { color: var(--mu); font-size: 18px; line-height: 1; }
+  .phead { display: flex; align-items: center; gap: 12px; padding: 7px 16px 6px; flex: none; border-bottom: 1px solid var(--ln2); }
+  .back { background: var(--fill); padding: 4px 10px; border-radius: 2px; font-size: 13px; color: #fff; }
+  .ptitle { font-size: 17px; font-weight: 600; color: #fff; }
+
+  .cols { display: grid; grid-template-columns: 264px minmax(0, 1fr); gap: 16px; padding: 8px 16px 10px; flex: 1; min-height: 0; }
+  .list, .pane { overflow: auto; min-height: 0; }
+  .lrow { display: flex; align-items: center; gap: 8px; padding: 7px 8px; border-bottom: 1px solid var(--ln); }
+  .lrow .nm { flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .lrow.sel { background: var(--fill2); outline: 2px solid #fff; outline-offset: -2px; border-radius: 2px; }
+  .sec-t { font-size: 10px; letter-spacing: .1em; text-transform: uppercase; color: var(--mu); padding: 10px 0 3px; display: flex; align-items: center; gap: 8px; }
+  .sec-t .sp { margin-left: auto; letter-spacing: 0; text-transform: none; font-size: 12px; }
+  .row { display: flex; justify-content: space-between; align-items: center; gap: 12px; padding: 6px 0; border-bottom: 1px solid var(--ln); }
+  .row .val { color: var(--mu); font-variant-numeric: tabular-nums; text-align: right; display: flex; align-items: center; gap: 8px; flex: none; }
+  .row .val.t { color: var(--t); }
+  .desc { font-size: 12px; color: var(--mu); margin-top: 1px; }
+  .tg { width: 34px; height: 18px; border-radius: 9px; background: rgba(255,255,255,.22); position: relative; flex: none; }
+  .tg::after { content: ""; position: absolute; top: 2px; left: 2px; width: 14px; height: 14px; border-radius: 50%; background: #fff; }
+  .tg.on { background: var(--blue); }
+  .tg.on::after { left: 18px; }
+  .btn { display: flex; justify-content: space-between; align-items: center; gap: 10px; background: var(--fill); padding: 6px 10px; border-radius: 2px; font-weight: 500; margin-top: 6px; color: #fff; font-size: 13px; }
+  .btn .ar { color: var(--mu); }
+  .btn.sm { padding: 3px 8px; font-size: 12px; margin: 0; }
+  .btns { display: flex; gap: 6px; margin-top: 6px; }
+  .tbl { width: 100%; border-collapse: collapse; font-size: 13px; }
+  .tbl th { font-size: 10px; text-transform: uppercase; letter-spacing: .08em; color: var(--mu); text-align: left; padding: 4px 6px; border-bottom: 1px solid var(--ln2); font-weight: 500; }
+  .tbl td { padding: 6px 6px; border-bottom: 1px solid var(--ln); vertical-align: middle; }
+  .tbl td.tnum { font-variant-numeric: tabular-nums; }
+  .tbl td.cell { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 0; }
+  .mu { color: var(--mu); } .ok { color: var(--ok); }
+  .here { color: #6ab04c; font-size: 12px; margin-left: 8px; }
+  .m { display: inline-block; width: 17px; height: 17px; border-radius: 50%; background: #c4731a; color: #fff;
+      font: 600 10px/17px var(--font-mono); text-align: center; vertical-align: middle; margin-left: 6px; flex: none; }
+  .inl { background: rgba(255,255,255,.045); border-left: 2px solid var(--warn); padding: 6px 10px; margin-top: 6px; }
+  .two { display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; padding: 6px 0; border-bottom: 1px solid var(--ln); }
+  .two .rt { color: var(--mu); font-size: 13px; flex: none; font-variant-numeric: tabular-nums; }
+</style>
+
+</head>
+<body>
+
+<div class="top">
+  <h1>Tender Device List Layouts <small>#1816 · Settings › Save Sync · panel 854 px, list 264 px</small></h1>
+  <div class="switch">
+    <span class="lab">VARIANT</span>
+    <button class="chip" data-v="a" aria-pressed="false">A — today</button>
+    <button class="chip" data-v="b" aria-pressed="false">B — three columns <span class="rec">CHOSEN</span></button>
+    <button class="chip" data-v="c" aria-pressed="false">C — two columns</button>
+  </div>
+</div>
+
+<main>
+  <h2>How the registered devices are drawn</h2>
+  <p class="sub">
+    Three layouts for one block: the devices registered with the RomM server for save-file sync. Everything else on the
+    page is identical across the three so the comparison is about the block alone. Switch above. <strong>B was
+    chosen.</strong>
+  </p>
+
+  <div class="facts">
+    <dl>
+      <dt>Width</dt>
+      <dd>The panel is <strong>854 px</strong> and the content <strong>806 px</strong>. The section list takes
+        <strong>264 px</strong>, leaving about <strong>530 px</strong> for the detail pane. Drawn on the same stage as
+        the other studies, 854 × 534.</dd>
+      <dt>Height</dt>
+      <dd>The scarce axis. The Library study measured about <strong>263 px</strong> of body — but with a tab row.
+        Settings has no tabs and gets that height back. What hangs below the fold is still reachable only by moving
+        focus.</dd>
+      <dt>The facts per device</dt>
+      <dd>The server answers with five: name, client, client version, platform, last seen — plus an id and the
+        “this device” mark.</dd>
+      <dt>Why it was a question at all</dt>
+      <dd>The Tables rule asks for aligned columns, because a device row carries more than two facts. But every other
+        row in this pane is a Steam <code>Field</code> — label left, value right — so a grid here is the only content
+        on the page in a second visual language.</dd>
+    </dl>
+  </div>
+
+  <!-- ============ VARIANT A ============ -->
+  <div class="variant" id="v-a">
+    <h3>A — the shape it has today</h3>
+    <div class="stage" data-w="854" data-h="534"><div class="deck">
+      <div class="bgtile" style="left:40px;top:120px;width:300px;height:200px"></div>
+      <div class="qam">
+        <div class="rail"><i></i><i class="c"></i><i></i><i class="c"></i><i></i><i class="on"></i></div>
+        <div class="content">
+          <div class="dtitle"><span class="ar">‹</span> Tender</div>
+          <div class="phead"><span class="back">‹ Back</span><span class="ptitle">Settings</span></div>
+          <div class="cols">
+            <div class="list">
+              <div class="lrow"><span class="nm">Connections</span></div>
+              <div class="lrow sel"><span class="nm">Save Sync</span></div>
+              <div class="lrow"><span class="nm">Controller</span></div>
+              <div class="lrow"><span class="nm">Steam Library</span></div>
+              <div class="lrow"><span class="nm">Advanced</span></div>
+            </div>
+            <div class="pane">
+              <div class="inl">Save file sorting changed<div class="desc">Your saves are stored the old way.</div>
+                <div class="btns"><span class="btn sm">Migrate</span><span class="btn sm">Dismiss</span></div>
+              </div>
+              <div class="sec-t">Save Sync</div>
+              <div class="row"><span>Enable save sync</span><span class="val"><span class="tg on"></span></span></div>
+              <div class="row"><span>This device<div class="desc">Steam Deck</div></span><span class="val t">Rename ›</span></div>
+              <div class="row"><span>Sync before launch</span><span class="val"><span class="tg on"></span></span></div>
+              <div class="row"><span>Sync after exit</span><span class="val"><span class="tg on"></span></span></div>
+              <div class="row"><span>Default slot</span><span class="val t">Slot 1 ›</span></div>
+              <div class="row"><span>Version history limit</span><span class="val t">10</span></div>
+              <div class="btn"><span>Sync all now</span><span class="ar">›</span></div>
+              <div class="sec-t">Registered Devices <span class="m">A</span></div>
+              <div class="row" style="display:block">
+                <span>Steam Deck<span class="here">(this device)</span></span>
+                <div class="desc">tender v0.32.0 · linux · last seen 2 minutes ago · ID a1b2c3d4</div>
+              </div>
+              <div class="row" style="display:block">
+                <span>Living-room PC</span>
+                <div class="desc">tender v0.31.0 · linux · last seen 6 days ago · ID 7f2e91bc</div>
+              </div>
+              <div class="row" style="display:block">
+                <span>Old Deck</span>
+                <div class="desc">tender v0.29.1 · linux · last seen 3 months ago · ID c05a44d1</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div></div>
+    <div class="caption"><span>nothing to build</span><span>3 devices = 6 rows</span><span>matches the rows above it</span></div>
+
+    <div class="notes">
+      <ol>
+        <li><span class="mk">A</span><p><strong>Name on top, everything else small underneath</strong> as one sentence
+          with separators. This is what the plugin renders today.</p></li>
+        <li><span class="mk">·</span><p><strong>Comparing means reading.</strong> Whether the living-room machine runs
+          an older client sits mid-sentence — at a different place in every row, because the names differ in
+          length.</p></li>
+        <li><span class="mk">·</span><p><strong>Two rows per device.</strong> Three devices cost six rows; eight cost
+          sixteen, half of them small print.</p></li>
+        <li><span class="mk">·</span><p><strong>What it buys:</strong> nothing stands out. The block looks like the
+          toggles and values above it because it is built from the same pieces.</p></li>
+      </ol>
+    </div>
+  </div>
+
+  <!-- ============ VARIANT B ============ -->
+  <div class="variant" id="v-b">
+    <h3>B — three columns with a header · chosen</h3>
+    <div class="stage" data-w="854" data-h="534"><div class="deck">
+      <div class="bgtile" style="left:40px;top:120px;width:300px;height:200px"></div>
+      <div class="qam">
+        <div class="rail"><i></i><i class="c"></i><i></i><i class="c"></i><i></i><i class="on"></i></div>
+        <div class="content">
+          <div class="dtitle"><span class="ar">‹</span> Tender</div>
+          <div class="phead"><span class="back">‹ Back</span><span class="ptitle">Settings</span></div>
+          <div class="cols">
+            <div class="list">
+              <div class="lrow"><span class="nm">Connections</span></div>
+              <div class="lrow sel"><span class="nm">Save Sync</span></div>
+              <div class="lrow"><span class="nm">Controller</span></div>
+              <div class="lrow"><span class="nm">Steam Library</span></div>
+              <div class="lrow"><span class="nm">Advanced</span></div>
+            </div>
+            <div class="pane">
+              <div class="inl">Save file sorting changed<div class="desc">Your saves are stored the old way.</div>
+                <div class="btns"><span class="btn sm">Migrate</span><span class="btn sm">Dismiss</span></div>
+              </div>
+              <div class="sec-t">Save Sync</div>
+              <div class="row"><span>Enable save sync</span><span class="val"><span class="tg on"></span></span></div>
+              <div class="row"><span>This device<div class="desc">Steam Deck</div></span><span class="val t">Rename ›</span></div>
+              <div class="row"><span>Sync before launch</span><span class="val"><span class="tg on"></span></span></div>
+              <div class="row"><span>Sync after exit</span><span class="val"><span class="tg on"></span></span></div>
+              <div class="row"><span>Default slot</span><span class="val t">Slot 1 ›</span></div>
+              <div class="row"><span>Version history limit</span><span class="val t">10</span></div>
+              <div class="btn"><span>Sync all now</span><span class="ar">›</span></div>
+              <div class="sec-t">Registered Devices <span class="sp">3</span></div>
+              <table class="tbl">
+                <thead><tr><th>Device</th><th>Client</th><th>Last seen</th></tr></thead>
+                <tbody>
+                  <tr><td class="cell" style="width:46%">Steam Deck<span class="here">(this)</span></td><td class="cell tnum" style="width:27%">tender v0.32.0</td><td class="cell tnum" style="width:27%">2 minutes ago</td></tr>
+                  <tr><td class="cell">Living-room PC</td><td class="cell tnum">tender v0.31.0</td><td class="cell tnum">6 days ago</td></tr>
+                  <tr><td class="cell">Old Deck</td><td class="cell tnum mu">tender v0.29.1</td><td class="cell tnum mu">3 months ago</td></tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div></div>
+    <div class="caption"><span>~50 lines plus its test</span><span>3 devices = 4 rows incl. header</span><span>platform and id drop out</span></div>
+
+    <div class="notes">
+      <ol>
+        <li><span class="mk">B</span><p><strong>Values line up.</strong> “6 days ago” under “2 minutes ago” — which
+          machine has been away is a glance, not a read.</p></li>
+        <li><span class="mk">·</span><p><strong>One row per device.</strong> Eight devices cost nine rows instead of
+          sixteen, on the axis the Deck is short of.</p></li>
+        <li><span class="mk">·</span><p><strong>Two facts drop out:</strong> the platform and the shortened id. The id
+          only helps when two devices share a name; the platform is practically always the same value.</p></li>
+        <li><span class="mk">·</span><p><strong>It is the shape the Platforms detail already uses</strong> for BIOS
+          files under File / On disk / Contents, so the two pages read alike.</p></li>
+        <li><span class="mk">!</span><p><strong>The objection:</strong> in this pane it is the only content with column
+          headers. On the Platforms detail it does not stand out, because everything there is built that way. That ends
+          when the Settings panes are written against the same pane primitives.</p></li>
+      </ol>
+    </div>
+  </div>
+
+  <!-- ============ VARIANT C ============ -->
+  <div class="variant" id="v-c">
+    <h3>C — two columns, no header row</h3>
+    <div class="stage" data-w="854" data-h="534"><div class="deck">
+      <div class="bgtile" style="left:40px;top:120px;width:300px;height:200px"></div>
+      <div class="qam">
+        <div class="rail"><i></i><i class="c"></i><i></i><i class="c"></i><i></i><i class="on"></i></div>
+        <div class="content">
+          <div class="dtitle"><span class="ar">‹</span> Tender</div>
+          <div class="phead"><span class="back">‹ Back</span><span class="ptitle">Settings</span></div>
+          <div class="cols">
+            <div class="list">
+              <div class="lrow"><span class="nm">Connections</span></div>
+              <div class="lrow sel"><span class="nm">Save Sync</span></div>
+              <div class="lrow"><span class="nm">Controller</span></div>
+              <div class="lrow"><span class="nm">Steam Library</span></div>
+              <div class="lrow"><span class="nm">Advanced</span></div>
+            </div>
+            <div class="pane">
+              <div class="inl">Save file sorting changed<div class="desc">Your saves are stored the old way.</div>
+                <div class="btns"><span class="btn sm">Migrate</span><span class="btn sm">Dismiss</span></div>
+              </div>
+              <div class="sec-t">Save Sync</div>
+              <div class="row"><span>Enable save sync</span><span class="val"><span class="tg on"></span></span></div>
+              <div class="row"><span>This device<div class="desc">Steam Deck</div></span><span class="val t">Rename ›</span></div>
+              <div class="row"><span>Sync before launch</span><span class="val"><span class="tg on"></span></span></div>
+              <div class="row"><span>Sync after exit</span><span class="val"><span class="tg on"></span></span></div>
+              <div class="row"><span>Default slot</span><span class="val t">Slot 1 ›</span></div>
+              <div class="row"><span>Version history limit</span><span class="val t">10</span></div>
+              <div class="btn"><span>Sync all now</span><span class="ar">›</span></div>
+              <div class="sec-t">Registered Devices <span class="sp">3</span></div>
+              <div class="two">
+                <span>Steam Deck<span class="here">(this device)</span><div class="desc">tender v0.32.0</div></span>
+                <span class="rt">2 minutes ago</span>
+              </div>
+              <div class="two">
+                <span>Living-room PC<div class="desc">tender v0.31.0</div></span>
+                <span class="rt">6 days ago</span>
+              </div>
+              <div class="two">
+                <span>Old Deck<div class="desc">tender v0.29.1</div></span>
+                <span class="rt">3 months ago</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div></div>
+    <div class="caption"><span>~20 lines plus its test</span><span>3 devices = 6 rows</span><span>no header row</span></div>
+
+    <div class="notes">
+      <ol>
+        <li><span class="mk">C</span><p><strong>The middle.</strong> Last seen right-aligned like every other value on
+          the page — it is the fact people actually compare. The client stays small under the name.</p></li>
+        <li><span class="mk">·</span><p><strong>No break in the language.</strong> It reads like “Default slot ▸ Slot
+          1”, because it is the same shape: label left, value right.</p></li>
+        <li><span class="mk">·</span><p><strong>But still two rows per device</strong>, and the client versions still do
+          not line up — they are only shorter than today.</p></li>
+        <li><span class="mk">·</span><p><strong>Without headers</strong> “2 minutes ago” has to speak for itself. For a
+          last-seen time it does; for a column of bare numbers it would not.</p></li>
+      </ol>
+    </div>
+  </div>
+
+  <h3>Side by side</h3>
+  <div class="cmpwrap">
+    <table class="cmp">
+      <thead><tr><th></th><th>A — today</th><th>B — three columns</th><th>C — two columns</th></tr></thead>
+      <tbody>
+        <tr><td>Rows at 3 devices</td><td>6</td><td class="y">4</td><td>6</td></tr>
+        <tr><td>Rows at 8 devices</td><td class="n">16</td><td class="y">9</td><td class="n">16</td></tr>
+        <tr><td>Values line up</td><td class="n">no</td><td class="y">all three</td><td>last seen only</td></tr>
+        <tr><td>Matches the rest of the pane</td><td class="y">yes</td><td class="n">no — the only content with column headers</td><td class="y">yes</td></tr>
+        <tr><td>What the Tables rule asks for</td><td class="n">no</td><td class="y">yes</td><td class="n">in part</td></tr>
+        <tr><td>Facts dropped</td><td>none</td><td>platform, id</td><td>platform, id</td></tr>
+        <tr><td>Cost</td><td class="y">none — it is built</td><td>~50 lines + test</td><td>~20 lines + test</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="recbox">
+    <b>Chosen: B</b>
+    One row per device is worth the break in language on the axis the Deck is short of, and the break itself is
+    temporary: it ends when the remaining Settings panes are written against the same pane primitives the Platforms
+    detail uses. The platform and the shortened id are dropped with it — the id only distinguishes devices that share a
+    name, and the platform is practically always the same value.
+  </div>
+</main>
+
+<script>
+  (function () {
+    var KEY = "tender-device-list-layouts";
+    var state = { v: "b" };
+    try { Object.assign(state, JSON.parse(localStorage.getItem(KEY) || "{}")); } catch (e) {}
+
+    function fit() {
+      document.querySelectorAll(".variant.on .stage").forEach(function (s) {
+        var w = s.clientWidth; if (!w) return;
+        var dw = Number(s.dataset.w), dh = Number(s.dataset.h);
+        var sc = Math.min(1, w / dw);
+        var deck = s.querySelector(".deck");
+        deck.style.width = dw + "px";
+        deck.style.height = dh + "px";
+        deck.style.transform = "scale(" + sc + ")";
+        s.style.height = Math.round(dh * sc) + "px";
+      });
+    }
+    function apply() {
+      document.querySelectorAll(".variant").forEach(function (el) { el.classList.toggle("on", el.id === "v-" + state.v); });
+      document.querySelectorAll(".chip[data-v]").forEach(function (c) { c.setAttribute("aria-pressed", String(c.dataset.v === state.v)); });
+      try { localStorage.setItem(KEY, JSON.stringify(state)); } catch (e) {}
+      fit();
+    }
+    document.querySelectorAll(".chip[data-v]").forEach(function (c) {
+      c.addEventListener("click", function () { state.v = c.dataset.v; apply(); window.scrollTo({ top: 0 }); });
+    });
+    if ("ResizeObserver" in window) new ResizeObserver(fit).observe(document.body);
+    window.addEventListener("resize", fit);
+    if (document.fonts && document.fonts.ready) document.fonts.ready.then(fit);
+    apply();
+  })();
+</script>
+
+</body>
+</html>

--- a/docs/assets/device-list-layouts.html
+++ b/docs/assets/device-list-layouts.html
@@ -168,6 +168,11 @@
       <dt>The facts per device</dt>
       <dd>The server answers with five: name, client, client version, platform, last seen — plus an id and the
         “this device” mark.</dd>
+      <dt>What the client column holds</dt>
+      <dd>The rows above are the mix a real listing carries: this plugin registers as <code>Tender</code> since the
+        rename, RomM keeps what earlier versions wrote under <code>decky-romm-sync</code>, and RomM's own frontend
+        registers <code>web</code>. Those older rows do not expire, which is why the column is sized for the longest of
+        the three rather than for today's name.</dd>
       <dt>Why it was a question at all</dt>
       <dd>The Tables rule asks for aligned columns, because a device row carries more than two facts. But every other
         row in this pane is a Steam <code>Field</code> — label left, value right — so a grid here is the only content
@@ -208,15 +213,15 @@
               <div class="sec-t">Registered Devices <span class="m">A</span></div>
               <div class="row" style="display:block">
                 <span>Steam Deck<span class="here">(this device)</span></span>
-                <div class="desc">decky-romm-sync v0.32.0 · linux · last seen just now · ID a1b2c3d4</div>
+                <div class="desc">Tender v0.33.0 · linux · last seen just now · ID a1b2c3d4</div>
               </div>
               <div class="row" style="display:block">
                 <span>Living-room PC</span>
                 <div class="desc">decky-romm-sync v0.31.0 · linux · last seen 3 Sep · ID 7f2e91bc</div>
               </div>
               <div class="row" style="display:block">
-                <span>Old Deck</span>
-                <div class="desc">decky-romm-sync v0.29.1 · linux · last seen 12 Jun · ID c05a44d1</div>
+                <span>Chrome on Linux</span>
+                <div class="desc">web v148 · linux · last seen 12 Jun · ID c05a44d1</div>
               </div>
             </div>
           </div>
@@ -274,9 +279,9 @@
               <table class="tbl">
                 <thead><tr><th>Device</th><th>Client</th><th>Last seen</th></tr></thead>
                 <tbody>
-                  <tr><td class="cell" style="width:58%">Steam Deck<span class="here">(this)</span></td><td class="cell tnum" style="width:27%">decky-romm-sync v0.32.0</td><td class="cell tnum" style="width:15%">just now</td></tr>
+                  <tr><td class="cell" style="width:58%">Steam Deck<span class="here">(this)</span></td><td class="cell tnum" style="width:27%">Tender v0.33.0</td><td class="cell tnum" style="width:15%">just now</td></tr>
                   <tr><td class="cell">Living-room PC</td><td class="cell tnum">decky-romm-sync v0.31.0</td><td class="cell tnum">3 Sep</td></tr>
-                  <tr><td class="cell">Old Deck</td><td class="cell tnum mu">decky-romm-sync v0.29.1</td><td class="cell tnum mu">12 Jun</td></tr>
+                  <tr><td class="cell">Chrome on Linux</td><td class="cell tnum mu">web v148</td><td class="cell tnum mu">12 Jun</td></tr>
                 </tbody>
               </table>
             </div>
@@ -336,7 +341,7 @@
               <div class="btn"><span>Sync all now</span><span class="ar">›</span></div>
               <div class="sec-t">Registered Devices <span class="sp">3</span></div>
               <div class="two">
-                <span>Steam Deck<span class="here">(this device)</span><div class="desc">decky-romm-sync v0.32.0</div></span>
+                <span>Steam Deck<span class="here">(this device)</span><div class="desc">Tender v0.33.0</div></span>
                 <span class="rt">just now</span>
               </div>
               <div class="two">
@@ -344,7 +349,7 @@
                 <span class="rt">3 Sep</span>
               </div>
               <div class="two">
-                <span>Old Deck<div class="desc">decky-romm-sync v0.29.1</div></span>
+                <span>Chrome on Linux<div class="desc">web v148</div></span>
                 <span class="rt">12 Jun</span>
               </div>
             </div>

--- a/docs/assets/device-list-layouts.html
+++ b/docs/assets/device-list-layouts.html
@@ -208,15 +208,15 @@
               <div class="sec-t">Registered Devices <span class="m">A</span></div>
               <div class="row" style="display:block">
                 <span>Steam Deck<span class="here">(this device)</span></span>
-                <div class="desc">tender v0.32.0 · linux · last seen 2 minutes ago · ID a1b2c3d4</div>
+                <div class="desc">decky-romm-sync v0.32.0 · linux · last seen just now · ID a1b2c3d4</div>
               </div>
               <div class="row" style="display:block">
                 <span>Living-room PC</span>
-                <div class="desc">tender v0.31.0 · linux · last seen 6 days ago · ID 7f2e91bc</div>
+                <div class="desc">decky-romm-sync v0.31.0 · linux · last seen 3 Sep · ID 7f2e91bc</div>
               </div>
               <div class="row" style="display:block">
                 <span>Old Deck</span>
-                <div class="desc">tender v0.29.1 · linux · last seen 3 months ago · ID c05a44d1</div>
+                <div class="desc">decky-romm-sync v0.29.1 · linux · last seen 12 Jun · ID c05a44d1</div>
               </div>
             </div>
           </div>
@@ -274,9 +274,9 @@
               <table class="tbl">
                 <thead><tr><th>Device</th><th>Client</th><th>Last seen</th></tr></thead>
                 <tbody>
-                  <tr><td class="cell" style="width:46%">Steam Deck<span class="here">(this)</span></td><td class="cell tnum" style="width:27%">tender v0.32.0</td><td class="cell tnum" style="width:27%">2 minutes ago</td></tr>
-                  <tr><td class="cell">Living-room PC</td><td class="cell tnum">tender v0.31.0</td><td class="cell tnum">6 days ago</td></tr>
-                  <tr><td class="cell">Old Deck</td><td class="cell tnum mu">tender v0.29.1</td><td class="cell tnum mu">3 months ago</td></tr>
+                  <tr><td class="cell" style="width:58%">Steam Deck<span class="here">(this)</span></td><td class="cell tnum" style="width:27%">decky-romm-sync v0.32.0</td><td class="cell tnum" style="width:15%">just now</td></tr>
+                  <tr><td class="cell">Living-room PC</td><td class="cell tnum">decky-romm-sync v0.31.0</td><td class="cell tnum">3 Sep</td></tr>
+                  <tr><td class="cell">Old Deck</td><td class="cell tnum mu">decky-romm-sync v0.29.1</td><td class="cell tnum mu">12 Jun</td></tr>
                 </tbody>
               </table>
             </div>
@@ -288,8 +288,9 @@
 
     <div class="notes">
       <ol>
-        <li><span class="mk">B</span><p><strong>Values line up.</strong> “6 days ago” under “2 minutes ago” — which
-          machine has been away is a glance, not a read.</p></li>
+        <li><span class="mk">B</span><p><strong>Values line up.</strong> Last seen answers a relative time while a
+          device is recent and a bare date once it is not, so a column of them separates the machines that are still
+          around from the ones that are not — a glance, where a sentence is a read.</p></li>
         <li><span class="mk">·</span><p><strong>One row per device.</strong> Eight devices cost nine rows instead of
           sixteen, on the axis the Deck is short of.</p></li>
         <li><span class="mk">·</span><p><strong>Two facts drop out:</strong> the platform and the shortened id. The id
@@ -335,16 +336,16 @@
               <div class="btn"><span>Sync all now</span><span class="ar">›</span></div>
               <div class="sec-t">Registered Devices <span class="sp">3</span></div>
               <div class="two">
-                <span>Steam Deck<span class="here">(this device)</span><div class="desc">tender v0.32.0</div></span>
-                <span class="rt">2 minutes ago</span>
+                <span>Steam Deck<span class="here">(this device)</span><div class="desc">decky-romm-sync v0.32.0</div></span>
+                <span class="rt">just now</span>
               </div>
               <div class="two">
-                <span>Living-room PC<div class="desc">tender v0.31.0</div></span>
-                <span class="rt">6 days ago</span>
+                <span>Living-room PC<div class="desc">decky-romm-sync v0.31.0</div></span>
+                <span class="rt">3 Sep</span>
               </div>
               <div class="two">
-                <span>Old Deck<div class="desc">tender v0.29.1</div></span>
-                <span class="rt">3 months ago</span>
+                <span>Old Deck<div class="desc">decky-romm-sync v0.29.1</div></span>
+                <span class="rt">12 Jun</span>
               </div>
             </div>
           </div>
@@ -361,7 +362,7 @@
           1”, because it is the same shape: label left, value right.</p></li>
         <li><span class="mk">·</span><p><strong>But still two rows per device</strong>, and the client versions still do
           not line up — they are only shorter than today.</p></li>
-        <li><span class="mk">·</span><p><strong>Without headers</strong> “2 minutes ago” has to speak for itself. For a
+        <li><span class="mk">·</span><p><strong>Without headers</strong> “just now” has to speak for itself. For a
           last-seen time it does; for a column of bare numbers it would not.</p></li>
       </ol>
     </div>

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -1,11 +1,49 @@
 # Configuration
 
-All settings are accessible from the plugin's QAM panel. Open the Quick Access Menu (**...** button) and navigate to the
-Tender plugin.
+All settings are accessible from the plugin's QAM panel. Open the Quick Access Menu (**...** button), navigate to the
+Tender plugin, and pick **Settings** from the menu at the bottom of the panel.
+
+## The Settings page
+
+Settings is a wide page split in two: a list of five sections on the left, and the focused section's controls on the
+right. Move onto a section in the list and the right-hand side changes at once — there is nothing to confirm.
+
+| Section           | What is in it                                                                                                                                                                                                  |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Connections**   | the services Tender talks to: **RomM** (server URL, account, Sign out, Allow Insecure SSL) and **SteamGridDB** (the API key)                                                                                   |
+| **Save Sync**     | the save-sync switch and its settings (device, before launch, after exit, default slot, history limit, Sync All Saves Now), the list of registered devices, and the save-sorting migration when one is waiting |
+| **Controller**    | Steam Input Mode, Apply to All Shortcuts, and the RetroArch `input_driver` fix                                                                                                                                 |
+| **Steam Library** | preferred region, collection games in platform groups, collection types in Steam names                                                                                                                         |
+| **Advanced**      | log level                                                                                                                                                                                                      |
+
+If you used an earlier version, everything is still here — the eight blocks the panel used to stack are grouped into
+those five. Registered Devices and the save-sorting migration are now inside **Save Sync**, the SteamGridDB key is
+inside **Connections**, and the section that used to be called **Library** is now **Steam Library**: the Library _page_
+is about what gets synced out of RomM, this section is about how it looks once it is in Steam.
+
+**Signing in to RetroAchievements is not here yet.** When it arrives it will live under Connections, with the other
+accounts.
+
+### Getting there from a notice
+
+Three of the notices on the plugin's main panel are doors into a section, and the action they are about lives only
+behind that door:
+
+| The notice says                | Its button           | Where it takes you     |
+| ------------------------------ | -------------------- | ---------------------- |
+| RetroArch: input_driver issue  | **Open Controller**  | Settings › Controller  |
+| RetroArch save sorting changed | **Open Save Sync**   | Settings › Save Sync   |
+| Cross-device playtime          | **Open Connections** | Settings › Connections |
+
+The main panel only names the condition — it no longer carries a Fix button or the migration's own buttons, so there is
+one place to do each of these and no chance of two of them disagreeing. **B** takes you back to the main panel from
+anywhere on the page.
+
+Where the sections below say "in Connection Settings", read it as **Settings › Connections**.
 
 ## Connection Settings
 
-The Connection Settings page manages your RomM server connection.
+The **Connections** section manages your RomM server connection.
 
 <!-- Screenshot: Connection Settings page -->
 
@@ -119,6 +157,8 @@ carry them. `me.write` is deliberately **not** requested — a pasted token cann
 
 ## SteamGridDB API Key
 
+Under **Settings › Connections**, below the RomM group — SteamGridDB is one of the two services Tender talks to.
+
 The plugin uses [SteamGridDB](https://www.steamgriddb.com/) to fetch additional artwork for your games — hero banners,
 logos, and wide grid images. RomM provides cover art, but SteamGridDB fills in the rest so your games look like
 first-class Steam titles.
@@ -127,7 +167,7 @@ To set this up:
 
 1. Create a free account at [steamgriddb.com](https://www.steamgriddb.com/)
 2. Go to your [API preferences](https://www.steamgriddb.com/profile/preferences/api) and copy your API key
-3. In Connection Settings, tap **Edit** next to **API Key** under "SteamGridDB" and paste your key
+3. In **Settings › Connections**, tap **Edit** next to **API Key** under "SteamGridDB" and paste your key
 4. Tap **Save** — the key is checked against SteamGridDB first, so an invalid key is rejected inline and only a working
    key is stored
 
@@ -138,8 +178,7 @@ will be missing.
 
 ## Steam Input Mode
 
-Controls how Steam handles controller input for ROM shortcuts. Found under the **Controller** section in Connection
-Settings.
+Controls how Steam handles controller input for ROM shortcuts. Found in **Settings › Controller**.
 
 | Mode                      | Description                                                                                                                |
 | ------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
@@ -147,15 +186,17 @@ Settings.
 | **Force On**              | Explicitly enables Steam Input wrapping. Normalizes the controller as standard XInput, which RetroArch autoconfig expects. |
 | **Force Off**             | Raw HID passthrough. Only for advanced users — may break RetroArch menu navigation.                                        |
 
-After changing the mode, tap **Apply to All Shortcuts** to update all existing ROM shortcuts.
+After changing the mode, tap **Apply to All Shortcuts** to update all existing ROM shortcuts. The button reads
+**Applying to all shortcuts…** and stops responding while the run is going — a second tap is refused rather than
+starting a second pass over the same shortcuts.
 
 <!-- Screenshot: Steam Input Mode dropdown with the three options -->
 
 ## Preferred region
 
-A dropdown in the **Library** section of the settings page. When a game exists in your RomM library as several regional
-dumps (versions), this decides which region the plugin prefers when it picks the version to bind and the name it gives
-the Steam shortcut.
+A dropdown in **Settings › Steam Library**. When a game exists in your RomM library as several regional dumps
+(versions), this decides which region the plugin prefers when it picks the version to bind and the name it gives the
+Steam shortcut.
 
 | Option                                   | Effect                                                                                              |
 | ---------------------------------------- | --------------------------------------------------------------------------------------------------- |
@@ -178,7 +219,7 @@ picture.
 
 ## Log Level
 
-A dropdown in the **Advanced** section on the main page. Controls how much detail the plugin logs.
+A dropdown in **Settings › Advanced**. Controls how much detail the plugin logs.
 
 | Level              | Description                        |
 | ------------------ | ---------------------------------- |
@@ -193,8 +234,10 @@ problems.
 ## RetroArch Input Driver Fix
 
 If the plugin detects that RetroArch is using the `x` input driver (which causes controller issues in menus on Wayland
-systems), a warning appears on the main page with a **Change to sdl2** button. This modifies your RetroArch config to
-use `sdl2` instead, which fixes controller navigation in RetroArch menus.
+systems), a notice appears on the main panel with an **Open Controller** button. The fix itself is in **Settings ›
+Controller**: **Fix input_driver to sdl2** modifies your RetroArch config to use `sdl2` instead, which fixes controller
+navigation in RetroArch menus. The result is reported under the button, and the warning goes away once the config has
+been changed.
 
 <!-- Screenshot: RetroArch input_driver warning with fix button -->
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -239,6 +239,11 @@ Controller**: **Fix input_driver to sdl2** modifies your RetroArch config to use
 navigation in RetroArch menus. The result is reported under the button, and the warning goes away once the config has
 been changed.
 
+The button **asks before it acts** — it opens a confirmation naming the change, and only **Apply Fix** writes anything;
+**Cancel** leaves your config exactly as it was. The confirmation is there because the change is made in place and the
+plugin keeps no copy of the file it replaces, so if you have hand-edited your `retroarch.cfg` and want a copy, take one
+before confirming.
+
 <!-- Screenshot: RetroArch input_driver warning with fix button -->
 
 ---

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -102,7 +102,7 @@ location — your existing settings and synced library are in the older install 
 After installation, you need to connect the plugin to your RomM server:
 
 1. Open the QAM and find **Tender**
-2. Tap **Connection Settings**
+2. Tap **Settings** in the menu, then **Connections** in the section list on the left
 3. Enter your RomM server URL (e.g. `http://192.168.1.100:8080`) — this saves automatically
 4. Tap **Sign in**, enter your RomM username and password once, and confirm
 5. The **RomM Account** row shows **Signed in** on success. The plugin's main QAM panel has a **Connection** row that

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -202,7 +202,7 @@ keep a particular recovery copy long-term, move it out of `.romm-backup` yoursel
 
 **Symptom**: Games have cover art but no hero banner, logo, or wide grid image. The detail page background is blank.
 
-**Fix**: Configure a SteamGridDB API key in [Connection Settings](configuration.md#steamgriddb-api-key). It's free —
+**Fix**: Configure a SteamGridDB API key in [Settings › Connections](configuration.md#steamgriddb-api-key). It's free —
 create an account at steamgriddb.com and copy your API key.
 
 ### Game not found on SteamGridDB

--- a/src/components/MainPage.test.tsx
+++ b/src/components/MainPage.test.tsx
@@ -15,8 +15,6 @@
 //   - handleCancel try/catch → showTransientStatus("Failed to cancel sync"),
 //     surfaced under the still-running progress rows (the status field is not
 //     gated on the run being idle).
-//   - fixRetroarchInputDriver inline `.catch(() => {})` (inside ConfirmModal
-//     onOK) — truly-ignored; warning state remains (no clear).
 //
 // MUTATION CHECKS (by inspection — auto-mode classifier likely blocks on
 // React state internals + listener cleanup, so confidence is recorded here):
@@ -36,7 +34,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, fireEvent, act } from "@testing-library/react";
-import { createElement, useSyncExternalStore, type ReactElement } from "react";
+import { createElement, useSyncExternalStore } from "react";
 import { MainPage, ConnectionIndicator } from "./MainPage";
 import * as backend from "../api/backend";
 import { useVersionError } from "./VersionErrorCard";
@@ -56,9 +54,9 @@ import { setDownloads } from "../utils/downloadStore";
 import { resetConnectionProbeForTests } from "../utils/connectionProbe";
 import { resetSyncStatsStoreForTests } from "../utils/syncStatsStore";
 import { setLegacyInstallState } from "../utils/legacyInstallStore";
+import { setPlaytimeScopeState } from "../utils/playtimeScopeStore";
 import { LEGACY_INSTALL_TITLE } from "./LegacyInstallBanner";
 import { resetPendingPreviewStoreForTests, adoptPreview, clearPendingPreview } from "../utils/pendingPreviewStore";
-import { showModal } from "@decky/ui";
 import * as syncManager from "../utils/syncManager";
 import * as connectionState from "../utils/connectionState";
 import { firstBodyStop, pageEntryStop, placeEntryFocus } from "../utils/entryFocus";
@@ -152,8 +150,7 @@ vi.mock("../utils/syncManager", () => ({
 }));
 
 // Local @decky/ui re-mock — global stub lacks ProgressBar (used to render sync
-// + download progress). Mirror the rest with thin pass-throughs + a vi.fn
-// showModal so we can capture ConfirmModal calls.
+// + download progress). Mirror the rest with thin pass-throughs.
 vi.mock("@decky/ui", async () => {
   type AnyProps = Record<string, unknown> & { children?: unknown };
   const { createElement: ce } = await import("react");
@@ -296,13 +293,6 @@ function buttonByExactText(container: HTMLElement, text: string): HTMLButtonElem
   return (btn as HTMLButtonElement | undefined) ?? null;
 }
 
-function lastConfirmModalProps<T = Record<string, unknown>>(): T | null {
-  const calls = vi.mocked(showModal).mock.calls;
-  if (calls.length === 0) return null;
-  const el = calls[calls.length - 1]?.[0] as ReactElement<T> | undefined;
-  return el?.props ?? null;
-}
-
 /** What the conditional slot says, or `null` where there is no slot at all. */
 function slotLabel(container: HTMLElement): string | null {
   return container.querySelector('[data-testid="sync-slot-label"]')?.textContent ?? null;
@@ -383,6 +373,11 @@ describe("MainPage", () => {
       };
     });
 
+    // The playtime-scope store is module-level and outlives a render, so a test
+    // that raises the condition would leave the notice standing over every test
+    // after it.
+    setPlaytimeScopeState({ pending: false });
+
     // Default backend mocks — tests override per case.
     vi.mocked(backend.refreshMigrationState).mockResolvedValue({
       retrodeck: { pending: false },
@@ -451,10 +446,6 @@ describe("MainPage", () => {
     vi.mocked(backend.clearSyncCache).mockResolvedValue({
       success: true,
       message: "Cleared",
-    });
-    vi.mocked(backend.fixRetroarchInputDriver).mockResolvedValue({
-      success: true,
-      message: "Fixed",
     });
 
     // Reset version error spy + connectionState side-channel.
@@ -527,7 +518,7 @@ describe("MainPage", () => {
       const { container } = render(<MainPage onNavigate={vi.fn()} />);
       await flushAsync();
 
-      const noticeButton = buttonByExactText(container, "Go to Settings");
+      const noticeButton = buttonByExactText(container, "Open Save Sync");
       expect(noticeButton).not.toBeNull();
       expect(container.querySelector("button")).toBe(noticeButton);
       expect(pageEntryStop(container)?.textContent).toBe("Sync");
@@ -2569,81 +2560,31 @@ describe("MainPage", () => {
   // ===========================================================================
   // J. handleClearCache — Force Full Sync flow
   // ===========================================================================
-  describe("handleFixInputDriver (via ConfirmModal onOK)", () => {
-    async function renderWithWarning(): Promise<HTMLElement> {
+  describe("the input_driver notice", () => {
+    async function renderWithWarning(onNavigate = vi.fn()): Promise<HTMLElement> {
       vi.mocked(backend.getSettings).mockResolvedValue({
         ...defaultSettings(),
         retroarch_input_check: { warning: true, current: "udev" },
       });
-      const { container } = render(<MainPage onNavigate={vi.fn()} />);
+      const { container } = render(<MainPage onNavigate={onNavigate} />);
       await flushAsync();
       return container;
     }
 
-    it("clicking the Fix button opens the ConfirmModal via showModal", async () => {
+    it("names the condition and carries no fix of its own", async () => {
       const container = await renderWithWarning();
-      const fixBtn = Array.from(container.querySelectorAll('[data-testid="dialog-button"]')).find(
-        (b) => b.textContent === "Fix",
-      ) as HTMLButtonElement | undefined;
-      expect(fixBtn).not.toBeUndefined();
-      fireEvent.click(fixBtn!);
-      expect(vi.mocked(showModal)).toHaveBeenCalledTimes(1);
-      const props = lastConfirmModalProps<{
-        strTitle?: string;
-        strOKButtonText?: string;
-      }>();
-      expect(props?.strTitle).toBe("Fix RetroArch input_driver?");
-      expect(props?.strOKButtonText).toBe("Apply Fix");
+      expect(container.textContent).toContain("RetroArch: input_driver issue");
+      // The fix's only home is Settings › Controller: Main offers the door and
+      // never the action, so nothing here can write the RetroArch config.
+      expect(buttonByExactText(container, "Fix")).toBeNull();
+      expect(vi.mocked(backend.fixRetroarchInputDriver)).not.toHaveBeenCalled();
     });
 
-    it("onOK success=true clears the retroarchWarning section", async () => {
-      vi.mocked(backend.fixRetroarchInputDriver).mockResolvedValue({
-        success: true,
-        message: "Done",
-      });
-      const container = await renderWithWarning();
-      const fixBtn = Array.from(container.querySelectorAll('[data-testid="dialog-button"]')).find(
-        (b) => b.textContent === "Fix",
-      ) as HTMLButtonElement | undefined;
-      fireEvent.click(fixBtn!);
-      const props = lastConfirmModalProps<{ onOK?: () => void | Promise<void> }>();
-      await act(async () => {
-        await props?.onOK?.();
-      });
-      expect(container.textContent).not.toContain("RetroArch: input_driver");
-    });
-
-    it("onOK success=false leaves the warning in place", async () => {
-      vi.mocked(backend.fixRetroarchInputDriver).mockResolvedValue({
-        success: false,
-        message: "Could not write",
-      });
-      const container = await renderWithWarning();
-      const fixBtn = Array.from(container.querySelectorAll('[data-testid="dialog-button"]')).find(
-        (b) => b.textContent === "Fix",
-      ) as HTMLButtonElement | undefined;
-      fireEvent.click(fixBtn!);
-      const props = lastConfirmModalProps<{ onOK?: () => void | Promise<void> }>();
-      await act(async () => {
-        await props?.onOK?.();
-      });
-      // Warning stays
-      expect(container.textContent).toContain("RetroArch: input_driver");
-    });
-
-    it("onOK rejection is silently swallowed (warning stays, no crash)", async () => {
-      vi.mocked(backend.fixRetroarchInputDriver).mockRejectedValue(new Error("perm"));
-      const container = await renderWithWarning();
-      const fixBtn = Array.from(container.querySelectorAll('[data-testid="dialog-button"]')).find(
-        (b) => b.textContent === "Fix",
-      ) as HTMLButtonElement | undefined;
-      fireEvent.click(fixBtn!);
-      const props = lastConfirmModalProps<{ onOK?: () => void | Promise<void> }>();
-      await act(async () => {
-        await props?.onOK?.();
-      });
-      // Truly-ignored catch — warning unchanged.
-      expect(container.textContent).toContain("RetroArch: input_driver");
+    it("Open Controller lands on Settings › Controller", async () => {
+      const onNavigate = vi.fn();
+      const container = await renderWithWarning(onNavigate);
+      fireEvent.click(buttonByExactText(container, "Open Controller")!);
+      expect(onNavigate).toHaveBeenCalledWith({ page: "settings", section: "controller" });
     });
   });
 
@@ -2688,7 +2629,7 @@ describe("MainPage", () => {
       expect(buttonByExactText(container, "System")).toBeNull();
     });
 
-    it("clicking 'Go to Settings' (save-sort migration banner) invokes onNavigate('settings')", async () => {
+    it("the save-sort notice's Open Save Sync lands on Settings › Save Sync", async () => {
       currentSaveSortState = { pending: true, saves_count: 3 };
       // refreshMigrationState runs on mount and writes save_sort back to the
       // store — also return pending:true so the banner stays visible.
@@ -2699,8 +2640,23 @@ describe("MainPage", () => {
       const onNavigate = vi.fn();
       const { container } = render(<MainPage onNavigate={onNavigate} />);
       await flushAsync();
-      fireEvent.click(buttonByExactText(container, "Go to Settings")!);
-      expect(onNavigate).toHaveBeenCalledWith("settings");
+      // The migration itself has one home, and this is not it: Main names the
+      // condition, Settings › Save Sync holds Migrate and Dismiss.
+      expect(buttonByExactText(container, "Migrate Save Files")).toBeNull();
+      fireEvent.click(buttonByExactText(container, "Open Save Sync")!);
+      expect(onNavigate).toHaveBeenCalledWith({ page: "settings", section: "save-sync" });
+    });
+
+    it("the playtime-scope notice's Open Connections lands on Settings › Connections", async () => {
+      vi.mocked(backend.getPlaytimeScopeNotice).mockResolvedValue({ pending: true });
+      const onNavigate = vi.fn();
+      const { container } = render(<MainPage onNavigate={onNavigate} />);
+      await flushAsync();
+      // Dismiss is still beside it — the jump did not replace the way to end
+      // the notice locally.
+      expect(buttonByExactText(container, "Dismiss")).not.toBeNull();
+      fireEvent.click(buttonByExactText(container, "Open Connections")!);
+      expect(onNavigate).toHaveBeenCalledWith({ page: "settings", section: "connections" });
     });
 
     it("clicking 'View All' (Downloads section) invokes onNavigate('downloads')", async () => {

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -703,7 +703,7 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
           </PanelSectionRow>
         )}
         {/* A notice, not the fix: the button that rewrites the RetroArch config
-            is in Settings \u203A Controller and nowhere else. */}
+            is in Settings › Controller and nowhere else. */}
         {retroarchWarning?.warning && (
           <>
             <PanelSectionRow>

--- a/src/components/MainPage.tsx
+++ b/src/components/MainPage.tsx
@@ -1,21 +1,9 @@
 import { useState, useEffect, useRef, FC, ReactNode } from "react";
-import {
-  PanelSection,
-  PanelSectionRow,
-  ButtonItem,
-  Field,
-  Focusable,
-  ProgressBar,
-  Spinner,
-  DialogButton,
-  ConfirmModal,
-  showModal,
-} from "@decky/ui";
+import { PanelSection, PanelSectionRow, ButtonItem, Field, Focusable, ProgressBar, Spinner } from "@decky/ui";
 import { FaCheckCircle, FaTimesCircle, FaExclamationTriangle } from "react-icons/fa";
 import {
   cancelSync,
   getSettings,
-  fixRetroarchInputDriver,
   refreshMigrationState,
   getSyncStatus,
   getRetroDeckStatus,
@@ -46,12 +34,12 @@ import { SettingsResetBanner } from "./SettingsResetBanner";
 import { LegacyInstallNotice } from "./LegacyInstallBanner";
 import { DataLocationNotice } from "./DataLocationNotice";
 import { PlaytimeScopeBanner } from "./PlaytimeScopeBanner";
-import type { SyncPreview, SyncProgress, SyncRunKind, SyncStats, Page } from "../types";
+import type { SyncPreview, SyncProgress, SyncRunKind, SyncStats, NavTarget } from "../types";
 import { detach } from "../utils/detach";
 import { wrapText } from "../utils/textStyles";
 
 interface MainPageProps {
-  onNavigate: (page: Exclude<Page, "main">) => void;
+  onNavigate: (target: NavTarget) => void;
 }
 
 /** The connection-row label for a failed probe, mapped from the backend's
@@ -588,7 +576,9 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
     <>
       <LegacyInstallNotice />
       {settingsReset.pending && <SettingsResetBanner backedUpTo={settingsReset.backedUpTo} />}
-      {playtimeScope.pending && <PlaytimeScopeBanner />}
+      {playtimeScope.pending && (
+        <PlaytimeScopeBanner onOpenConnections={() => onNavigate({ page: "settings", section: "connections" })} />
+      )}
       {/* Untitled status block (Connection / Last sync / Library) leads the
           panel — a hairline is what separates one block from the next, so a
           "Status" title would cost a row and buy nothing. */}
@@ -712,43 +702,28 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
             />
           </PanelSectionRow>
         )}
+        {/* A notice, not the fix: the button that rewrites the RetroArch config
+            is in Settings \u203A Controller and nowhere else. */}
         {retroarchWarning?.warning && (
-          <PanelSectionRow>
-            <Field
-              label="RetroArch: input_driver issue"
-              description={`Using "${retroarchWarning.current}"`}
-              bottomSeparator="none"
-            >
-              <DialogButton
-                onClick={() =>
-                  showModal(
-                    <ConfirmModal
-                      strTitle="Fix RetroArch input_driver?"
-                      strDescription="This will change input_driver to sdl2 in your RetroArch config. Controllers should work better in RetroArch menus after this change."
-                      strOKButtonText="Apply Fix"
-                      strCancelButtonText="Cancel"
-                      onOK={() => {
-                        detach(
-                          (async () => {
-                            try {
-                              const result = await fixRetroarchInputDriver();
-                              if (result.success) {
-                                setRetroarchWarning(null);
-                              }
-                            } catch {
-                              // ignore
-                            }
-                          })(),
-                        );
-                      }}
-                    />,
-                  )
-                }
+          <>
+            <PanelSectionRow>
+              <Field
+                label="RetroArch: input_driver issue"
+                description={`Using "${retroarchWarning.current}" \u2014 controller navigation in RetroArch menus may not work.`}
+                focusable={true}
+                bottomSeparator="none"
+              />
+            </PanelSectionRow>
+            <PanelSectionRow>
+              <ButtonItem
+                layout="below"
+                bottomSeparator="none"
+                onClick={() => onNavigate({ page: "settings", section: "controller" })}
               >
-                Fix
-              </DialogButton>
-            </Field>
-          </PanelSectionRow>
+                Open Controller
+              </ButtonItem>
+            </PanelSectionRow>
+          </>
         )}
         {saveSortMigration.pending && (
           <>
@@ -773,8 +748,12 @@ export const MainPage: FC<MainPageProps> = ({ onNavigate }) => {
               </Focusable>
             </PanelSectionRow>
             <PanelSectionRow>
-              <ButtonItem layout="below" bottomSeparator="none" onClick={() => onNavigate("settings")}>
-                Go to Settings
+              <ButtonItem
+                layout="below"
+                bottomSeparator="none"
+                onClick={() => onNavigate({ page: "settings", section: "save-sync" })}
+              >
+                Open Save Sync
               </ButtonItem>
             </PanelSectionRow>
           </>

--- a/src/components/PlaytimeScopeBanner.test.tsx
+++ b/src/components/PlaytimeScopeBanner.test.tsx
@@ -29,7 +29,7 @@ const ScopeBannerHost: FC = () => {
     const unsub = onPlaytimeScopeChange(() => setScope(getPlaytimeScopeState()));
     return unsub;
   }, []);
-  return scope.pending ? <PlaytimeScopeBanner /> : null;
+  return scope.pending ? <PlaytimeScopeBanner onOpenConnections={() => {}} /> : null;
 };
 
 describe("PlaytimeScopeBanner component", () => {
@@ -39,7 +39,7 @@ describe("PlaytimeScopeBanner component", () => {
   });
 
   it("renders the PanelSection title + the sign-in message", () => {
-    const { container } = render(<PlaytimeScopeBanner />);
+    const { container } = render(<PlaytimeScopeBanner onOpenConnections={vi.fn()} />);
     // PanelSection's `title` prop is forwarded by the global stub as a DOM
     // attribute on <section>, so assert via getAttribute, not textContent.
     const section = container.querySelector("section");
@@ -49,13 +49,24 @@ describe("PlaytimeScopeBanner component", () => {
   });
 
   it("renders a Dismiss button", () => {
-    const { getByText } = render(<PlaytimeScopeBanner />);
+    const { getByText } = render(<PlaytimeScopeBanner onOpenConnections={vi.fn()} />);
     expect(getByText("Dismiss")).toBeInTheDocument();
+  });
+
+  it("Open Connections calls the jump and leaves the condition standing", () => {
+    setPlaytimeScopeState({ pending: true });
+    const onOpenConnections = vi.fn();
+    const { getByText } = render(<PlaytimeScopeBanner onOpenConnections={onOpenConnections} />);
+    fireEvent.click(getByText("Open Connections"));
+    expect(onOpenConnections).toHaveBeenCalledTimes(1);
+    // The jump is not an answer: only a fresh sign-in ends the condition, so
+    // the notice is still pending when the reader comes back.
+    expect(getPlaytimeScopeState()).toEqual({ pending: true });
   });
 
   it("Dismiss → clears the shared store (local dismiss, no backend call)", async () => {
     setPlaytimeScopeState({ pending: true });
-    const { getByText } = render(<PlaytimeScopeBanner />);
+    const { getByText } = render(<PlaytimeScopeBanner onOpenConnections={vi.fn()} />);
     await act(async () => {
       fireEvent.click(getByText("Dismiss"));
       await flushAsync();

--- a/src/components/PlaytimeScopeBanner.tsx
+++ b/src/components/PlaytimeScopeBanner.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import { PanelSection, PanelSectionRow, ButtonItem } from "@decky/ui";
+import { PanelSection, PanelSectionRow, DialogButton, Focusable } from "@decky/ui";
 import { setPlaytimeScopeState } from "../utils/playtimeScopeStore";
 
 /** Title of the account-wide QAM playtime-scope banner. */
@@ -16,8 +16,11 @@ export const PLAYTIME_SCOPE_MESSAGE = "Sign in again to enable cross-device play
  * is no backend dismiss callable: the durable flag clears itself once a scoped
  * token is minted (a fresh sign-in or a later successful reconcile), so the
  * next MainPage mount re-fetches the real state.
+ *
+ * The condition's home is Settings › Connections, where the accounts are: the
+ * sign-in that ends it exists only there, and this notice is the door to it.
  */
-export const PlaytimeScopeBanner: FC = () => {
+export const PlaytimeScopeBanner: FC<{ onOpenConnections: () => void }> = ({ onOpenConnections }) => {
   const handleDismiss = () => {
     setPlaytimeScopeState({ pending: false });
   };
@@ -49,9 +52,17 @@ export const PlaytimeScopeBanner: FC = () => {
         </div>
       </PanelSectionRow>
       <PanelSectionRow>
-        <ButtonItem layout="below" onClick={handleDismiss}>
-          Dismiss
-        </ButtonItem>
+        {/* Two buttons on one row rather than two full-width rows: Main is the
+            narrow page, and a notice that costs three rows pushes the status
+            block it sits above off the screen. */}
+        <Focusable flow-children="horizontal" style={{ display: "flex", gap: "8px" }}>
+          <DialogButton style={{ flex: "1 1 auto", minWidth: 0 }} onClick={onOpenConnections}>
+            Open Connections
+          </DialogButton>
+          <DialogButton style={{ flex: "1 1 auto", minWidth: 0 }} onClick={handleDismiss}>
+            Dismiss
+          </DialogButton>
+        </Focusable>
       </PanelSectionRow>
     </PanelSection>
   );

--- a/src/components/SettingsPage.test.tsx
+++ b/src/components/SettingsPage.test.tsx
@@ -10,6 +10,7 @@ import { render, fireEvent, act } from "@testing-library/react";
 import { createElement, useSyncExternalStore, type ComponentProps, type ReactElement } from "react";
 import { SettingsPage } from "./SettingsPage";
 import * as backend from "../api/backend";
+import { ENTRY_STOP_ATTR } from "../utils/entryFocus";
 import type { SaveSortMigrationStatus, RegisteredDevice, SettingsSection } from "../types";
 import { showModal } from "@decky/ui";
 import { toaster } from "@decky/api";
@@ -1955,6 +1956,24 @@ describe("SettingsPage", () => {
       await flushAsync();
       expect(capturedController.length).toBeGreaterThan(0);
       expect(capturedConnection).toHaveLength(0);
+    });
+
+    it("declares that section's row the area entry focus belongs in, so the open is not undone", async () => {
+      // Mounting on the section is only half of it: focus selects on this
+      // layout, so entry focus landing on row one would select Connections a
+      // moment later — which is what a notice's Open Controller did on the
+      // device. The declaration is what the frame places focus on instead.
+      //
+      // **The undoing itself is not reachable here.** It needs Steam's focus
+      // resolution after the mount and the frame's timer; happy-dom has no nav
+      // tree, so what this pins is the mark, and the frame reading it is pinned
+      // in `qam/WidePage.test.tsx`.
+      openOn = "controller";
+      const { getByTestId } = renderPage();
+      await flushAsync();
+
+      expect(getByTestId("settings-section-controller").closest(`[${ENTRY_STOP_ATTR}]`)).not.toBeNull();
+      expect(getByTestId("settings-section-connections").closest(`[${ENTRY_STOP_ATTR}]`)).toBeNull();
     });
 
     it("opens on the first section when a navigation names none", async () => {

--- a/src/components/SettingsPage.test.tsx
+++ b/src/components/SettingsPage.test.tsx
@@ -1954,7 +1954,7 @@ describe("SettingsPage", () => {
       renderPage();
       await flushAsync();
       expect(capturedController.length).toBeGreaterThan(0);
-      expect(capturedConnection.length).toBe(0);
+      expect(capturedConnection).toHaveLength(0);
     });
 
     it("opens on the first section when a navigation names none", async () => {
@@ -1970,9 +1970,7 @@ describe("SettingsPage", () => {
       expect(queryByTestId("advanced-section")).toBeNull();
       // The wrapper the layout puts round each row is what carries the activate
       // handler; the press on the row's own content bubbles to it.
-      await act(async () => {
-        fireEvent.click(getByTestId("settings-section-advanced"));
-      });
+      fireEvent.click(getByTestId("settings-section-advanced"));
       expect(queryByTestId("advanced-section")).not.toBeNull();
       expect(queryByTestId("connection-section")).toBeNull();
     });
@@ -1980,9 +1978,7 @@ describe("SettingsPage", () => {
     it("moving focus onto a row selects it, without a press", async () => {
       const { getByTestId, queryByTestId } = renderPage();
       await flushAsync();
-      await act(async () => {
-        fireEvent.focus(getByTestId("settings-section-steam-library"));
-      });
+      fireEvent.focus(getByTestId("settings-section-steam-library"));
       expect(queryByTestId("library-section")).not.toBeNull();
     });
 
@@ -1995,9 +1991,7 @@ describe("SettingsPage", () => {
     ] as const)("reaches every section's content: %s", async (section, testId) => {
       const { getByTestId, queryByTestId } = renderPage();
       await flushAsync();
-      await act(async () => {
-        fireEvent.click(getByTestId(`settings-section-${section}`));
-      });
+      fireEvent.click(getByTestId(`settings-section-${section}`));
       expect(queryByTestId(testId)).not.toBeNull();
     });
 

--- a/src/components/SettingsPage.test.tsx
+++ b/src/components/SettingsPage.test.tsx
@@ -10,7 +10,7 @@ import { render, fireEvent, act } from "@testing-library/react";
 import { createElement, useSyncExternalStore, type ComponentProps, type ReactElement } from "react";
 import { SettingsPage } from "./SettingsPage";
 import * as backend from "../api/backend";
-import type { SaveSortMigrationStatus, RegisteredDevice } from "../types";
+import type { SaveSortMigrationStatus, RegisteredDevice, SettingsSection } from "../types";
 import { showModal } from "@decky/ui";
 import { toaster } from "@decky/api";
 import {
@@ -120,23 +120,53 @@ vi.mock("./settings/TextInputModal", () => ({
   pendingEdits: {} as { url?: string; username?: string; password?: string },
 }));
 
-// Local @decky/ui re-mock — the global stub in src/test-setup.ts doesn't ship
-// a ButtonItem (used here for Back), so render() would crash on "Element type
-// is invalid". We mirror the stubs we need (ButtonItem + ConfirmModal +
-// showModal + PanelSection/Row) and keep showModal a vi.fn so the call-capture
-// pattern still works.
+// Local @decky/ui re-mock — the page is a wide list-and-detail page, so the
+// frame and the layout it wraps need Focusable (the row wrapper the layout
+// makes a focus stop), DialogButton (the Back chip) and Field (a section row).
+// showModal stays a vi.fn so the call-capture pattern still works.
 type AnyProps = Record<string, unknown> & { children?: unknown };
 vi.mock("@decky/ui", () => ({
   PanelSection: (p: AnyProps) => createElement("section", null, p.children as never),
   PanelSectionRow: (p: AnyProps) => createElement("div", null, p.children as never),
   ButtonItem: (p: AnyProps & { onClick?: () => void }) =>
     createElement("button", { onClick: p.onClick }, p.children as never),
+  DialogButton: (p: AnyProps & { onClick?: () => void }) =>
+    createElement("button", { onClick: p.onClick }, p.children as never),
+  Field: (p: AnyProps & { label?: unknown }) => createElement("div", { "data-testid": "field" }, p.label as never),
+  // onFocus is how the layout learns focus moved onto a row, and onActivate is
+  // what `selectOnActivate` puts there — surfaced as onClick so a test can
+  // press a section row the way a reader does. Dropping either would make the
+  // selection vacuously untestable.
+  Focusable: (p: AnyProps & { onFocus?: (e: unknown) => void; onActivate?: (e: unknown) => void }) =>
+    createElement(
+      "div",
+      { "data-testid": "focusable", onFocus: p.onFocus, onClick: p.onActivate },
+      p.children as never,
+    ),
   ConfirmModal: (p: AnyProps) => createElement("div", { "data-testid": "confirm-modal" }, p.children as never),
   showModal: vi.fn(),
+  useQuickAccessVisible: () => true,
 }));
 
-// scrollToTop is a no-op in jsdom; mock for cleanliness.
-vi.mock("../utils/scrollHelpers", () => ({ scrollToTop: vi.fn() }));
+// The wide frame reaches Steam's tabbed page and its scroll panel through this
+// module — a webpack probe with no answer under happy-dom. Settings is untabbed,
+// so only the absences matter here.
+vi.mock("../utils/deckyUiInternals", () => ({
+  quickAccessMenuClasses: undefined,
+  ScrollPanel: undefined,
+  findSP: () => undefined,
+  ControllerGlyph: undefined,
+  GLYPH_BUTTON_B: 1,
+  Tabs: undefined,
+}));
+
+// Scroll helpers are no-ops without a layout engine; the frame reads
+// offsetWithinScroller when it measures its body.
+vi.mock("../utils/scrollHelpers", () => ({
+  scrollToTop: vi.fn(),
+  scrollElementToTop: vi.fn(),
+  offsetWithinScroller: () => 0,
+}));
 
 // Mock the saveSortMigrationStore — own listener list + state so tests can
 // drive the subscribe/unsubscribe + state-change flow deterministically.
@@ -213,8 +243,17 @@ function lastConfirmModalProps<T = Record<string, unknown>>(): T | null {
   return el?.props ?? null;
 }
 
+// Which section the page opens on for the tests below. The page is list and
+// detail, so a section's props reach its component only while that section is
+// the selected one — a describe whose tests are about one section declares it
+// here rather than every test re-stating it.
+let openOn: SettingsSection = "connections";
+
+const renderPage = () => render(<SettingsPage onBack={vi.fn()} section={openOn} />);
+
 describe("SettingsPage", () => {
   beforeEach(() => {
+    openOn = "connections";
     vi.resetAllMocks();
     capturedConnection.length = 0;
     capturedSgdb.length = 0;
@@ -244,18 +283,22 @@ describe("SettingsPage", () => {
   });
 
   describe("initial mount — getSettings", () => {
-    it("applies the full settings payload to ConnectionSection / SteamGridDBSection / ControllerSection / AdvancedSection", async () => {
-      vi.mocked(backend.getSettings).mockResolvedValue({
-        ...defaultSettings(),
-        romm_url: "https://my.romm",
-        has_token: true,
-        romm_allow_insecure_ssl: true,
-        sgdb_api_key_masked: "abc",
-        steam_input_mode: "force_on",
-        log_level: "debug",
-        retroarch_input_check: { warning: true, current: "sdl2" },
-      });
-      render(<SettingsPage onBack={vi.fn()} />);
+    // The payload feeds four sections and the pane mounts one at a time, so
+    // each half of the hydration is asserted on the section that shows it.
+    const fullPayload = (): import("../types").PluginSettings => ({
+      ...defaultSettings(),
+      romm_url: "https://my.romm",
+      has_token: true,
+      romm_allow_insecure_ssl: true,
+      sgdb_api_key_masked: "abc",
+      steam_input_mode: "force_on",
+      log_level: "debug",
+      retroarch_input_check: { warning: true, current: "sdl2" },
+    });
+
+    it("applies the payload's connection half to ConnectionSection / SteamGridDBSection", async () => {
+      vi.mocked(backend.getSettings).mockResolvedValue(fullPayload());
+      renderPage();
       await flushAsync();
 
       const conn = capturedConnection[capturedConnection.length - 1];
@@ -265,18 +308,31 @@ describe("SettingsPage", () => {
 
       const sgdb = capturedSgdb[capturedSgdb.length - 1];
       expect(sgdb?.sgdbApiKey).toBe("abc");
+    });
+
+    it("applies the payload's controller half to ControllerSection", async () => {
+      openOn = "controller";
+      vi.mocked(backend.getSettings).mockResolvedValue(fullPayload());
+      renderPage();
+      await flushAsync();
 
       const ctrl = capturedController[capturedController.length - 1];
       expect(ctrl?.steamInputMode).toBe("force_on");
       expect(ctrl?.retroarchWarning).toEqual({ warning: true, current: "sdl2" });
+    });
 
-      const adv = capturedAdvanced[capturedAdvanced.length - 1];
-      expect(adv?.logLevel).toBe("debug");
+    it("applies the payload's log level to AdvancedSection", async () => {
+      openOn = "advanced";
+      vi.mocked(backend.getSettings).mockResolvedValue(fullPayload());
+      renderPage();
+      await flushAsync();
+
+      expect(capturedAdvanced[capturedAdvanced.length - 1]?.logLevel).toBe("debug");
     });
 
     it("prefers a pendingEdits URL over the backend value", async () => {
       pendingEdits.url = "https://pending.url";
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
 
       const conn = capturedConnection[capturedConnection.length - 1];
@@ -288,13 +344,14 @@ describe("SettingsPage", () => {
         ...defaultSettings(),
         has_token: false,
       });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       expect(capturedConnection[capturedConnection.length - 1]?.hasToken).toBe(false);
     });
 
     it("does not set retroarchWarning when retroarch_input_check is absent", async () => {
-      render(<SettingsPage onBack={vi.fn()} />);
+      openOn = "controller";
+      renderPage();
       await flushAsync();
       expect(capturedController[capturedController.length - 1]?.retroarchWarning).toBeNull();
     });
@@ -302,7 +359,7 @@ describe("SettingsPage", () => {
     it("logs the failure and surfaces 'Failed to load settings' when getSettings rejects", async () => {
       vi.mocked(backend.getSettings).mockRejectedValue(new Error("boom"));
       const logSpy = vi.spyOn(backend, "logError").mockImplementation(() => {});
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Failed to load settings"));
       logSpy.mockRestore();
@@ -310,10 +367,14 @@ describe("SettingsPage", () => {
   });
 
   describe("initial mount — getSaveSyncSettings", () => {
+    beforeEach(() => {
+      openOn = "save-sync";
+    });
+
     it("forwards the fetched settings to SaveSyncSection", async () => {
       const s = { ...defaultSaveSyncSettings(), save_sync_enabled: true };
       vi.mocked(backend.getSaveSyncSettings).mockResolvedValue(s);
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       const ss = capturedSaveSync[capturedSaveSync.length - 1];
       expect(ss?.saveSyncSettings).toEqual(s);
@@ -324,7 +385,7 @@ describe("SettingsPage", () => {
         ...defaultSaveSyncSettings(),
         save_sync_enabled: true,
       });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       expect(vi.mocked(backend.ensureDeviceRegistered)).toHaveBeenCalledTimes(1);
       expect(vi.mocked(backend.listDevices)).toHaveBeenCalledTimes(1);
@@ -335,7 +396,7 @@ describe("SettingsPage", () => {
 
     it("does NOT call ensureDeviceRegistered / listDevices when disabled", async () => {
       // defaults to disabled
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       expect(vi.mocked(backend.ensureDeviceRegistered)).not.toHaveBeenCalled();
       expect(vi.mocked(backend.listDevices)).not.toHaveBeenCalled();
@@ -351,7 +412,7 @@ describe("SettingsPage", () => {
         device_id: "",
         device_name: "",
       });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       expect(capturedSaveSync[capturedSaveSync.length - 1]?.deviceInfo).toBeNull();
     });
@@ -363,7 +424,7 @@ describe("SettingsPage", () => {
       });
       vi.mocked(backend.ensureDeviceRegistered).mockRejectedValue(new Error("net"));
       const logSpy = vi.spyOn(backend, "logError").mockImplementation(() => {});
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       expect(capturedSaveSync[capturedSaveSync.length - 1]?.deviceInfo).toBeNull();
       // Catch is `.catch(() => {})` — rejection must NOT escape to logError.
@@ -374,7 +435,7 @@ describe("SettingsPage", () => {
     it("logs the failure when getSaveSyncSettings rejects", async () => {
       vi.mocked(backend.getSaveSyncSettings).mockRejectedValue(new Error("denied"));
       const logSpy = vi.spyOn(backend, "logError").mockImplementation(() => {});
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Failed to load save sync settings"));
       logSpy.mockRestore();
@@ -382,6 +443,10 @@ describe("SettingsPage", () => {
   });
 
   describe("initial mount — getSaveSortMigrationStatus", () => {
+    beforeEach(() => {
+      openOn = "save-sync";
+    });
+
     it("forwards a pending status into the store and into local state", async () => {
       const pending: SaveSortMigrationStatus = {
         pending: true,
@@ -390,7 +455,7 @@ describe("SettingsPage", () => {
         saves_count: 5,
       };
       vi.mocked(backend.getSaveSortMigrationStatus).mockResolvedValue(pending);
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       expect(vi.mocked(setSaveSortMigrationStatus)).toHaveBeenCalledWith(pending);
       expect(capturedMigration[capturedMigration.length - 1]?.migration).toEqual(pending);
@@ -398,7 +463,7 @@ describe("SettingsPage", () => {
 
     it("does nothing when the status is not pending", async () => {
       // defaults — pending=false
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       expect(vi.mocked(setSaveSortMigrationStatus)).not.toHaveBeenCalled();
     });
@@ -406,7 +471,7 @@ describe("SettingsPage", () => {
     it("silently swallows a getSaveSortMigrationStatus rejection", async () => {
       vi.mocked(backend.getSaveSortMigrationStatus).mockRejectedValue(new Error("oops"));
       const logSpy = vi.spyOn(backend, "logError").mockImplementation(() => {});
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       // No logError for this branch — it's a fire-and-forget probe.
       const calls = logSpy.mock.calls.map((c) => c[0]);
@@ -416,6 +481,10 @@ describe("SettingsPage", () => {
   });
 
   describe("loadDevices flow", () => {
+    beforeEach(() => {
+      openOn = "save-sync";
+    });
+
     it("forwards the devices list down on listDevices success", async () => {
       vi.mocked(backend.getSaveSyncSettings).mockResolvedValue({
         ...defaultSaveSyncSettings(),
@@ -434,7 +503,7 @@ describe("SettingsPage", () => {
         },
       ];
       vi.mocked(backend.listDevices).mockResolvedValue({ success: true, devices });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       expect(capturedDevices[capturedDevices.length - 1]?.registeredDevices).toEqual(devices);
     });
@@ -449,7 +518,7 @@ describe("SettingsPage", () => {
         devices: [],
         disabled: true,
       });
-      const { queryByTestId } = render(<SettingsPage onBack={vi.fn()} />);
+      const { queryByTestId } = renderPage();
       await flushAsync();
       expect(queryByTestId("devices-section")).toBeNull();
     });
@@ -469,7 +538,7 @@ describe("SettingsPage", () => {
         reason: "server_unreachable",
         message: "Could not load devices",
       });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       const d = capturedDevices[capturedDevices.length - 1];
       expect(d?.devicesError).toBe("Could not load devices");
@@ -487,7 +556,7 @@ describe("SettingsPage", () => {
         success: false,
         devices: [],
       });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       expect(capturedDevices[capturedDevices.length - 1]?.devicesError).toBe("Failed to load devices");
     });
@@ -498,7 +567,7 @@ describe("SettingsPage", () => {
         save_sync_enabled: true,
       });
       vi.mocked(backend.listDevices).mockRejectedValue(new Error("network down"));
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       const d = capturedDevices[capturedDevices.length - 1];
       expect(d?.devicesError).toBe("network down");
@@ -511,7 +580,7 @@ describe("SettingsPage", () => {
         save_sync_enabled: true,
       });
       vi.mocked(backend.listDevices).mockRejectedValue("string error");
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       expect(capturedDevices[capturedDevices.length - 1]?.devicesError).toBe("Failed to load devices");
     });
@@ -521,7 +590,7 @@ describe("SettingsPage", () => {
     it("handleUrlChange persists URL + SSL via saveServerUrl and clears the pending URL edit", async () => {
       vi.mocked(backend.saveServerUrl).mockResolvedValue({ success: true, message: "" });
       pendingEdits.url = "draft";
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       const conn = capturedConnection[capturedConnection.length - 1];
 
@@ -536,7 +605,7 @@ describe("SettingsPage", () => {
 
     it("rejects an invalid URL inline without calling saveServerUrl", async () => {
       vi.mocked(backend.saveServerUrl).mockResolvedValue({ success: true, message: "" });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       const conn = capturedConnection[capturedConnection.length - 1];
 
@@ -553,7 +622,7 @@ describe("SettingsPage", () => {
 
     it("trims the URL before persisting", async () => {
       vi.mocked(backend.saveServerUrl).mockResolvedValue({ success: true, message: "" });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       const conn = capturedConnection[capturedConnection.length - 1];
 
@@ -565,10 +634,10 @@ describe("SettingsPage", () => {
       expect(vi.mocked(backend.saveServerUrl)).toHaveBeenCalledWith("https://new.url", false);
     });
 
-    it("does not delete the pending URL edit when saveServerUrl rejects (status fallback wired)", async () => {
+    it("clears the pending URL edit when saveServerUrl rejects (status fallback wired)", async () => {
       vi.mocked(backend.saveServerUrl).mockRejectedValue(new Error("nope"));
       pendingEdits.url = "draft";
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       const conn = capturedConnection[capturedConnection.length - 1];
 
@@ -577,13 +646,47 @@ describe("SettingsPage", () => {
         await Promise.resolve();
       });
 
-      expect(pendingEdits.url).toBe("draft");
+      expect(pendingEdits.url).toBeUndefined();
       expect(capturedConnection[capturedConnection.length - 1]?.status).toBe("Failed to save settings");
+    });
+
+    it("clears the pending URL edit when the URL is refused as invalid", async () => {
+      pendingEdits.url = "draft";
+      renderPage();
+      await flushAsync();
+      const conn = capturedConnection[capturedConnection.length - 1];
+
+      await act(async () => {
+        conn?.onUrlChange("romm.local");
+        await Promise.resolve();
+      });
+
+      expect(pendingEdits.url).toBeUndefined();
+    });
+
+    it("shows the saved URL, not the rejected one, at the next open (#1020)", async () => {
+      vi.mocked(backend.saveServerUrl).mockRejectedValue(new Error("nope"));
+      const first = renderPage();
+      await flushAsync();
+
+      await act(async () => {
+        capturedConnection[capturedConnection.length - 1]?.onUrlChange("https://rejected.url");
+        await Promise.resolve();
+      });
+      // The attempt is still in the field it was typed into, under the reason
+      // it did not take.
+      expect(capturedConnection[capturedConnection.length - 1]?.url).toBe("https://rejected.url");
+      first.unmount();
+
+      capturedConnection.length = 0;
+      renderPage();
+      await flushAsync();
+      expect(capturedConnection[capturedConnection.length - 1]?.url).toBe("https://romm.local");
     });
 
     it("handleAllowInsecureSslChange forwards the URL + new flag to saveServerUrl", async () => {
       vi.mocked(backend.saveServerUrl).mockResolvedValue({ success: true, message: "" });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       const conn = capturedConnection[capturedConnection.length - 1];
 
@@ -597,7 +700,7 @@ describe("SettingsPage", () => {
 
     it("handleAllowInsecureSslChange surfaces 'Failed to save settings' on rejection", async () => {
       vi.mocked(backend.saveServerUrl).mockRejectedValue(new Error("ssl"));
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       const conn = capturedConnection[capturedConnection.length - 1];
 
@@ -624,7 +727,7 @@ describe("SettingsPage", () => {
         message: "Connected!",
         romm_version: "4.8.1",
       });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       // Precondition: not yet connected.
       expect(capturedConnection[capturedConnection.length - 1]?.hasToken).toBe(false);
@@ -656,7 +759,7 @@ describe("SettingsPage", () => {
         message: "This account cannot create API tokens.",
         reason: "auth_failed",
       });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
 
       let result: { success: boolean; message: string } | undefined;
@@ -677,7 +780,7 @@ describe("SettingsPage", () => {
         romm_url: "romm.local", // scheme-less — invalid
         has_token: false,
       });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
 
       let result: { success: boolean; message: string } | undefined;
@@ -692,7 +795,7 @@ describe("SettingsPage", () => {
 
     it("returns a generic failure to the modal when connectWithCredentials throws", async () => {
       vi.mocked(backend.connectWithCredentials).mockRejectedValue(new Error("net"));
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
 
       let result: { success: boolean; message: string } | undefined;
@@ -716,7 +819,7 @@ describe("SettingsPage", () => {
         message: "Connected!",
         romm_version: "4.9.0",
       });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       expect(capturedConnection[capturedConnection.length - 1]?.hasToken).toBe(false);
 
@@ -742,7 +845,7 @@ describe("SettingsPage", () => {
         message: "The API token is missing required permissions (scopes).",
         reason: "auth_failed",
       });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
 
       let result: { success: boolean; message: string } | undefined;
@@ -765,7 +868,7 @@ describe("SettingsPage", () => {
         romm_url: "romm.local", // scheme-less — invalid
         has_token: false,
       });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
 
       let result: { success: boolean; message: string } | undefined;
@@ -780,7 +883,7 @@ describe("SettingsPage", () => {
 
     it("returns a generic failure to the modal when connectWithToken throws", async () => {
       vi.mocked(backend.connectWithToken).mockRejectedValue(new Error("net"));
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
 
       let result: { success: boolean; message: string } | undefined;
@@ -804,7 +907,7 @@ describe("SettingsPage", () => {
         message: "Connected!",
         romm_version: "4.9.0",
       });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       expect(capturedConnection[capturedConnection.length - 1]?.hasToken).toBe(false);
 
@@ -832,7 +935,7 @@ describe("SettingsPage", () => {
         message: "Pairing code is invalid or has expired.",
         reason: "auth_failed",
       });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
 
       let result: { success: boolean; message: string } | undefined;
@@ -852,7 +955,7 @@ describe("SettingsPage", () => {
         romm_url: "romm.local", // scheme-less — invalid
         has_token: false,
       });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
 
       let result: { success: boolean; message: string } | undefined;
@@ -867,7 +970,7 @@ describe("SettingsPage", () => {
 
     it("returns a generic failure to the modal when connectWithPairingCode throws", async () => {
       vi.mocked(backend.connectWithPairingCode).mockRejectedValue(new Error("net"));
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
 
       let result: { success: boolean; message: string } | undefined;
@@ -890,7 +993,7 @@ describe("SettingsPage", () => {
         success: true,
         message: "Signed out. The token is still valid in RomM.",
       });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       // Precondition: signed in.
       expect(capturedConnection[capturedConnection.length - 1]?.hasToken).toBe(true);
@@ -916,7 +1019,7 @@ describe("SettingsPage", () => {
         message: "Could not save settings.",
         reason: "config_error",
       });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
 
       await act(async () => {
@@ -935,7 +1038,7 @@ describe("SettingsPage", () => {
         has_token: true,
       });
       vi.mocked(backend.signOut).mockRejectedValue(new Error("net"));
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
 
       await act(async () => {
@@ -951,6 +1054,10 @@ describe("SettingsPage", () => {
   });
 
   describe("handleSaveSyncSettingChange", () => {
+    beforeEach(() => {
+      openOn = "save-sync";
+    });
+
     it("does nothing when saveSyncSettings is still null", async () => {
       // Cause getSaveSyncSettings to never resolve — saveSyncSettings stays null.
       vi.mocked(backend.getSaveSyncSettings).mockImplementation(
@@ -959,7 +1066,7 @@ describe("SettingsPage", () => {
             /* never */
           }),
       );
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       // No flush — initial state null. capturedSaveSync still has at least one
       // entry from the synchronous first render.
       const ss = capturedSaveSync[capturedSaveSync.length - 1];
@@ -972,7 +1079,7 @@ describe("SettingsPage", () => {
 
     it("updates a non-enabled partial via updateSaveSyncSettings without dispatching", async () => {
       vi.mocked(backend.updateSaveSyncSettings).mockResolvedValue({ success: true });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
 
       const listener = vi.fn();
@@ -996,7 +1103,7 @@ describe("SettingsPage", () => {
     it("dispatches romm_data_changed with detail.save_sync_enabled=true and triggers loadDevices on enable", async () => {
       vi.mocked(backend.updateSaveSyncSettings).mockResolvedValue({ success: true });
       vi.mocked(backend.listDevices).mockResolvedValue({ success: true, devices: [] });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
 
       const listener = vi.fn();
@@ -1028,7 +1135,7 @@ describe("SettingsPage", () => {
         save_sync_enabled: true,
       });
       vi.mocked(backend.updateSaveSyncSettings).mockResolvedValue({ success: true });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
 
       const listener = vi.fn();
@@ -1059,7 +1166,7 @@ describe("SettingsPage", () => {
       });
       vi.mocked(backend.updateSaveSyncSettings).mockResolvedValue({ success: true });
       vi.mocked(backend.listDevices).mockResolvedValue({ success: true, devices: [] });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
 
       // Sanity: before disable, devices section is mounted with [] (non-null).
@@ -1101,7 +1208,7 @@ describe("SettingsPage", () => {
     it("logs the failure when updateSaveSyncSettings rejects", async () => {
       vi.mocked(backend.updateSaveSyncSettings).mockRejectedValue(new Error("denied"));
       const logSpy = vi.spyOn(backend, "logError").mockImplementation(() => {});
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       await act(async () => {
         capturedSaveSync[capturedSaveSync.length - 1]?.onSettingChange({
@@ -1114,6 +1221,10 @@ describe("SettingsPage", () => {
   });
 
   describe("handleSyncAll", () => {
+    beforeEach(() => {
+      openOn = "save-sync";
+    });
+
     it("forwards syncAllSaves result.message to syncStatus and dispatches romm_data_changed on success", async () => {
       vi.mocked(backend.syncAllSaves).mockResolvedValue({
         success: true,
@@ -1121,7 +1232,7 @@ describe("SettingsPage", () => {
         synced: 4,
         conflicts: 0,
       });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
 
       const listener = vi.fn();
@@ -1141,7 +1252,7 @@ describe("SettingsPage", () => {
 
     it("sets syncStatus='Sync failed' on throw", async () => {
       vi.mocked(backend.syncAllSaves).mockRejectedValue(new Error("net"));
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       await act(async () => {
         capturedSaveSync[capturedSaveSync.length - 1]?.onSyncAll();
@@ -1151,8 +1262,12 @@ describe("SettingsPage", () => {
   });
 
   describe("handleToggleSaveSync — enable confirmation flow", () => {
+    beforeEach(() => {
+      openOn = "save-sync";
+    });
+
     it("opens the enable-save-sync ConfirmModal when toggled to true", async () => {
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       act(() => {
         capturedSaveSync[capturedSaveSync.length - 1]?.onToggleSaveSync(true);
@@ -1177,7 +1292,7 @@ describe("SettingsPage", () => {
 
     it("invokes handleSaveSyncSettingChange({save_sync_enabled:true}) when OK is clicked", async () => {
       vi.mocked(backend.updateSaveSyncSettings).mockResolvedValue({ success: true });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       act(() => {
         capturedSaveSync[capturedSaveSync.length - 1]?.onToggleSaveSync(true);
@@ -1192,7 +1307,7 @@ describe("SettingsPage", () => {
     });
 
     it("bumps saveSyncToggleKey when Cancel is clicked", async () => {
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       const initialKey = capturedSaveSync[capturedSaveSync.length - 1]?.saveSyncToggleKey;
       expect(initialKey).toBe(0);
@@ -1210,13 +1325,17 @@ describe("SettingsPage", () => {
   });
 
   describe("handleToggleSaveSync — disable path", () => {
+    beforeEach(() => {
+      openOn = "save-sync";
+    });
+
     it("calls handleSaveSyncSettingChange({save_sync_enabled:false}) directly without showing a modal", async () => {
       vi.mocked(backend.getSaveSyncSettings).mockResolvedValue({
         ...defaultSaveSyncSettings(),
         save_sync_enabled: true,
       });
       vi.mocked(backend.updateSaveSyncSettings).mockResolvedValue({ success: true });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       await act(async () => {
         capturedSaveSync[capturedSaveSync.length - 1]?.onToggleSaveSync(false);
@@ -1230,9 +1349,13 @@ describe("SettingsPage", () => {
   });
 
   describe("default-slot submit + reset", () => {
+    beforeEach(() => {
+      openOn = "save-sync";
+    });
+
     it("forwards a trimmed non-empty value to handleSaveSyncSettingChange", async () => {
       vi.mocked(backend.updateSaveSyncSettings).mockResolvedValue({ success: true });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       await act(async () => {
         capturedSaveSync[capturedSaveSync.length - 1]?.onDefaultSlotSubmit("  alpha  ");
@@ -1245,7 +1368,7 @@ describe("SettingsPage", () => {
 
     it("resets to 'default' without a confirm modal when the value is empty", async () => {
       vi.mocked(backend.updateSaveSyncSettings).mockResolvedValue({ success: true });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       await act(async () => {
         capturedSaveSync[capturedSaveSync.length - 1]?.onDefaultSlotSubmit("   ");
@@ -1266,7 +1389,7 @@ describe("SettingsPage", () => {
 
     it("handleResetDefaultSlot sets default_slot='default' and toasts", async () => {
       vi.mocked(backend.updateSaveSyncSettings).mockResolvedValue({ success: true });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       await act(async () => {
         capturedSaveSync[capturedSaveSync.length - 1]?.onResetDefaultSlot();
@@ -1287,7 +1410,7 @@ describe("SettingsPage", () => {
   describe("SteamGridDB handlers", () => {
     it("wires onVerifyKey directly to the verifySgdbApiKey callable (tests the key without persisting)", async () => {
       vi.mocked(backend.verifySgdbApiKey).mockResolvedValue({ success: true, message: "API key is valid" });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       const sgdb = capturedSgdb[capturedSgdb.length - 1];
       await act(async () => {
@@ -1300,7 +1423,7 @@ describe("SettingsPage", () => {
 
     it("handleSaveSgdbKey persists via saveSgdbApiKey and flips the masked display to a configured key", async () => {
       vi.mocked(backend.saveSgdbApiKey).mockResolvedValue({ success: true, message: "Saved!" });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       await act(async () => {
         await capturedSgdb[capturedSgdb.length - 1]?.onSaveKey("apikey123");
@@ -1312,7 +1435,7 @@ describe("SettingsPage", () => {
 
     it("handleSaveSgdbKey lets a save rejection propagate so the modal can surface it", async () => {
       vi.mocked(backend.saveSgdbApiKey).mockRejectedValue(new Error("boom"));
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       const sgdb = capturedSgdb[capturedSgdb.length - 1];
       // The handler does not swallow — the modal's own try/catch owns the error
@@ -1324,8 +1447,12 @@ describe("SettingsPage", () => {
   });
 
   describe("Controller handlers", () => {
+    beforeEach(() => {
+      openOn = "controller";
+    });
+
     it("handleSteamInputModeChange persists via saveSteamInputSetting and updates the dropdown", async () => {
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       act(() => {
         capturedController[capturedController.length - 1]?.onModeChange("force_on");
@@ -1339,7 +1466,7 @@ describe("SettingsPage", () => {
         success: true,
         message: "Applied",
       });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       await act(async () => {
         capturedController[capturedController.length - 1]?.onApplyMode();
@@ -1348,9 +1475,54 @@ describe("SettingsPage", () => {
       expect(capturedController[capturedController.length - 1]?.steamInputStatus).toBe("Applied");
     });
 
+    it("refuses a second Apply while one run is in flight, and says so on the button (#1020)", async () => {
+      let release: ((r: { success: boolean; message: string }) => void) | undefined;
+      vi.mocked(backend.applySteamInputSetting).mockReturnValue(
+        new Promise((resolve) => {
+          release = resolve;
+        }),
+      );
+      renderPage();
+      await flushAsync();
+
+      await act(async () => {
+        capturedController[capturedController.length - 1]?.onApplyMode();
+        await Promise.resolve();
+      });
+      // The run is still going: the button is dead and says which state it is in.
+      expect(capturedController[capturedController.length - 1]?.applying).toBe(true);
+
+      await act(async () => {
+        capturedController[capturedController.length - 1]?.onApplyMode();
+        await Promise.resolve();
+      });
+      expect(vi.mocked(backend.applySteamInputSetting)).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        release?.({ success: true, message: "Applied" });
+        await Promise.resolve();
+      });
+      // Re-armed by the run ending, and the second press left no trace on the
+      // answer the first one produced.
+      expect(capturedController[capturedController.length - 1]?.applying).toBe(false);
+      expect(capturedController[capturedController.length - 1]?.steamInputStatus).toBe("Applied");
+    });
+
+    it("re-arms the Apply button after a run that threw", async () => {
+      vi.mocked(backend.applySteamInputSetting).mockRejectedValue(new Error("boom"));
+      renderPage();
+      await flushAsync();
+      await act(async () => {
+        capturedController[capturedController.length - 1]?.onApplyMode();
+        await Promise.resolve();
+      });
+      expect(capturedController[capturedController.length - 1]?.applying).toBe(false);
+      expect(capturedController[capturedController.length - 1]?.steamInputStatus).toBe("Failed to apply");
+    });
+
     it("handleApplySteamInput throw → steamInputStatus='Failed to apply'", async () => {
       vi.mocked(backend.applySteamInputSetting).mockRejectedValue(new Error("boom"));
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       await act(async () => {
         capturedController[capturedController.length - 1]?.onApplyMode();
@@ -1368,7 +1540,7 @@ describe("SettingsPage", () => {
         success: true,
         message: "Fixed",
       });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       // Pre-condition: warning is set
       expect(capturedController[capturedController.length - 1]?.retroarchWarning).not.toBeNull();
@@ -1391,7 +1563,7 @@ describe("SettingsPage", () => {
         success: false,
         message: "Could not write",
       });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       await act(async () => {
         capturedController[capturedController.length - 1]?.onFixInputDriver();
@@ -1404,7 +1576,7 @@ describe("SettingsPage", () => {
 
     it("handleFixInputDriver throw → retroarchFixStatus='Failed to apply fix'", async () => {
       vi.mocked(backend.fixRetroarchInputDriver).mockRejectedValue(new Error("perm"));
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       await act(async () => {
         capturedController[capturedController.length - 1]?.onFixInputDriver();
@@ -1415,8 +1587,12 @@ describe("SettingsPage", () => {
   });
 
   describe("Advanced handlers", () => {
+    beforeEach(() => {
+      openOn = "advanced";
+    });
+
     it("handleLogLevelChange persists via saveLogLevel and updates the dropdown", async () => {
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       act(() => {
         capturedAdvanced[capturedAdvanced.length - 1]?.onLogLevelChange("debug");
@@ -1427,32 +1603,36 @@ describe("SettingsPage", () => {
   });
 
   describe("Library handlers", () => {
+    beforeEach(() => {
+      openOn = "steam-library";
+    });
+
     it("hydrates preferredRegion from getSettings", async () => {
       vi.mocked(backend.getSettings).mockResolvedValue({
         ...defaultSettings(),
         preferred_region: "Japan",
       });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       expect(capturedLibrary[capturedLibrary.length - 1]?.preferredRegion).toBe("Japan");
     });
 
     it("defaults preferredRegion to 'auto' when getSettings omits it", async () => {
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       expect(capturedLibrary[capturedLibrary.length - 1]?.preferredRegion).toBe("auto");
     });
 
     it("forwards library regions from getKnownRegions to LibrarySection", async () => {
       vi.mocked(backend.getKnownRegions).mockResolvedValue(["Korea", "Brazil"]);
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       expect(capturedLibrary[capturedLibrary.length - 1]?.libraryRegions).toEqual(["Korea", "Brazil"]);
     });
 
     it("change → confirm shows the explanation modal, then persists and updates the dropdown", async () => {
       vi.mocked(showPreferredRegionModal).mockResolvedValue(true);
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       await act(async () => {
         capturedLibrary[capturedLibrary.length - 1]?.onPreferredRegionChange("Japan");
@@ -1468,7 +1648,7 @@ describe("SettingsPage", () => {
 
     it("change → cancel shows the modal but does NOT persist and leaves the dropdown unchanged", async () => {
       vi.mocked(showPreferredRegionModal).mockResolvedValue(false);
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       await act(async () => {
         capturedLibrary[capturedLibrary.length - 1]?.onPreferredRegionChange("Japan");
@@ -1482,7 +1662,7 @@ describe("SettingsPage", () => {
     });
 
     it("selecting the already-current region is a no-op (no modal, no save)", async () => {
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       await act(async () => {
         capturedLibrary[capturedLibrary.length - 1]?.onPreferredRegionChange("auto");
@@ -1497,20 +1677,20 @@ describe("SettingsPage", () => {
         ...defaultSettings(),
         collection_create_platform_groups: true,
       });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       expect(capturedLibrary[capturedLibrary.length - 1]?.platformGroups).toBe(true);
     });
 
     it("defaults platformGroups to false when getSettings omits it", async () => {
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       expect(capturedLibrary[capturedLibrary.length - 1]?.platformGroups).toBe(false);
     });
 
     it("onPlatformGroupsChange persists via saveCollectionPlatformGroups and flips the value", async () => {
       vi.mocked(backend.saveCollectionPlatformGroups).mockResolvedValue({ success: true });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       await act(async () => {
         capturedLibrary[capturedLibrary.length - 1]?.onPlatformGroupsChange(true);
@@ -1522,7 +1702,7 @@ describe("SettingsPage", () => {
 
     it("reverts platformGroups when saveCollectionPlatformGroups rejects", async () => {
       vi.mocked(backend.saveCollectionPlatformGroups).mockRejectedValue(new Error("boom"));
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       await act(async () => {
         capturedLibrary[capturedLibrary.length - 1]?.onPlatformGroupsChange(true);
@@ -1539,20 +1719,20 @@ describe("SettingsPage", () => {
         ...defaultSettings(),
         collection_naming_mode: "by_label",
       });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       expect(capturedLibrary[capturedLibrary.length - 1]?.namingMode).toBe("by_label");
     });
 
     it("defaults namingMode to merge when getSettings omits it", async () => {
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       expect(capturedLibrary[capturedLibrary.length - 1]?.namingMode).toBe("merge");
     });
 
     it("onNamingModeChange persists via setCollectionNamingMode and flips the value", async () => {
       vi.mocked(backend.setCollectionNamingMode).mockResolvedValue({ success: true });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       await act(async () => {
         capturedLibrary[capturedLibrary.length - 1]?.onNamingModeChange("by_label");
@@ -1564,7 +1744,7 @@ describe("SettingsPage", () => {
 
     it("reverts namingMode to its prior value when setCollectionNamingMode rejects", async () => {
       vi.mocked(backend.setCollectionNamingMode).mockRejectedValue(new Error("boom"));
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       await act(async () => {
         capturedLibrary[capturedLibrary.length - 1]?.onNamingModeChange("by_label");
@@ -1578,6 +1758,10 @@ describe("SettingsPage", () => {
   });
 
   describe("save-sort migration handlers", () => {
+    beforeEach(() => {
+      openOn = "save-sync";
+    });
+
     it("handleMigrateSaveSort success clears the store, toasts, and forwards result.message", async () => {
       vi.mocked(backend.getSaveSortMigrationStatus).mockResolvedValue({
         pending: true,
@@ -1589,7 +1773,7 @@ describe("SettingsPage", () => {
         success: true,
         message: "Moved 2 files",
       });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
 
       await act(async () => {
@@ -1614,7 +1798,7 @@ describe("SettingsPage", () => {
         success: true,
         message: "",
       });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
 
       await act(async () => {
@@ -1634,7 +1818,7 @@ describe("SettingsPage", () => {
         pending: true,
       });
       vi.mocked(backend.migrateSaveSortFiles).mockRejectedValue(new Error("io"));
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       await act(async () => {
         capturedMigration[capturedMigration.length - 1]?.onMigrate();
@@ -1648,7 +1832,7 @@ describe("SettingsPage", () => {
         pending: true,
       });
       vi.mocked(backend.dismissSaveSortMigration).mockResolvedValue({ success: true });
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       await act(async () => {
         capturedMigration[capturedMigration.length - 1]?.onDismiss();
@@ -1663,7 +1847,7 @@ describe("SettingsPage", () => {
         pending: true,
       });
       vi.mocked(backend.dismissSaveSortMigration).mockRejectedValue(new Error("net"));
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       await act(async () => {
         capturedMigration[capturedMigration.length - 1]?.onDismiss();
@@ -1674,8 +1858,12 @@ describe("SettingsPage", () => {
   });
 
   describe("saveSortMigrationStore subscribe / unsubscribe", () => {
+    beforeEach(() => {
+      openOn = "save-sync";
+    });
+
     it("subscribes on mount and unsubscribes on unmount", async () => {
-      const { unmount } = render(<SettingsPage onBack={vi.fn()} />);
+      const { unmount } = renderPage();
       await flushAsync();
       expect(vi.mocked(onSaveSortMigrationChange)).toHaveBeenCalledTimes(1);
       expect(saveSortListeners.length).toBe(1);
@@ -1684,7 +1872,7 @@ describe("SettingsPage", () => {
     });
 
     it("re-renders the migration section when the store flips to pending", async () => {
-      render(<SettingsPage onBack={vi.fn()} />);
+      renderPage();
       await flushAsync();
       // Initially: no migration section because pending=false.
       expect(capturedMigration.length).toBe(0);
@@ -1703,8 +1891,12 @@ describe("SettingsPage", () => {
   });
 
   describe("conditional renders", () => {
+    beforeEach(() => {
+      openOn = "save-sync";
+    });
+
     it("hides RegisteredDevicesSection when save sync is disabled", async () => {
-      const { queryByTestId } = render(<SettingsPage onBack={vi.fn()} />);
+      const { queryByTestId } = renderPage();
       await flushAsync();
       expect(queryByTestId("devices-section")).toBeNull();
     });
@@ -1714,13 +1906,13 @@ describe("SettingsPage", () => {
         ...defaultSaveSyncSettings(),
         save_sync_enabled: true,
       });
-      const { queryByTestId } = render(<SettingsPage onBack={vi.fn()} />);
+      const { queryByTestId } = renderPage();
       await flushAsync();
       expect(queryByTestId("devices-section")).not.toBeNull();
     });
 
     it("hides SaveSortMigrationSection when pending=false", async () => {
-      const { queryByTestId } = render(<SettingsPage onBack={vi.fn()} />);
+      const { queryByTestId } = renderPage();
       await flushAsync();
       expect(queryByTestId("migration-section")).toBeNull();
     });
@@ -1730,19 +1922,89 @@ describe("SettingsPage", () => {
         pending: true,
         saves_count: 3,
       });
-      const { queryByTestId } = render(<SettingsPage onBack={vi.fn()} />);
+      const { queryByTestId } = renderPage();
       await flushAsync();
       expect(queryByTestId("migration-section")).not.toBeNull();
     });
   });
 
-  describe("back button", () => {
-    it("calls onBack when the Back button is clicked", async () => {
+  describe("the page frame", () => {
+    it("renders as a wide page titled Settings with a Back chip that calls onBack", async () => {
       const onBack = vi.fn();
       const { getByText } = render(<SettingsPage onBack={onBack} />);
       await flushAsync();
-      fireEvent.click(getByText("Back"));
+      expect(getByText("Settings")).toBeInTheDocument();
+      // The chip's glyph probe misses under happy-dom, so it renders its
+      // chevron fallback.
+      fireEvent.click(getByText("‹ Back"));
       expect(onBack).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("the section list", () => {
+    it("shows exactly the five sections, in order", async () => {
+      const { getAllByTestId } = renderPage();
+      await flushAsync();
+      const labels = getAllByTestId("field").map((el) => el.textContent);
+      expect(labels).toEqual(["Connections", "Save Sync", "Controller", "Steam Library", "Advanced"]);
+    });
+
+    it("opens on the section a navigation names", async () => {
+      openOn = "controller";
+      renderPage();
+      await flushAsync();
+      expect(capturedController.length).toBeGreaterThan(0);
+      expect(capturedConnection.length).toBe(0);
+    });
+
+    it("opens on the first section when a navigation names none", async () => {
+      const { queryByTestId } = render(<SettingsPage onBack={vi.fn()} />);
+      await flushAsync();
+      expect(queryByTestId("connection-section")).not.toBeNull();
+      expect(queryByTestId("advanced-section")).toBeNull();
+    });
+
+    it("selects on activate, so a row that carries no control is still a focus stop", async () => {
+      const { getByTestId, queryByTestId } = renderPage();
+      await flushAsync();
+      expect(queryByTestId("advanced-section")).toBeNull();
+      // The wrapper the layout puts round each row is what carries the activate
+      // handler; the press on the row's own content bubbles to it.
+      await act(async () => {
+        fireEvent.click(getByTestId("settings-section-advanced"));
+      });
+      expect(queryByTestId("advanced-section")).not.toBeNull();
+      expect(queryByTestId("connection-section")).toBeNull();
+    });
+
+    it("moving focus onto a row selects it, without a press", async () => {
+      const { getByTestId, queryByTestId } = renderPage();
+      await flushAsync();
+      await act(async () => {
+        fireEvent.focus(getByTestId("settings-section-steam-library"));
+      });
+      expect(queryByTestId("library-section")).not.toBeNull();
+    });
+
+    it.each([
+      ["connections", "connection-section"],
+      ["save-sync", "savesync-section"],
+      ["controller", "controller-section"],
+      ["steam-library", "library-section"],
+      ["advanced", "advanced-section"],
+    ] as const)("reaches every section's content: %s", async (section, testId) => {
+      const { getByTestId, queryByTestId } = renderPage();
+      await flushAsync();
+      await act(async () => {
+        fireEvent.click(getByTestId(`settings-section-${section}`));
+      });
+      expect(queryByTestId(testId)).not.toBeNull();
+    });
+
+    it("keeps the SteamGridDB key on the Connections pane, not on its own section", async () => {
+      const { queryByTestId } = renderPage();
+      await flushAsync();
+      expect(queryByTestId("sgdb-section")).not.toBeNull();
     });
   });
 });

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -57,6 +57,7 @@ import { detach } from "../utils/detach";
 import { trimServerUrl, isValidServerUrl } from "../utils/serverUrl";
 import { WidePage } from "./qam/WidePage";
 import { ListDetail, type ListDetailItem } from "./qam/ListDetail";
+import { ROW_MARKER_GAP, ROW_MARKER_WIDTH, SELECTION_ACCENT } from "./qam/pane";
 import { pendingEdits } from "./settings/TextInputModal";
 import { SaveSortMigrationSection } from "./settings/SaveSortMigrationSection";
 import { ConnectionSection } from "./settings/ConnectionSection";
@@ -94,11 +95,6 @@ const SECTION_LABELS: Record<SettingsSection, string> = {
   "steam-library": "Steam Library",
   advanced: "Advanced",
 };
-
-// The selection marker and the gap after it — the same pair the Platforms list
-// insets its rows by, so the two lists read as one kind of list.
-const ROW_MARKER_WIDTH = 3;
-const ROW_MARKER_GAP = 5;
 
 /** The list hands its ids back as plain strings; this is where one becomes a
  *  section again — by lookup rather than by assertion, so an id no section
@@ -658,7 +654,7 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack, section }) => {
       <div
         data-testid={`settings-section-${id}`}
         style={{
-          borderLeft: `${ROW_MARKER_WIDTH}px solid ${selected ? "#1a9fff" : "transparent"}`,
+          borderLeft: `${ROW_MARKER_WIDTH}px solid ${selected ? SELECTION_ACCENT : "transparent"}`,
           paddingLeft: `${ROW_MARKER_GAP}px`,
         }}
       >

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,5 +1,17 @@
-import { useState, useEffect, FC } from "react";
-import { PanelSection, PanelSectionRow, ButtonItem, ConfirmModal, showModal } from "@decky/ui";
+/**
+ * The Settings page: five sections on the left, the focused section's controls
+ * on the right.
+ *
+ * Every section's state and every handler lives here rather than in the section
+ * components, which are pure renderers — the pane mounts only the focused
+ * section, so a section owning its own reads would re-issue them on each move
+ * through the list.
+ *
+ * Structure and vocabulary: `docs/architecture/qam-panel.md`, section Settings.
+ */
+
+import { useState, useEffect, FC, type ReactNode } from "react";
+import { ConfirmModal, Field, showModal } from "@decky/ui";
 import { showToast } from "../utils/toast";
 import {
   getSettings,
@@ -33,15 +45,18 @@ import type {
   CollectionNamingMode,
   SaveSyncSettings as SaveSyncSettingsType,
   RetroArchInputCheck,
+  SettingsSection,
 } from "../types";
+import { SETTINGS_SECTIONS } from "../types";
 import {
   setSaveSortMigrationStatus as setStoreSaveSortStatus,
   clearSaveSortMigration,
   useSaveSortMigrationState,
 } from "../utils/saveSortMigrationStore";
-import { scrollToTop } from "../utils/scrollHelpers";
 import { detach } from "../utils/detach";
 import { trimServerUrl, isValidServerUrl } from "../utils/serverUrl";
+import { WidePage } from "./qam/WidePage";
+import { ListDetail, type ListDetailItem } from "./qam/ListDetail";
 import { pendingEdits } from "./settings/TextInputModal";
 import { SaveSortMigrationSection } from "./settings/SaveSortMigrationSection";
 import { ConnectionSection } from "./settings/ConnectionSection";
@@ -55,6 +70,13 @@ import { showPreferredRegionModal } from "./settings/PreferredRegionModal";
 
 interface SettingsPageProps {
   onBack: () => void;
+  /**
+   * The section the page opens on — a navigation from one of Main's notices
+   * names the one that holds the action it is about. It is the OPENING
+   * selection and nothing more: the panel reaches Settings only from Main, so
+   * every navigation here mounts the page afresh.
+   */
+  section?: SettingsSection;
 }
 
 // Messages the connect handlers return to the ConnectModal (which surfaces them
@@ -63,7 +85,29 @@ interface SettingsPageProps {
 const INVALID_URL_MESSAGE = "Enter a valid http:// or https:// server URL";
 const GENERIC_SIGN_IN_ERROR = "Sign-in failed. Check your connection and try again.";
 
-export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
+// What the list calls each section. The ids and their order are the navigation
+// module's, so a section reachable by a jump is a section the list shows.
+const SECTION_LABELS: Record<SettingsSection, string> = {
+  connections: "Connections",
+  "save-sync": "Save Sync",
+  controller: "Controller",
+  "steam-library": "Steam Library",
+  advanced: "Advanced",
+};
+
+// The selection marker and the gap after it — the same pair the Platforms list
+// insets its rows by, so the two lists read as one kind of list.
+const ROW_MARKER_WIDTH = 3;
+const ROW_MARKER_GAP = 5;
+
+/** The list hands its ids back as plain strings; this is where one becomes a
+ *  section again — by lookup rather than by assertion, so an id no section
+ *  answers to opens the first section instead of typing as one that is absent. */
+const asSection = (id: string | null): SettingsSection =>
+  SETTINGS_SECTIONS.find((candidate) => candidate === id) ?? SETTINGS_SECTIONS[0];
+
+export const SettingsPage: FC<SettingsPageProps> = ({ onBack, section }) => {
+  const [selectedSection, setSelectedSection] = useState<SettingsSection>(section ?? SETTINGS_SECTIONS[0]);
   // Connection state
   const [url, setUrl] = useState("");
   const [hasToken, setHasToken] = useState(false);
@@ -88,6 +132,7 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
   // Controller state
   const [steamInputMode, setSteamInputMode] = useState("default");
   const [steamInputStatus, setSteamInputStatus] = useState("");
+  const [applyingSteamInput, setApplyingSteamInput] = useState(false);
   const [retroarchWarning, setRetroarchWarning] = useState<RetroArchInputCheck | null>(null);
   const [retroarchFixStatus, setRetroarchFixStatus] = useState("");
 
@@ -270,15 +315,20 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
   const handleUrlChange = async (value: string) => {
     const trimmed = trimServerUrl(value);
     setUrl(trimmed);
-    if (!isValidServerUrl(trimmed)) {
-      setStatus("Enter a valid http:// or https:// server URL");
-      return;
-    }
     try {
+      if (!isValidServerUrl(trimmed)) {
+        setStatus(INVALID_URL_MESSAGE);
+        return;
+      }
       await saveServerUrl(trimmed, allowInsecureSsl);
-      delete pendingEdits.url;
     } catch {
       setStatus("Failed to save settings");
+    } finally {
+      // The pending value exists to carry an edit across the remount closing
+      // the modal can cause, not to outlive the attempt: left behind, a value
+      // the backend refused is what every later open of the page shows in the
+      // field, over the URL actually saved (#1020).
+      delete pendingEdits.url;
     }
   };
   const handleAllowInsecureSslChange = (val: boolean) => {
@@ -386,12 +436,22 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
     setSteamInputStatus("");
   };
   const handleApplySteamInput = async () => {
+    // A second press while the first run is in flight is refused rather than
+    // queued: the run walks every shortcut Steam holds and two of them
+    // interleave their writes, and the button says so while it is dead (#1020).
+    // The guard is here rather than only on the button because a press is
+    // delivered on activate, and a disabled control still reports one on the
+    // device.
+    if (applyingSteamInput) return;
+    setApplyingSteamInput(true);
     setSteamInputStatus("Applying...");
     try {
       const result = await applySteamInputSetting();
       setSteamInputStatus(result.message);
     } catch {
       setSteamInputStatus("Failed to apply");
+    } finally {
+      setApplyingSteamInput(false);
     }
   };
   const handleFixInputDriver = async () => {
@@ -486,100 +546,136 @@ export const SettingsPage: FC<SettingsPageProps> = ({ onBack }) => {
     }
   };
 
-  return (
-    <>
-      <PanelSection>
-        <PanelSectionRow>
-          <ButtonItem
-            layout="below"
-            onClick={onBack}
-            // @ts-expect-error onFocus works at runtime; not in Decky's ButtonItem types
-            onFocus={scrollToTop}
-          >
-            Back
-          </ButtonItem>
-        </PanelSectionRow>
-      </PanelSection>
-      {saveSortMigration.pending && (
-        <SaveSortMigrationSection
-          migration={saveSortMigration}
-          migrating={saveSortMigrating}
-          result={saveSortResult}
-          onMigrate={() => {
-            detach(handleMigrateSaveSort());
-          }}
-          onDismiss={() => {
-            detach(handleDismissSaveSort());
-          }}
-        />
-      )}
-      <ConnectionSection
-        url={url}
-        hasToken={hasToken}
-        allowInsecureSsl={allowInsecureSsl}
-        status={status}
-        onUrlChange={(value) => {
-          detach(handleUrlChange(value));
-        }}
-        onConnect={handleConnect}
-        onConnectToken={handleConnectToken}
-        onConnectPairing={handleConnectPairing}
-        onAllowInsecureSslChange={handleAllowInsecureSslChange}
-        onSignOut={() => {
-          detach(handleSignOut());
-        }}
-      />
-      <SteamGridDBSection sgdbApiKey={sgdbApiKey} onVerifyKey={verifySgdbApiKey} onSaveKey={handleSaveSgdbKey} />
-      <SaveSyncSection
-        saveSyncSettings={saveSyncSettings}
-        saveSyncToggleKey={saveSyncToggleKey}
-        deviceInfo={deviceInfo}
-        syncing={syncing}
-        syncStatus={syncStatus}
-        onToggleSaveSync={handleToggleSaveSync}
-        onSettingChange={(partial) => {
-          detach(handleSaveSyncSettingChange(partial));
-        }}
-        onDefaultSlotSubmit={handleDefaultSlotSubmit}
-        onResetDefaultSlot={handleResetDefaultSlot}
-        onSyncAll={() => {
-          detach(handleSyncAll());
-        }}
-      />
-      {saveSyncEnabled && (devicesLoading || registeredDevices !== null) && (
-        <RegisteredDevicesSection
-          devicesLoading={devicesLoading}
-          devicesError={devicesError}
-          registeredDevices={registeredDevices}
-        />
-      )}
-      <ControllerSection
-        steamInputMode={steamInputMode}
-        steamInputStatus={steamInputStatus}
-        retroarchWarning={retroarchWarning}
-        retroarchFixStatus={retroarchFixStatus}
-        // No manual connection test remains to drive a shared loading flag; the
-        // Apply button is never gated on one.
-        loading={false}
-        onModeChange={handleSteamInputModeChange}
-        onApplyMode={() => {
-          detach(handleApplySteamInput());
-        }}
-        onFixInputDriver={() => {
-          detach(handleFixInputDriver());
-        }}
-      />
-      <LibrarySection
-        preferredRegion={preferredRegion}
-        libraryRegions={libraryRegions}
-        onPreferredRegionChange={handlePreferredRegionChange}
-        platformGroups={platformGroups}
-        onPlatformGroupsChange={handlePlatformGroupsChange}
-        namingMode={namingMode}
-        onNamingModeChange={handleNamingModeChange}
-      />
+  const renderSection = (id: SettingsSection): ReactNode => {
+    switch (id) {
+      case "connections":
+        return (
+          <>
+            <ConnectionSection
+              url={url}
+              hasToken={hasToken}
+              allowInsecureSsl={allowInsecureSsl}
+              status={status}
+              onUrlChange={(value) => {
+                detach(handleUrlChange(value));
+              }}
+              onConnect={handleConnect}
+              onConnectToken={handleConnectToken}
+              onConnectPairing={handleConnectPairing}
+              onAllowInsecureSslChange={handleAllowInsecureSslChange}
+              onSignOut={() => {
+                detach(handleSignOut());
+              }}
+            />
+            <SteamGridDBSection sgdbApiKey={sgdbApiKey} onVerifyKey={verifySgdbApiKey} onSaveKey={handleSaveSgdbKey} />
+          </>
+        );
+      case "save-sync":
+        return (
+          <>
+            {/* First in the pane: it is a condition asking to be answered, and
+                the two settings groups below it are true whether it stands or
+                not. */}
+            {saveSortMigration.pending && (
+              <SaveSortMigrationSection
+                migration={saveSortMigration}
+                migrating={saveSortMigrating}
+                result={saveSortResult}
+                onMigrate={() => {
+                  detach(handleMigrateSaveSort());
+                }}
+                onDismiss={() => {
+                  detach(handleDismissSaveSort());
+                }}
+              />
+            )}
+            <SaveSyncSection
+              saveSyncSettings={saveSyncSettings}
+              saveSyncToggleKey={saveSyncToggleKey}
+              deviceInfo={deviceInfo}
+              syncing={syncing}
+              syncStatus={syncStatus}
+              onToggleSaveSync={handleToggleSaveSync}
+              onSettingChange={(partial) => {
+                detach(handleSaveSyncSettingChange(partial));
+              }}
+              onDefaultSlotSubmit={handleDefaultSlotSubmit}
+              onResetDefaultSlot={handleResetDefaultSlot}
+              onSyncAll={() => {
+                detach(handleSyncAll());
+              }}
+            />
+            {saveSyncEnabled && (devicesLoading || registeredDevices !== null) && (
+              <RegisteredDevicesSection
+                devicesLoading={devicesLoading}
+                devicesError={devicesError}
+                registeredDevices={registeredDevices}
+              />
+            )}
+          </>
+        );
+      case "controller":
+        return (
+          <ControllerSection
+            steamInputMode={steamInputMode}
+            steamInputStatus={steamInputStatus}
+            retroarchWarning={retroarchWarning}
+            retroarchFixStatus={retroarchFixStatus}
+            applying={applyingSteamInput}
+            onModeChange={handleSteamInputModeChange}
+            onApplyMode={() => {
+              detach(handleApplySteamInput());
+            }}
+            onFixInputDriver={() => {
+              detach(handleFixInputDriver());
+            }}
+          />
+        );
+      case "steam-library":
+        return (
+          <LibrarySection
+            preferredRegion={preferredRegion}
+            libraryRegions={libraryRegions}
+            onPreferredRegionChange={handlePreferredRegionChange}
+            platformGroups={platformGroups}
+            onPlatformGroupsChange={handlePlatformGroupsChange}
+            namingMode={namingMode}
+            onNamingModeChange={handleNamingModeChange}
+          />
+        );
+      case "advanced":
+        return <AdvancedSection logLevel={logLevel} onLogLevelChange={handleLogLevelChange} />;
+    }
+  };
 
-      <AdvancedSection logLevel={logLevel} onLogLevelChange={handleLogLevelChange} />
-    </>
+  const items: ListDetailItem[] = SETTINGS_SECTIONS.map((id) => ({
+    id,
+    render: (selected: boolean) => (
+      // The marker bar and the label, and nothing else: these rows carry no
+      // control, which is what `selectOnActivate` below is for — the activate
+      // handler it adds to the wrapper is what makes the row a focus stop at
+      // all.
+      <div
+        data-testid={`settings-section-${id}`}
+        style={{
+          borderLeft: `${ROW_MARKER_WIDTH}px solid ${selected ? "#1a9fff" : "transparent"}`,
+          paddingLeft: `${ROW_MARKER_GAP}px`,
+        }}
+      >
+        <Field label={SECTION_LABELS[id]} bottomSeparator="none" />
+      </div>
+    ),
+  }));
+
+  return (
+    <WidePage title="Settings" onBack={onBack} ownRegions>
+      <ListDetail
+        items={items}
+        selectedId={selectedSection}
+        onSelect={(id) => setSelectedSection(asSection(id))}
+        selectOnActivate
+        renderDetail={(id) => renderSection(asSection(id))}
+      />
+    </WidePage>
   );
 };

--- a/src/components/library/PlatformDetail.tsx
+++ b/src/components/library/PlatformDetail.tsx
@@ -33,6 +33,8 @@ import {
   MUTED,
   Muted,
   PALE_GREEN,
+  PaneTableHeader,
+  PaneTableRow,
   RED,
   ROW_BUTTON,
   SECONDARY_FONT,
@@ -358,23 +360,7 @@ function libraryMark(file: FirmwareRow): typeof LIBRARY_MARK | null {
 const TABLE_COLUMNS = "1fr 48px 84px 92px";
 
 const BiosTableHeader: FC = () => (
-  // Column names accompany the rows below them and scroll with them; making the
-  // header a focus stop would add a step that leads nowhere.
-  <div
-    style={{
-      display: "grid",
-      gridTemplateColumns: TABLE_COLUMNS,
-      gap: "8px",
-      padding: "0 16px 4px",
-      fontSize: SECONDARY_FONT,
-      color: MUTED,
-    }}
-  >
-    <span>File</span>
-    <span>On disk</span>
-    <span>Contents</span>
-    <span />
-  </div>
+  <PaneTableHeader columns={TABLE_COLUMNS} cells={["File", "On disk", "Contents", ""]} />
 );
 
 /**
@@ -583,35 +569,56 @@ const BiosFileRow: FC<{ file: FirmwareRow; systemImage: SystemImage; action: Rea
   // on a platform whose library holds little it was the same words under nearly
   // every row. Everything else moves under the row rather than into the cell.
   const rowLines = fromLibrary ? [] : [...(note ? [note] : []), ...lines];
-  const cells = (
-    <>
-      <div style={{ display: "grid", gridTemplateColumns: TABLE_COLUMNS, gap: "8px", alignItems: "center" }}>
-        {/* The cell ellipsises, and with the folder in front of it what gets cut
-            is now the NAME rather than the description that used to sit here —
-            `scummvm/extra/hadesch_translations.dat` does not fit 202px in any
-            arrangement. The title is the mouse's way back to it; a reader on the
-            controller has none, and the only real fix is width the list column
-            currently holds. */}
-        <span
-          title={file.declared_path ?? file.file_name}
-          style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
-        >
-          {folder && <span style={{ color: MUTED }}>{folder}</span>}
-          {file.file_name}
-        </span>
-        <span style={{ display: "flex", gap: "4px", fontSize: "14px", whiteSpace: "nowrap" }}>
-          <span data-testid="disk-mark" style={{ color: mark.color }} title={mark.title}>
-            {mark.glyph}
-          </span>
-          {library && (
-            <span data-testid="library-mark" style={{ color: library.color }} title={library.title}>
-              {library.glyph}
-            </span>
-          )}
-        </span>
-        <span style={{ color: MUTED, fontSize: SECONDARY_FONT }}>{contentsCell(file)}</span>
-        <span>{action}</span>
-      </div>
+  return (
+    // The row is a focus stop only while it has nothing to press: an action cell
+    // holds a button that is already a stop, and a second one on the wrapper
+    // would put a dead step in front of every one of them. `action` is therefore
+    // a NODE that may be null and never a component element — an element is
+    // always truthy, which is how this branch went dead once while the comment
+    // on it went on explaining it.
+    <PaneTableRow
+      columns={TABLE_COLUMNS}
+      focusStop={!action}
+      cells={[
+        {
+          // With the folder in front of it what gets cut is the NAME rather
+          // than the description that used to sit here —
+          // `scummvm/extra/hadesch_translations.dat` does not fit 202px in any
+          // arrangement. The title is the mouse's way back to it; a reader on
+          // the controller has none, and the only real fix is width the list
+          // column currently holds.
+          content: (
+            <>
+              {folder && <span style={{ color: MUTED }}>{folder}</span>}
+              {file.file_name}
+            </>
+          ),
+          title: file.declared_path ?? file.file_name,
+        },
+        {
+          // Glyphs rather than a run of text: nothing to ellipsise, and the
+          // pair is laid out rather than flowed.
+          content: (
+            <>
+              <span data-testid="disk-mark" style={{ color: mark.color }} title={mark.title}>
+                {mark.glyph}
+              </span>
+              {library && (
+                <span data-testid="library-mark" style={{ color: library.color }} title={library.title}>
+                  {library.glyph}
+                </span>
+              )}
+            </>
+          ),
+          style: { display: "flex", gap: "4px", fontSize: "14px", whiteSpace: "nowrap" },
+          clip: false,
+        },
+        { content: contentsCell(file), style: { color: MUTED, fontSize: SECONDARY_FONT } },
+        // The button draws its focus ring outside its own box (the injected
+        // sheet's outline), so this cell must not hide its overflow.
+        { content: action, clip: false },
+      ]}
+    >
       {description && (
         <div
           style={{
@@ -627,18 +634,7 @@ const BiosFileRow: FC<{ file: FirmwareRow; systemImage: SystemImage; action: Rea
         </div>
       )}
       <BiosRowLines lines={rowLines} />
-    </>
-  );
-  if (action) return <div style={{ padding: "4px 16px" }}>{cells}</div>;
-  // A row with nothing to press still has to be reachable, or the reader cannot
-  // scroll past it to the rows below: the activate handler is what makes a
-  // Focusable a focus stop. `action` is therefore a NODE that may be null and
-  // never a component element — an element is always truthy, which is how this
-  // branch went dead once while this comment went on explaining it.
-  return (
-    <Focusable onActivate={() => {}} style={{ padding: "4px 16px" }}>
-      {cells}
-    </Focusable>
+    </PaneTableRow>
   );
 };
 

--- a/src/components/library/PlatformsTab.tsx
+++ b/src/components/library/PlatformsTab.tsx
@@ -21,6 +21,7 @@
 import type { FC, ReactNode } from "react";
 import { DialogButton, Focusable, ToggleField } from "@decky/ui";
 import { ListDetail, type ListDetailItem } from "../qam/ListDetail";
+import { ROW_CONTENT_INSET, ROW_MARKER_GAP, ROW_MARKER_WIDTH, SELECTION_ACCENT } from "../qam/pane";
 import { LoadingRow } from "../LoadingRow";
 import { biosColorForLevel } from "../../utils/biosColor";
 import { PlatformDetail } from "./PlatformDetail";
@@ -49,15 +50,6 @@ function biosTooltip(row: PlatformRow): string {
   if (required === 0) return "Nothing required";
   return `${firmware.required_downloaded ?? 0} / ${required} required BIOS files ready`;
 }
-
-// The selection marker and the gap after it, which together are how far a row's
-// content sits from the list column's edge. Named because the list header's
-// padding has to be the same number: the pair of buttons up there spans the rows
-// below it, and happy-dom lays nothing out, so a drift between the two would be
-// invisible to every test.
-const ROW_MARKER_WIDTH = 3;
-const ROW_MARKER_GAP = 5;
-const ROW_CONTENT_INSET = ROW_MARKER_WIDTH + ROW_MARKER_GAP;
 
 const GroupHeading: FC<{ title: string; count: number }> = ({ title, count }) => (
   // Plain text: it accompanies the rows under it and scrolls with them. Making
@@ -142,7 +134,7 @@ export const PlatformsTab: FC<{ state: PlatformsPageState }> = ({ state }) => {
                 against the dot it reads as part of it. */}
             <div
               style={{
-                borderLeft: `${ROW_MARKER_WIDTH}px solid ${selected ? "#1a9fff" : "transparent"}`,
+                borderLeft: `${ROW_MARKER_WIDTH}px solid ${selected ? SELECTION_ACCENT : "transparent"}`,
                 paddingLeft: `${ROW_MARKER_GAP}px`,
               }}
             >

--- a/src/components/qam/ListDetail.test.tsx
+++ b/src/components/qam/ListDetail.test.tsx
@@ -9,6 +9,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { useState, type CSSProperties, type FC, type ReactNode } from "react";
+import { ENTRY_STOP_ATTR } from "../../utils/entryFocus";
 import { ListDetail, type ListDetailItem, type ListDetailProps } from "./ListDetail";
 
 const PLATFORMS = [
@@ -234,6 +235,86 @@ describe("ListDetail", () => {
 
     const row = screen.getByRole("button", { name: /PlayStation/ }).closest("[data-testid='focusable']");
     expect((row as HTMLElement).dataset.activate).toBeUndefined();
+  });
+
+  it("declares the selected row the area entry focus belongs in, and moves the mark with it", () => {
+    // Focus selects here, so a page opened on a section other than its first
+    // would have that section overwritten by entry focus landing on row one.
+    // The mark is what the placer reads; that Steam then puts focus there, and
+    // that the row's own onFocus finds the selection already matching, is the
+    // device's to show — happy-dom has no nav tree and nothing here runs the
+    // frame's timer.
+    const { rerender } = render(
+      <ListDetail
+        items={platformItems(() => {})}
+        selectedId="psx"
+        onSelect={vi.fn()}
+        renderDetail={(id) => <div>detail for {id ?? "nothing"}</div>}
+      />,
+    );
+    const declared = () => document.querySelectorAll(`[${ENTRY_STOP_ATTR}]`);
+    const rowOf = (name: RegExp) => screen.getByRole("button", { name }).closest(`[${ENTRY_STOP_ATTR}]`);
+
+    // Not the first row: that is the whole point, and asserting on the first
+    // would pass on the accident this fixes.
+    expect(declared()).toHaveLength(1);
+    expect(rowOf(/PlayStation/)).not.toBeNull();
+    expect(rowOf(/Nintendo 64/)).toBeNull();
+
+    rerender(
+      <ListDetail
+        items={platformItems(() => {})}
+        selectedId="n64"
+        onSelect={vi.fn()}
+        renderDetail={(id) => <div>detail for {id ?? "nothing"}</div>}
+      />,
+    );
+
+    expect(declared()).toHaveLength(1);
+    expect(rowOf(/Nintendo 64/)).not.toBeNull();
+    expect(rowOf(/PlayStation/)).toBeNull();
+  });
+
+  it("declares nothing where nothing is selected", () => {
+    // A list that opens with no selection — the Library page's platforms —
+    // names no area, so the frame falls back to the body's first stop and the
+    // page opens exactly where it did before.
+    render(
+      <ListDetail
+        items={platformItems(() => {})}
+        selectedId={null}
+        onSelect={vi.fn()}
+        renderDetail={() => <div>pick one</div>}
+      />,
+    );
+
+    expect(document.querySelectorAll(`[${ENTRY_STOP_ATTR}]`)).toHaveLength(0);
+  });
+
+  it("keeps the row a stable element as the selection moves through it", () => {
+    // The mark rides a wrapper every row has, marked or not: a wrapper that
+    // appeared when a row became selected would remount the row Steam is
+    // standing on, mid-navigation.
+    const { rerender } = render(
+      <ListDetail
+        items={platformItems(() => {})}
+        selectedId="n64"
+        onSelect={vi.fn()}
+        renderDetail={() => <div>detail</div>}
+      />,
+    );
+    const row = screen.getByRole("button", { name: /Nintendo 64/ });
+
+    rerender(
+      <ListDetail
+        items={platformItems(() => {})}
+        selectedId="psx"
+        onSelect={vi.fn()}
+        renderDetail={() => <div>detail</div>}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /Nintendo 64/ })).toBe(row);
   });
 
   it("renders a detail for an empty selection", () => {

--- a/src/components/qam/ListDetail.tsx
+++ b/src/components/qam/ListDetail.tsx
@@ -16,10 +16,16 @@
  *
  * Selection is controlled: the page owns `selectedId` and decides what a change
  * means for the rest of it.
+ *
+ * Because focus selects, where the page OPENS decides what it opens on: entry
+ * focus landing on the first row selects that row and overwrites the selection
+ * the page was opened with. So the selected row declares itself the area entry
+ * focus belongs in ({@link ENTRY_STOP_ATTR}) and the frame places focus there.
  */
 
 import type { FC, ReactNode } from "react";
 import { Focusable } from "@decky/ui";
+import { ENTRY_STOP_ATTR } from "../../utils/entryFocus";
 import { Columns } from "./Columns";
 
 export interface ListDetailItem {
@@ -71,24 +77,39 @@ export const ListDetail: FC<ListDetailProps> = ({
           <Focusable flow-children="vertical">
             {listHeader}
             {items.map((item) => (
-              // React delivers onFocus through focusin, so this fires for focus
-              // landing on whatever control the row itself renders — and again for
-              // every move between controls inside the same row, or on the way back
-              // from the detail pane. Only a real change is reported, so a page may
-              // treat onSelect as an event and do work on it.
-              <Focusable
+              // The declaration sits on a wrapper rather than on the row itself
+              // for the reason Main's does (`MainPage`, the menu's Sync entry):
+              // Steam's `Focusable` takes its own props and nothing establishes
+              // that it passes an unknown one down to the DOM. `display:
+              // contents` keeps the wrapper out of the layout — it carries the
+              // attribute and nothing else.
+              //
+              // Every row gets one, marked or not: an element that appeared
+              // around a row when it became selected would remount the row, and
+              // the row being selected is the one focus is standing on.
+              <div
                 key={item.id}
-                onFocus={() => {
-                  if (item.id !== selectedId) onSelect(item.id);
-                }}
-                // Spread rather than a conditional value: under
-                // `exactOptionalPropertyTypes` an explicit `undefined` is not
-                // the same as an absent prop, and `FocusableProps` declares the
-                // handler without it.
-                {...(selectOnActivate ? { onActivate: () => onSelect(item.id) } : {})}
+                style={{ display: "contents" }}
+                {...(item.id === selectedId ? { [ENTRY_STOP_ATTR]: "" } : {})}
               >
-                {item.render(item.id === selectedId)}
-              </Focusable>
+                {/* React delivers onFocus through focusin, so this fires for focus
+                    landing on whatever control the row itself renders — and again for
+                    every move between controls inside the same row, or on the way back
+                    from the detail pane. Only a real change is reported, so a page may
+                    treat onSelect as an event and do work on it. */}
+                <Focusable
+                  onFocus={() => {
+                    if (item.id !== selectedId) onSelect(item.id);
+                  }}
+                  // Spread rather than a conditional value: under
+                  // `exactOptionalPropertyTypes` an explicit `undefined` is not
+                  // the same as an absent prop, and `FocusableProps` declares the
+                  // handler without it.
+                  {...(selectOnActivate ? { onActivate: () => onSelect(item.id) } : {})}
+                >
+                  {item.render(item.id === selectedId)}
+                </Focusable>
+              </div>
             ))}
           </Focusable>
         ),

--- a/src/components/qam/WidePage.test.tsx
+++ b/src/components/qam/WidePage.test.tsx
@@ -14,6 +14,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent, cleanup, act } from "@testing-library/react";
 import type { FC, ReactNode } from "react";
+import { ENTRY_STOP_ATTR } from "../../utils/entryFocus";
 import { WIDE_ROOT_CLASS } from "../../utils/qamExpansion";
 import { OWNS_ENTRY_FOCUS_ATTR, type WidePageProps, type WidePageTab } from "./WidePage";
 
@@ -445,6 +446,32 @@ describe("WidePage", () => {
       expect(row).toHaveClass("gpfocus");
       expect(screen.getByRole("button", { name: "‹ Back" })).not.toHaveFocus();
       expect(container.firstElementChild).toHaveAttribute(OWNS_ENTRY_FOCUS_ATTR);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("opens on the area the body declared rather than on its first stop", async () => {
+    const WidePage = await loadWidePage(StubTabs);
+    vi.useFakeTimers();
+    try {
+      render(
+        <WidePage title="Settings" onBack={vi.fn()}>
+          <button>Connections</button>
+          <div {...{ [ENTRY_STOP_ATTR]: "" }}>
+            <button>Controller</button>
+          </div>
+        </WidePage>,
+      );
+      act(() => {
+        vi.advanceTimersByTime(50);
+      });
+
+      // A NON-first declaration, because the first one passes whether the frame
+      // reads the declaration or not — which is exactly how Settings shipped
+      // opening on Connections whatever section it was sent to.
+      expect(screen.getByRole("button", { name: "Controller" })).toHaveFocus();
+      expect(screen.getByRole("button", { name: "Connections" })).not.toHaveFocus();
     } finally {
       vi.useRealTimers();
     }

--- a/src/components/qam/WidePage.test.tsx
+++ b/src/components/qam/WidePage.test.tsx
@@ -212,19 +212,26 @@ describe("WidePage", () => {
   it("gives the body a definite height taken from the remaining viewport", async () => {
     const WidePage = await loadWidePage(StubTabs);
 
-    render(
+    const { container } = render(
       <WidePage title="Settings" onBack={vi.fn()}>
         <div>page body</div>
       </WidePage>,
     );
 
     // happy-dom reports every rect at the origin, so the body's top is 0 and the
-    // measurement is the viewport minus the frame's bottom gap.
+    // measurement is the whole viewport: nothing is held back under the page.
     expect(window.innerHeight).toBeGreaterThan(240);
-    expect(body().style.height).toBe(`${window.innerHeight - 12}px`);
+    expect(body().style.height).toBe(`${window.innerHeight}px`);
     // Steam's tabbed page fills its parent instead of growing: a min-height
     // leaves the body with no height at all and the page clips.
     expect(body().style.minHeight).toBe("");
+    // Nothing computes `overflow-y: auto` here, so this is the no-scroller
+    // fallback — the one branch that measures no ancestor box. It must pull the
+    // root up by nothing: the height it just paid out is viewport-relative and
+    // counts no overhang, so a margin here would shorten the page against
+    // nothing, and the branch is what a chain this frame has never seen falls
+    // into. Every other case in this file takes the scroller branch.
+    expect((container.firstElementChild as HTMLElement).style.marginBottom).toBe("0px");
   });
 
   it("measures the same height however far the scrolling panel is scrolled", async () => {
@@ -264,27 +271,28 @@ describe("WidePage", () => {
       }
     };
 
-    // 600 − 100 − 12 both times. The panel-rect form answers 488 and then 988,
+    // 600 − 100 both times. The panel-rect form answers 500 and then 1000,
     // because the body's top has moved and the panel's has not; the original
     // `innerHeight − top` fails at the FIRST assertion instead, since
     // happy-dom's viewport is 768 rather than the panel's 600.
-    expect(await measure(0)).toBe(488);
-    expect(await measure(500)).toBe(488);
+    expect(await measure(0)).toBe(500);
+    expect(await measure(500)).toBe(500);
   });
 
   it("claims the space its ancestors hang below the panel, and pulls them back inside it", async () => {
-    // Decky wraps a plugin's content in a box that overhangs its parent — on
-    // the reference machine by 50 px, from its own inset plus padding. Nothing
-    // of ours is in those pixels, but the panel scrolls by them, and that is
-    // exactly enough to take the frame's Back row off the top. Giving the
-    // height up instead is what left a band of the panel empty under every wide
-    // page; the pull-up cancels the overhang without paying for it twice.
+    // Decky wraps a plugin's content in a box that overhangs its parent, from
+    // its own inset plus padding. Nothing of ours is painted in those pixels,
+    // but the panel scrolls by them, and that is enough to take the frame's
+    // Back row off the top. Giving the height up instead is what left a band of
+    // the panel empty under every wide page; the pull-up cancels the overhang
+    // without buying room for it.
     const fitWithOverhang = await measuredFit(50);
 
-    // 600 − 100 − 12, the whole of the panel below the body's top. Subtracting
-    // the overhang from the height as well leaves it at 438, which is the
-    // 50 px band the device reported.
-    expect(fitWithOverhang.height).toBe(488);
+    // 600 − 100, the whole of the panel below the body's top. Subtracting the
+    // overhang from the height as well leaves it at 450 — the band, in this
+    // fixture's terms. The 50 is the fixture's own parameter, not a fact about
+    // any panel: the next case runs the same page at 30.
+    expect(fitWithOverhang.height).toBe(500);
     expect(fitWithOverhang.rootMarginBottom).toBe("-50px");
   });
 
@@ -292,18 +300,19 @@ describe("WidePage", () => {
     // The two are one decision: a height counting the overhang without the
     // margin that cancels it overflows the scroller by exactly that much, and
     // the panel then scrolls the Back row off the top. So the margin has to
-    // follow whatever this machine's wrapper actually overhangs by — the whole
-    // reason the overhang is measured rather than written down as 50.
+    // follow whatever this chain actually overhangs by, whatever the display,
+    // scale or Decky version makes that — the whole reason it is measured
+    // rather than written down.
     const shallower = await measuredFit(30);
 
-    expect(shallower.height).toBe(488);
+    expect(shallower.height).toBe(500);
     expect(shallower.rootMarginBottom).toBe("-30px");
   });
 
   it("pulls the root up by nothing where no ancestor overhangs", async () => {
     const flush = await measuredFit(0);
 
-    expect(flush.height).toBe(488);
+    expect(flush.height).toBe(500);
     expect(flush.rootMarginBottom).toBe("0px");
   });
 

--- a/src/components/qam/WidePage.test.tsx
+++ b/src/components/qam/WidePage.test.tsx
@@ -92,6 +92,47 @@ function body(): HTMLElement {
   return screen.getByTestId("wide-page-body");
 }
 
+/**
+ * The frame's two-part fit under a mocked layout: a 600 px scrolling panel whose
+ * top is the viewport top, the page body 100 px down its content, and the body's
+ * own ancestors hanging `overhang` px below their parents.
+ *
+ * happy-dom performs no layout, so every rect here is a mock and the arithmetic
+ * is the whole of what these tests can pin. **Whether the panel then stops
+ * scrolling is a device question** — no test in this repo can see the defect
+ * this pair was written for, or its return.
+ */
+async function measuredFit(overhang: number): Promise<{ height: number; rootMarginBottom: string }> {
+  const WidePage = await loadWidePage(StubTabs);
+  // Only the document body scrolls, so the page's own body has real ancestors
+  // between it and the scroller — which is the shape the overhang lives in.
+  vi.spyOn(window, "getComputedStyle").mockImplementation(
+    (el: Element) => ({ overflowY: el.tagName === "BODY" ? "auto" : "visible" }) as CSSStyleDeclaration,
+  );
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function (this: HTMLElement) {
+    const isPageBody = this.dataset.testid === "wide-page-body";
+    return (isPageBody ? { top: 100, bottom: 600 + overhang } : { top: 0, bottom: 600 }) as DOMRect;
+  });
+  vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(600);
+  vi.spyOn(HTMLElement.prototype, "clientTop", "get").mockReturnValue(0);
+  vi.spyOn(Element.prototype, "scrollTop", "get").mockReturnValue(0);
+
+  try {
+    const { container } = render(
+      <WidePage title="Settings" onBack={vi.fn()}>
+        <div>page body</div>
+      </WidePage>,
+    );
+    return {
+      height: Number.parseFloat(body().style.height),
+      rootMarginBottom: (container.firstElementChild as HTMLElement).style.marginBottom,
+    };
+  } finally {
+    vi.restoreAllMocks();
+    cleanup();
+  }
+}
+
 describe("WidePage", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -231,38 +272,39 @@ describe("WidePage", () => {
     expect(await measure(500)).toBe(488);
   });
 
-  it("gives back the space its own ancestors hang below the panel", async () => {
+  it("claims the space its ancestors hang below the panel, and pulls them back inside it", async () => {
     // Decky wraps a plugin's content in a box that overhangs its parent — on
     // the reference machine by 50 px, from its own inset plus padding. Nothing
     // of ours is in those pixels, but the panel scrolls by them, and that is
-    // exactly enough to take the frame's Back row off the top.
-    const WidePage = await loadWidePage(StubTabs);
-    // Only the document body scrolls, so the page's own body has real ancestors
-    // between it and the scroller — which is the shape the overhang lives in.
-    vi.spyOn(window, "getComputedStyle").mockImplementation(
-      (el: Element) => ({ overflowY: el.tagName === "BODY" ? "auto" : "visible" }) as CSSStyleDeclaration,
-    );
-    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function (this: HTMLElement) {
-      const isPageBody = this.dataset.testid === "wide-page-body";
-      return (isPageBody ? { top: 100, bottom: 650 } : { top: 0, bottom: 600 }) as DOMRect;
-    });
-    vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(600);
-    vi.spyOn(HTMLElement.prototype, "clientTop", "get").mockReturnValue(0);
-    vi.spyOn(Element.prototype, "scrollTop", "get").mockReturnValue(0);
+    // exactly enough to take the frame's Back row off the top. Giving the
+    // height up instead is what left a band of the panel empty under every wide
+    // page; the pull-up cancels the overhang without paying for it twice.
+    const fitWithOverhang = await measuredFit(50);
 
-    try {
-      render(
-        <WidePage title="Settings" onBack={vi.fn()}>
-          <div>page body</div>
-        </WidePage>,
-      );
-      // 600 − 100 − 50 − 12. Without the overhang term it is 488, and the panel
-      // keeps 50 px of scroll it has no content for.
-      expect(Number.parseFloat(body().style.height)).toBe(438);
-    } finally {
-      vi.restoreAllMocks();
-      cleanup();
-    }
+    // 600 − 100 − 12, the whole of the panel below the body's top. Subtracting
+    // the overhang from the height as well leaves it at 438, which is the
+    // 50 px band the device reported.
+    expect(fitWithOverhang.height).toBe(488);
+    expect(fitWithOverhang.rootMarginBottom).toBe("-50px");
+  });
+
+  it("takes the pull-up from the same measurement as the height, not a constant", async () => {
+    // The two are one decision: a height counting the overhang without the
+    // margin that cancels it overflows the scroller by exactly that much, and
+    // the panel then scrolls the Back row off the top. So the margin has to
+    // follow whatever this machine's wrapper actually overhangs by — the whole
+    // reason the overhang is measured rather than written down as 50.
+    const shallower = await measuredFit(30);
+
+    expect(shallower.height).toBe(488);
+    expect(shallower.rootMarginBottom).toBe("-30px");
+  });
+
+  it("pulls the root up by nothing where no ancestor overhangs", async () => {
+    const flush = await measuredFit(0);
+
+    expect(flush.height).toBe(488);
+    expect(flush.rootMarginBottom).toBe("0px");
   });
 
   it("never measures the body below its floor", async () => {

--- a/src/components/qam/WidePage.tsx
+++ b/src/components/qam/WidePage.tsx
@@ -22,7 +22,7 @@
 import { useEffect, useLayoutEffect, useRef, useState, type FC, type ReactNode } from "react";
 import { DialogButton, Focusable } from "@decky/ui";
 import { ControllerGlyph, GLYPH_BUTTON_B, Tabs } from "../../utils/deckyUiInternals";
-import { ENTRY_FOCUS_DELAY_MS, firstBodyStop, placeEntryFocus } from "../../utils/entryFocus";
+import { ENTRY_FOCUS_DELAY_MS, pageEntryStop, placeEntryFocus } from "../../utils/entryFocus";
 import { WIDE_ROOT_CLASS, useWideQamPanel } from "../../utils/qamExpansion";
 import { offsetWithinScroller } from "../../utils/scrollHelpers";
 import { ScrollRegion } from "./ScrollRegion";
@@ -338,7 +338,13 @@ export const WidePage: FC<WidePageProps> = ({ title, onBack, tabs, activeTab, on
     // The same delay the panel's router uses for the pages it still covers:
     // Steam's navigation resolves its retained focus pointer after the mount,
     // and a focus placed before that is taken back.
-    const timer = setTimeout(() => placeEntryFocus(body, firstBodyStop), ENTRY_FOCUS_DELAY_MS);
+    //
+    // And the same rule as the router's: the area the body declared, or its
+    // first stop where it declared none. A page opened on something other than
+    // its first row has to be able to say so, because on a list-and-detail page
+    // focus is what selects — landing on the first row would select it and
+    // discard the section the reader was sent to.
+    const timer = setTimeout(() => placeEntryFocus(body, pageEntryStop), ENTRY_FOCUS_DELAY_MS);
     return () => clearTimeout(timer);
   }, [steamPlacesFocus]);
 

--- a/src/components/qam/WidePage.tsx
+++ b/src/components/qam/WidePage.tsx
@@ -93,6 +93,30 @@ const MIN_BODY_HEIGHT = 240;
 const BODY_BOTTOM_GAP = 12;
 
 /**
+ * The two halves of one measurement: how tall the body may be, and how far the
+ * root has to be pulled up for that height to fit.
+ *
+ * They are a pair because each half alone is measurably useless. `height`
+ * counts the space the frame's own ancestors hang into, so paying it out
+ * without the pull-up overflows the scroller by exactly `overhang` — live, a
+ * `scrollHeight` of 788 against a `clientHeight` of 750 — and 38 px of scroll
+ * is what takes the Back row off the top. The pull-up without the height moves
+ * nothing at all: live, the page still ends on the same line and the band under
+ * it is the same 62 px, because the room the ancestors stop claiming goes to
+ * nobody. So they travel as one value and are applied in one render.
+ */
+interface BodyFit {
+  height: number;
+  /**
+   * What the root's negative bottom margin cancels — the measured overhang,
+   * never a constant, for the reason `ancestorOverhang` states. A margin
+   * changes what the box claims after itself, not where it paints, so the
+   * ancestors stop where the scroller does and nothing on the page moves.
+   */
+  overhang: number;
+}
+
+/**
  * What the Back chip reads: the button's own glyph and the word.
  *
  * The glyph is Steam's, drawn for whatever controller is connected, so the chip
@@ -134,8 +158,14 @@ function scrollingAncestor(body: HTMLElement, view: Window): HTMLElement | null 
  * lands 50 px past that parent's. Nothing of ours is in those 50 px — but the
  * panel scrolls by them, and a 38 px scroll (50 less this frame's gap) moves
  * everything up by 38, which is exactly enough to take the Back row off the
- * top. So the space the body may occupy is smaller than the panel's by whatever
- * its ancestors overhang.
+ * top.
+ *
+ * **This is what the root's negative bottom margin cancels, not what the body
+ * gives up.** Subtracting it from the height instead is what left a band of the
+ * panel empty across every wide page: the wrapper then ended a gap above the
+ * scroller's box and our own content a further 50 px above that, with content
+ * that would have fitted clipped out of the difference. Cancelling it costs the
+ * page nothing, because the pixels were never ours to paint in.
  *
  * **Measured, never a constant.** The overhang comes from someone else's
  * markup, and a constant would pin every wide page to today's value of it. It
@@ -156,7 +186,15 @@ function ancestorOverhang(body: HTMLElement, scroller: HTMLElement): number {
 /**
  * The space left below `body` inside whatever scrolls it — the height a wide
  * page gets to work with, because Steam's tabbed page fills its parent rather
- * than growing and nothing in the QAM chain hands the plugin's panel a height.
+ * than growing and nothing in the QAM chain hands the plugin's panel a height —
+ * paired with the pull-up that makes room for it.
+ *
+ * The height is the whole of the scroller below the body's own top, less this
+ * frame's gap. The ancestors' overhang is not taken out of it: it rides along
+ * as the second half of the pair, and the caller spends it as a negative bottom
+ * margin on the root. Measured live, that is the difference between a page
+ * ending 62 px above the panel's box and one ending flush with the gap, with
+ * the scroller unscrollable either way (`scrollHeight` 750 == `clientHeight`).
  *
  * **The quantity has to be free of the scroller's own offset, and only a
  * layout-relative one is.** Every viewport-relative form grows as the panel
@@ -182,18 +220,23 @@ function ancestorOverhang(body: HTMLElement, scroller: HTMLElement): number {
  * from the QAM, where the panel is an ordinary element and Steam's own document
  * does not scroll.
  */
-function remainingBodyHeight(body: HTMLElement, view: Window): number {
+function measureBodyFit(body: HTMLElement, view: Window): BodyFit {
   const scroller = scrollingAncestor(body, view);
   const remaining = scroller
-    ? scroller.clientHeight - offsetWithinScroller(body, scroller) - ancestorOverhang(body, scroller)
+    ? scroller.clientHeight - offsetWithinScroller(body, scroller)
     : view.innerHeight - body.getBoundingClientRect().top;
-  return Math.max(MIN_BODY_HEIGHT, remaining - BODY_BOTTOM_GAP);
+  return {
+    height: Math.max(MIN_BODY_HEIGHT, remaining - BODY_BOTTOM_GAP),
+    // Nothing to cancel where the walk has no scroller to stop at — the
+    // fallback's height is viewport-relative and counts no ancestor box.
+    overhang: scroller ? ancestorOverhang(body, scroller) : 0,
+  };
 }
 
 export const WidePage: FC<WidePageProps> = ({ title, onBack, tabs, activeTab, onShowTab, children, ownRegions }) => {
   const rootRef = useRef<HTMLDivElement>(null);
   const bodyRef = useRef<HTMLDivElement>(null);
-  const [bodyHeight, setBodyHeight] = useState<number | null>(null);
+  const [fit, setFit] = useState<BodyFit | null>(null);
 
   useWideQamPanel(rootRef);
 
@@ -202,7 +245,14 @@ export const WidePage: FC<WidePageProps> = ({ title, onBack, tabs, activeTab, on
     const view = body?.ownerDocument.defaultView;
     if (!body || !view) return;
 
-    const measure = () => setBodyHeight(remainingBodyHeight(body, view));
+    // A re-measure that answers the same pair keeps the previous object, the
+    // bail-out an equal number used to get for free: the observers below fire
+    // on layout, and a fresh object every time would re-render on each one.
+    const measure = () =>
+      setFit((previous) => {
+        const next = measureBodyFit(body, view);
+        return previous?.height === next.height && previous.overhang === next.overhang ? previous : next;
+      });
     measure();
     // The view's own constructor, not the module's: plugin code runs in the
     // SharedJSContext window and these nodes are the QAM's.
@@ -246,8 +296,11 @@ export const WidePage: FC<WidePageProps> = ({ title, onBack, tabs, activeTab, on
   }, [steamPlacesFocus]);
 
   // A `min-height` is not enough here — Steam's tabbed page fills its parent and
-  // clips instead of growing, so the body needs a definite height.
-  const bodyStyle = { height: bodyHeight === null ? undefined : `${bodyHeight}px`, overflow: "hidden" };
+  // clips instead of growing, so the body needs a definite height. Its pull-up
+  // is read off the same value in the same render, which is the whole guard
+  // against the two drifting apart: there is no second thing to forget to set.
+  const bodyStyle = { height: fit === null ? undefined : `${fit.height}px`, overflow: "hidden" };
+  const rootStyle = fit === null ? undefined : { marginBottom: `${-fit.overhang}px` };
 
   // The frame's region is for a body of rows in one column, and nothing else
   // gets one. Steam's tabbed page already wraps each tab's content in this same
@@ -269,7 +322,7 @@ export const WidePage: FC<WidePageProps> = ({ title, onBack, tabs, activeTab, on
   }
 
   return (
-    <div className={WIDE_ROOT_CLASS} ref={rootRef} {...{ [OWNS_ENTRY_FOCUS_ATTR]: "" }}>
+    <div className={WIDE_ROOT_CLASS} ref={rootRef} style={rootStyle} {...{ [OWNS_ENTRY_FOCUS_ATTR]: "" }}>
       {/* One line, not three: the full-width Back row and the title on its own
           line cost two of the four rows the Deck's body has to spend. */}
       <Focusable style={{ display: "flex", alignItems: "center", gap: "10px", padding: "4px 16px 6px" }}>

--- a/src/components/qam/WidePage.tsx
+++ b/src/components/qam/WidePage.tsx
@@ -82,28 +82,20 @@ export const OWNS_ENTRY_FOCUS_ATTR = "data-romm-owns-entry-focus";
 // the panel out cannot collapse the page to nothing.
 const MIN_BODY_HEIGHT = 240;
 
-// Breathing room under the body, kept off the measurement so the page never
-// ends flush against the panel's bottom edge.
-//
-// **Not a knob for absorbing leftover scroll.** The ~50 px the panel used to
-// scroll by is a box Decky renders around every plugin's content, and it is
-// given back by measuring it — `ancestorOverhang` — rather than by growing this
-// number. A constant would pin every wide page to today's value of someone
-// else's markup.
-const BODY_BOTTOM_GAP = 12;
-
 /**
  * The two halves of one measurement: how tall the body may be, and how far the
  * root has to be pulled up for that height to fit.
  *
- * They are a pair because each half alone is measurably useless. `height`
- * counts the space the frame's own ancestors hang into, so paying it out
- * without the pull-up overflows the scroller by exactly `overhang` — live, a
- * `scrollHeight` of 788 against a `clientHeight` of 750 — and 38 px of scroll
- * is what takes the Back row off the top. The pull-up without the height moves
- * nothing at all: live, the page still ends on the same line and the band under
- * it is the same 62 px, because the room the ancestors stop claiming goes to
- * nobody. So they travel as one value and are applied in one render.
+ * **They are a pair because each half alone is useless, and measurably so.**
+ * `height` counts the space the frame's own ancestors hang into, so paying it
+ * out without the pull-up overflows the scroller by exactly `overhang` and the
+ * panel scrolls — which takes the Back row off the top. The pull-up without the
+ * height moves nothing at all: the page still ends on the same line and the
+ * band under it is unchanged, because the room the ancestors stop claiming goes
+ * to nobody. So they travel as one value and are applied in one render.
+ *
+ * Both are taken at runtime and re-taken together on every `measure()`, so a
+ * different display, UI scale or panel size changes them and nothing here.
  */
 interface BodyFit {
   height: number;
@@ -112,6 +104,11 @@ interface BodyFit {
    * never a constant, for the reason `ancestorOverhang` states. A margin
    * changes what the box claims after itself, not where it paints, so the
    * ancestors stop where the scroller does and nothing on the page moves.
+   *
+   * Zero is the safe reading and needs no special case: the margin is then
+   * `0px`, the height is what it always was, and the page behaves exactly as it
+   * did before this pair existed. So a chain this frame has never seen cannot
+   * come out worse than the version that gave the overhang away.
    */
   overhang: number;
 }
@@ -152,26 +149,45 @@ function scrollingAncestor(body: HTMLElement, view: Window): HTMLElement | null 
 /**
  * How far `body`'s own ancestors hang below their parents, up to `scroller`.
  *
- * Decky wraps a plugin's content in a box that overhangs: measured in the
- * running QAM, it sits 34 px below the panel top (Decky's own plugin title) and
- * takes `height: 100%` of a parent it is already inset within, so its bottom
- * lands 50 px past that parent's. Nothing of ours is in those 50 px — but the
- * panel scrolls by them, and a 38 px scroll (50 less this frame's gap) moves
- * everything up by 38, which is exactly enough to take the Back row off the
- * top.
+ * Decky wraps a plugin's content in a box that overhangs: it sits below the
+ * panel top by the height of Decky's own plugin title and takes `height: 100%`
+ * of a parent it is already inset within, so its bottom lands that far past
+ * that parent's. Nothing of ours is painted in those pixels — but the panel
+ * scrolls by them, and that is enough to take the Back row off the top.
  *
  * **This is what the root's negative bottom margin cancels, not what the body
  * gives up.** Subtracting it from the height instead is what left a band of the
- * panel empty across every wide page: the wrapper then ended a gap above the
- * scroller's box and our own content a further 50 px above that, with content
- * that would have fitted clipped out of the difference. Cancelling it costs the
- * page nothing, because the pixels were never ours to paint in.
+ * panel empty across every wide page: the wrapper then ended at the scroller's
+ * box and our own content an overhang above that, with content that would have
+ * fitted clipped out of the difference. Cancelling it costs the page nothing,
+ * because the pixels were never ours to paint in.
  *
- * **Measured, never a constant.** The overhang comes from someone else's
- * markup, and a constant would pin every wide page to today's value of it. It
- * also cannot oscillate: measured across body heights of 500, 600, 648 and 700
- * on the reference machine it stayed 50 every time, because it is the wrapper's
- * own inset and padding rather than anything derived from what we put inside.
+ * **Measured, never a constant.** The overhang comes from someone else's markup,
+ * and a constant would pin every wide page to today's value of it. That it has
+ * so far read the same 50 px in every environment tried — it is Decky's inset
+ * and padding in CSS pixels, so it does not scale with the viewport, and a
+ * 1.5-scale panel a third the height reports it unchanged — is evidence for the
+ * arithmetic, **not a value to hardcode**: the smaller the panel, the larger the
+ * same 50 px looms in it.
+ *
+ * **What the arithmetic assumes is a SHAPE, not a value.** Every value here is
+ * re-measured, so another display, scale or Decky release that merely overhangs
+ * by a different amount is already handled. What is assumed is that the boxes
+ * between the body and the scroller FOLLOW our content — the wrapper's bottom
+ * tracks ours plus its own inset, at every body height — so pulling the root's
+ * margin box up by the overhang moves those bottoms up with it. It holds
+ * because the overhang is the wrapper's own padding rather than anything
+ * derived from what we put inside, and it was checked at several body heights
+ * in two panel geometries.
+ *
+ * **If that ever stops holding, this is what it looks like.** A wrapper pinned
+ * to a height of its own — a future Decky or Steam nesting the plugin
+ * differently — would not follow the body up: growing the body would then
+ * overflow the wrapper instead of the wrapper's parent, the negative margin
+ * would cancel nothing that was in the way, and the panel would scroll again,
+ * which the reader meets as the Back row leaving the top. The check is one
+ * reading: the lowest ancestor bottom in this chain should equal the body's own
+ * once the margin is applied, and it should sit an overhang below it without.
  */
 function ancestorOverhang(body: HTMLElement, scroller: HTMLElement): number {
   let total = 0;
@@ -189,12 +205,38 @@ function ancestorOverhang(body: HTMLElement, scroller: HTMLElement): number {
  * than growing and nothing in the QAM chain hands the plugin's panel a height —
  * paired with the pull-up that makes room for it.
  *
- * The height is the whole of the scroller below the body's own top, less this
- * frame's gap. The ancestors' overhang is not taken out of it: it rides along
- * as the second half of the pair, and the caller spends it as a negative bottom
- * margin on the root. Measured live, that is the difference between a page
- * ending 62 px above the panel's box and one ending flush with the gap, with
- * the scroller unscrollable either way (`scrollHeight` 750 == `clientHeight`).
+ * The height is the whole of the scroller below the body's own top, and no
+ * allowance is taken off it. The ancestors' overhang is not taken out of it
+ * either: it rides along as the second half of the pair, and the caller spends
+ * it as a negative bottom margin on the root. That is the difference between a
+ * page ending an overhang above the panel's box and one ending on it, with the
+ * scroller unscrollable either way — the body carries `overflow: hidden`, so
+ * landing its bottom exactly on the scroller's cannot make the panel scroll.
+ *
+ * **Holding a few pixels back for breathing room is the obvious thing to do
+ * here, and it is wrong.** A constant subtracted at this point is not breathing
+ * room a reader perceives as such: it is a band of dead panel under the page,
+ * and the page has no way to end anywhere else. It also reads unevenly — a
+ * tabbed page keeps a bottom padding of Steam's own inside our body on top of
+ * it, which `qamExpansion` cancels — so the same constant showed as two
+ * different gaps depending on the page. Steam does not do it either: a QAM
+ * panel of its own, measured in this document, runs its content to its box with
+ * a gap of 0. Room under a page belongs to that page's own layout, where it can
+ * be seen and adjusted, not to a number the frame takes off every page's height.
+ *
+ * **Three runtime readings and one constant, and the readings are re-taken
+ * whenever the panel or the document resizes** (the layout effect's observers
+ * below). The readings are the scroller's `clientHeight`, the body's offset
+ * within its content, and the ancestors' overhang; the constant is the floor.
+ * Nothing here is a remembered pixel count, which is why a different display,
+ * UI scale or panel geometry needs no case of its own.
+ *
+ * The floor is the one place a reading is overruled, and it is unchanged: a
+ * measurement taken before Steam has laid the panel out can come back tiny or
+ * negative, and `MIN_BODY_HEIGHT` keeps the page from collapsing until the
+ * observers re-measure. The pull-up is not floored with it and does not need to
+ * be — a margin that cancels an overhang can only ever reduce what the chain
+ * claims, so it cannot turn a floored measurement into an overflow.
  *
  * **The quantity has to be free of the scroller's own offset, and only a
  * layout-relative one is.** Every viewport-relative form grows as the panel
@@ -226,7 +268,7 @@ function measureBodyFit(body: HTMLElement, view: Window): BodyFit {
     ? scroller.clientHeight - offsetWithinScroller(body, scroller)
     : view.innerHeight - body.getBoundingClientRect().top;
   return {
-    height: Math.max(MIN_BODY_HEIGHT, remaining - BODY_BOTTOM_GAP),
+    height: Math.max(MIN_BODY_HEIGHT, remaining),
     // Nothing to cancel where the walk has no scroller to stop at — the
     // fallback's height is viewport-relative and counts no ancestor box.
     overhang: scroller ? ancestorOverhang(body, scroller) : 0,
@@ -248,11 +290,15 @@ export const WidePage: FC<WidePageProps> = ({ title, onBack, tabs, activeTab, on
     // A re-measure that answers the same pair keeps the previous object, the
     // bail-out an equal number used to get for free: the observers below fire
     // on layout, and a fresh object every time would re-render on each one.
-    const measure = () =>
-      setFit((previous) => {
-        const next = measureBodyFit(body, view);
-        return previous?.height === next.height && previous.overhang === next.overhang ? previous : next;
-      });
+    //
+    // The layout is read HERE and only compared inside the updater. React
+    // requires an updater to be pure and calls it when it likes — StrictMode
+    // twice, a discarded concurrent render speculatively — so a rect read in
+    // there would be taken during render, at a moment nothing here chose.
+    const measure = () => {
+      const next = measureBodyFit(body, view);
+      setFit((previous) => (previous?.height === next.height && previous.overhang === next.overhang ? previous : next));
+    };
     measure();
     // The view's own constructor, not the module's: plugin code runs in the
     // SharedJSContext window and these nodes are the QAM's.

--- a/src/components/qam/WidePage.tsx
+++ b/src/components/qam/WidePage.tsx
@@ -157,16 +157,17 @@ function scrollingAncestor(body: HTMLElement, view: Window): HTMLElement | null 
  *
  * **This is what the root's negative bottom margin cancels, not what the body
  * gives up.** Subtracting it from the height instead is what left a band of the
- * panel empty across every wide page: the wrapper then ended at the scroller's
- * box and our own content an overhang above that, with content that would have
- * fitted clipped out of the difference. Cancelling it costs the page nothing,
+ * panel empty across every wide page: the wrapper then ended just short of the
+ * scroller's box and our own content an overhang above that, with content that
+ * would have fitted clipped out of the difference. Cancelling it costs the page nothing,
  * because the pixels were never ours to paint in.
  *
  * **Measured, never a constant.** The overhang comes from someone else's markup,
  * and a constant would pin every wide page to today's value of it. That it has
  * so far read the same 50 px in every environment tried — it is Decky's inset
  * and padding in CSS pixels, so it does not scale with the viewport, and a
- * 1.5-scale panel a third the height reports it unchanged — is evidence for the
+ * 1.5-scale panel three fifths the height (440 against 750) reports it
+ * unchanged — is evidence for the
  * arithmetic, **not a value to hardcode**: the smaller the panel, the larger the
  * same 50 px looms in it.
  *

--- a/src/components/qam/pane.tsx
+++ b/src/components/qam/pane.tsx
@@ -1,8 +1,9 @@
 /**
  * The pieces a wide page's detail pane is built from: the type scale it sets
  * secondary lines in, the colours it says things with, the two button shapes,
- * and the small components every pane repeats — a section title, a muted line,
- * a row of buttons, and the two lines that report an action.
+ * the table every page with more than two facts per row draws, and the small
+ * components every pane repeats — a section title, a muted line, a row of
+ * buttons, and the two lines that report an action.
  *
  * They are here rather than on a page because the next pane is written against
  * the same scale: a second literal for the same size is how two panes drift
@@ -11,7 +12,7 @@
  * Structure and vocabulary: `docs/architecture/qam-panel.md`.
  */
 
-import type { FC, ReactElement, ReactNode } from "react";
+import type { CSSProperties, FC, ReactElement, ReactNode } from "react";
 import { Focusable } from "@decky/ui";
 
 /** The size every secondary LINE on a pane is set in: a header's counts clause,
@@ -53,6 +54,181 @@ export const ROW_CONTENT_INSET = ROW_MARKER_WIDTH + ROW_MARKER_GAP;
 /** What the marker is drawn in while its row is the selected one. Outside the
  *  verdict palette above: it reports where the reader is, not how anything is. */
 export const SELECTION_ACCENT = "#1a9fff";
+
+/** The horizontal gutter a pane's content sits in — what `SectionTitle` and
+ *  `Muted` are padded by, so a table lines up with the section it sits under. */
+export const PANE_GUTTER = "16px";
+
+/** The rule under a table header and above a total row — Steam's own hairline
+ *  weight, the one the panel already separates its blocks with. */
+export const TABLE_LINE = "1px solid rgba(255, 255, 255, 0.12)";
+
+/**
+ * How tightly a page sets its table — the one thing the three tables genuinely
+ * differ in, and therefore a value a page passes rather than a reason to write
+ * a second table.
+ *
+ * The Sync page is the one that needs its own: a plan of seventeen units has to
+ * fit the column under the whole-run bar, so its rows are flatter and smaller
+ * than a pane's default type, and both of its tables take the same one so the
+ * preview and the run read as one family.
+ */
+export interface TableRegister {
+  /** Padding on the row wrapper, gutter included. */
+  rowPadding: string;
+  /** Padding on the header, gutter included — its bottom is the air between the
+   *  column names and the first row. */
+  headerPadding: string;
+  /** Set where a page wants a tighter type than the pane's own; left off, a row
+   *  inherits the pane's. */
+  rowFont?: CSSProperties["fontSize"];
+  rowLineHeight?: CSSProperties["lineHeight"];
+  /** A hairline under the column names. */
+  rule?: boolean;
+}
+
+/** What a table is set in unless a page says otherwise. */
+export const PANE_TABLE_REGISTER: TableRegister = {
+  rowPadding: `4px ${PANE_GUTTER}`,
+  headerPadding: `0 ${PANE_GUTTER} 4px`,
+};
+
+/**
+ * The three properties that make a cell clip rather than spill across the track
+ * beside it, plus the floor reset that lets it shrink at all.
+ *
+ * A grid track sized `minmax(0, 1fr)` shrinks under its content and the content
+ * then spills sideways — on the Deck a platform name ran into the New column's
+ * digit. They belong on the grid ITEM, which is blockified, so `text-overflow`
+ * applies to it where an inline `span` nested inside it is not and the same
+ * three do nothing at all. What the clip takes away is handed back in a `title`.
+ */
+export const CELL_CLIP: CSSProperties = {
+  minWidth: 0,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
+
+/** One cell of a table row or header. */
+export interface TableCell {
+  content: ReactNode;
+  /** Merged over the clip, so a cell can be right-aligned, muted, or made a flex
+   *  container without restating it. */
+  style?: CSSProperties;
+  /** What the clip took away, for the mouse. */
+  title?: string;
+  /**
+   * Off for a cell whose content is not a run of text — a row of glyphs, a
+   * button. There is nothing to ellipsise, and hidden overflow would cut the
+   * focus ring off a control.
+   */
+  clip?: boolean;
+}
+
+const asCell = (cell: string | TableCell): TableCell => (typeof cell === "string" ? { content: cell } : cell);
+
+const cellStyle = (cell: TableCell): CSSProperties => ({ ...(cell.clip === false ? {} : CELL_CLIP), ...cell.style });
+
+// The gap between columns is the same on every table here and is not a knob: two
+// tables whose columns breathe differently read as two kinds of table.
+const COLUMN_GAP = "8px";
+
+const Cells: FC<{ cells: readonly TableCell[] }> = ({ cells }) => (
+  <>
+    {cells.map((cell, index) => (
+      // The index IS the identity: a cell is the column it sits in, and the
+      // columns of one table never reorder.
+      <span key={index} style={cellStyle(cell)} {...(cell.title === undefined ? {} : { title: cell.title })}>
+        {cell.content}
+      </span>
+    ))}
+  </>
+);
+
+/**
+ * Column names over a table.
+ *
+ * Plain text, and never a focus stop: the names accompany the rows below them
+ * and scroll with them, so a stop here would add a step that leads nowhere.
+ * `ScrollRegion` reveals them when focus reaches the first row.
+ */
+export const PaneTableHeader: FC<{
+  columns: string;
+  cells: readonly (string | TableCell)[];
+  register?: TableRegister;
+  testId?: string;
+}> = ({ columns, cells, register = PANE_TABLE_REGISTER, testId }) => (
+  <div
+    {...(testId === undefined ? {} : { "data-testid": testId })}
+    style={{
+      display: "grid",
+      gridTemplateColumns: columns,
+      gap: COLUMN_GAP,
+      padding: register.headerPadding,
+      ...(register.rule ? { borderBottom: TABLE_LINE } : {}),
+      fontSize: SECONDARY_FONT,
+      color: MUTED,
+    }}
+  >
+    <Cells cells={cells.map(asCell)} />
+  </div>
+);
+
+/**
+ * One row of a table, and — unless one of its own cells carries a control — a
+ * focus stop.
+ *
+ * **A region scrolls only by moving focus**, so a row nothing can focus is a row
+ * nothing can scroll to. A row whose cells carry no control of their own has
+ * nothing else that could hold that focus, so the activate handler is what makes
+ * the `Focusable` a stop rather than a container that passes focus through to
+ * children it does not have.
+ *
+ * `focusStop={false}` is for the other case, and it is not an exemption from
+ * that rule: a row that DOES carry a control is already reachable through it,
+ * and a stop on the wrapper as well would put a dead step in front of every one
+ * of those controls.
+ *
+ * `children` are rendered inside the row and under its cells — the line a
+ * narrow column cannot hold, the note under a name. Inside rather than beside,
+ * so it travels with the focus highlight instead of being stranded between two
+ * stops.
+ */
+export const PaneTableRow: FC<{
+  columns: string;
+  cells: readonly TableCell[];
+  register?: TableRegister;
+  style?: CSSProperties;
+  testId?: string;
+  focusStop?: boolean;
+  children?: ReactNode;
+}> = ({ columns, cells, register = PANE_TABLE_REGISTER, style, testId, focusStop = true, children }) => {
+  const body = (
+    <>
+      <div style={{ display: "grid", gridTemplateColumns: columns, gap: COLUMN_GAP, alignItems: "center" }}>
+        <Cells cells={cells} />
+      </div>
+      {children}
+    </>
+  );
+  const wrapperStyle: CSSProperties = {
+    padding: register.rowPadding,
+    ...(register.rowFont === undefined ? {} : { fontSize: register.rowFont }),
+    ...(register.rowLineHeight === undefined ? {} : { lineHeight: register.rowLineHeight }),
+    ...style,
+  };
+  const marker = testId === undefined ? {} : { "data-testid": testId };
+  return focusStop ? (
+    <Focusable onActivate={() => {}} style={wrapperStyle} {...marker}>
+      {body}
+    </Focusable>
+  ) : (
+    <div style={wrapperStyle} {...marker}>
+      {body}
+    </div>
+  );
+};
 
 /**
  * The padding a `DialogButton` is given wherever a pane puts buttons in a row.

--- a/src/components/qam/pane.tsx
+++ b/src/components/qam/pane.tsx
@@ -137,9 +137,23 @@ const COLUMN_GAP = "8px";
 const Cells: FC<{ cells: readonly TableCell[] }> = ({ cells }) => (
   <>
     {cells.map((cell, index) => (
-      // The index IS the identity: a cell is the column it sits in, and the
-      // columns of one table never reorder.
-      <span key={index} style={cellStyle(cell)} {...(cell.title === undefined ? {} : { title: cell.title })}>
+      <span
+        // The index IS the identity: a cell is the column it sits in. A table's
+        // columns are fixed by the `columns` declaration it is drawn from — they
+        // never reorder, none is inserted or removed while the table is mounted,
+        // and a cell is a `span` holding no state, no ref and no uncontrolled
+        // input. So there is nothing a stable key would preserve that this does
+        // not, and content changing in place is what an index key handles best.
+        //
+        // A caller-supplied key was weighed and is not better HERE: it would be
+        // a real name for the two tables whose cells have one, and `col-${index}`
+        // for the Sync page's, which passes its cells positionally beside a
+        // `numericFrom` split — the same information, laundered into a string.
+        // Any of those three conditions changing is what makes this wrong again.
+        key={index} // NOSONAR(typescript:S6479) — fixed, non-reordering columns of stateless cells; see above.
+        style={cellStyle(cell)}
+        {...(cell.title === undefined ? {} : { title: cell.title })}
+      >
         {cell.content}
       </span>
     ))}

--- a/src/components/qam/pane.tsx
+++ b/src/components/qam/pane.tsx
@@ -36,6 +36,25 @@ export const PALE_GREEN = "#8fc46b";
 export const VIOLET = "#a48fd4";
 
 /**
+ * The bar down the left edge of the selected row of a list, and the gap between
+ * it and the row's content — together, how far every row of a list-and-detail
+ * page is inset from its column's edge.
+ *
+ * Here rather than on a page because every such list has to be inset by the same
+ * pair, and two lists that differ read as two kinds of list. A list header spans
+ * exactly what a row spans, so {@link ROW_CONTENT_INSET} is its left padding:
+ * happy-dom lays nothing out, so a drift between a list's rows and its header —
+ * or between one page's list and another's — is invisible to every test here.
+ */
+export const ROW_MARKER_WIDTH = 3;
+export const ROW_MARKER_GAP = 5;
+export const ROW_CONTENT_INSET = ROW_MARKER_WIDTH + ROW_MARKER_GAP;
+
+/** What the marker is drawn in while its row is the selected one. Outside the
+ *  verdict palette above: it reports where the reader is, not how anything is. */
+export const SELECTION_ACCENT = "#1a9fff";
+
+/**
  * The padding a `DialogButton` is given wherever a pane puts buttons in a row.
  *
  * `ButtonItem` — the full-width control most of the panel uses — takes no style

--- a/src/components/settings/ConnectionSection.test.tsx
+++ b/src/components/settings/ConnectionSection.test.tsx
@@ -21,12 +21,15 @@ interface ToggleFieldProps {
 const toggleCaptured: { items: ToggleFieldProps[] } = { items: [] };
 
 vi.mock("@decky/ui", () => ({
-  PanelSection: (p: AnyProps) => createElement("section", {}, p.children as never),
+  // The title is rendered rather than dropped: this is one of two service
+  // groups on the Connections pane, and it is the title that says which.
+  PanelSection: (p: AnyProps & { title?: unknown }) =>
+    createElement("section", { "data-title": typeof p.title === "string" ? p.title : undefined }, p.children as never),
   PanelSectionRow: (p: AnyProps) => createElement("div", {}, p.children as never),
-  Field: (p: AnyProps & { label?: unknown; description?: unknown }) =>
+  Field: (p: AnyProps & { label?: unknown; description?: unknown; focusable?: boolean }) =>
     createElement(
       "div",
-      { "data-testid": "field" },
+      { "data-testid": "field", tabIndex: p.focusable ? 0 : undefined },
       createElement("span", { "data-testid": "field-label" }, p.label as never),
       createElement("span", { "data-testid": "field-desc" }, p.description as never),
       p.children as never,
@@ -106,6 +109,19 @@ describe("ConnectionSection", () => {
   beforeEach(() => {
     toggleCaptured.items = [];
     vi.clearAllMocks();
+  });
+
+  it("titles its group after the service, not after the section it sits in", () => {
+    const { container } = render(<ConnectionSection {...defaultProps()} />);
+    expect(container.querySelector("section")?.getAttribute("data-title")).toBe("RomM");
+  });
+
+  it("makes the status line a focus stop, so a pane that scrolls by focus can reach it", () => {
+    const { getAllByTestId } = render(<ConnectionSection {...defaultProps({ status: "Signed in as deck" })} />);
+    const statusRow = getAllByTestId("field").find(
+      (el) => el.querySelector('[data-testid="field-label"]')?.textContent === "Signed in as deck",
+    );
+    expect(statusRow?.getAttribute("tabindex")).toBe("0");
   });
 
   describe("URL field", () => {

--- a/src/components/settings/ConnectionSection.tsx
+++ b/src/components/settings/ConnectionSection.tsx
@@ -3,6 +3,10 @@
  * Pure renderer: the parent owns the field values, the has-token flag, the
  * status string, and the save/sign-in logic. The QAM connection row probes the
  * server automatically, so there is no manual test affordance here.
+ *
+ * It is one group of the Settings page's Connections section, and its title
+ * names the SERVICE rather than the section: SteamGridDB is the other service
+ * on that pane and both are connections.
  */
 
 import { FC } from "react";
@@ -52,7 +56,7 @@ export const ConnectionSection: FC<ConnectionSectionProps> = ({
   onSignOut,
 }) => {
   return (
-    <PanelSection title="Connection">
+    <PanelSection title="RomM">
       <PanelSectionRow>
         <Field label="RomM URL" description={url || "(not set)"}>
           <DialogButton
@@ -116,7 +120,11 @@ export const ConnectionSection: FC<ConnectionSectionProps> = ({
       )}
       {status && (
         <PanelSectionRow>
-          <Field label={status} />
+          {/* Focusable because the pane scrolls by moving focus and this line
+              is not the last thing on it — the SteamGridDB group follows, so a
+              reader walking down would step straight over the answer to the
+              sign-in they just made. */}
+          <Field label={status} focusable={true} />
         </PanelSectionRow>
       )}
     </PanelSection>

--- a/src/components/settings/ControllerSection.test.tsx
+++ b/src/components/settings/ControllerSection.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, fireEvent } from "@testing-library/react";
-import { createElement } from "react";
+import { createElement, type ReactElement } from "react";
+import { showModal } from "@decky/ui";
 import { ControllerSection } from "./ControllerSection";
 import type { RetroArchInputCheck } from "../../types";
 
@@ -42,7 +43,27 @@ vi.mock("@decky/ui", () => ({
     dropdownCaptured.items.push(p);
     return createElement("div", { "data-testid": "dropdown" }, p.label as never);
   },
+  // A no-render stub: showModal captures the element, so the confirmation is
+  // inspected off the mock rather than the DOM. Rendering it would also make
+  // the fix look reachable without a press on OK.
+  ConfirmModal: () => null,
+  showModal: vi.fn(),
 }));
+
+interface ConfirmModalProps {
+  strTitle?: string;
+  strDescription?: string;
+  strOKButtonText?: string;
+  strCancelButtonText?: string;
+  onOK?: () => void;
+}
+
+function lastShownModalProps(): ConfirmModalProps | null {
+  const calls = vi.mocked(showModal).mock.calls;
+  if (calls.length === 0) return null;
+  const el = calls[calls.length - 1]?.[0] as ReactElement<ConfirmModalProps> | undefined;
+  return el?.props ?? null;
+}
 
 function defaultProps(overrides: Partial<React.ComponentProps<typeof ControllerSection>> = {}) {
   return {
@@ -150,13 +171,45 @@ describe("ControllerSection", () => {
       expect(container.textContent).toContain('RetroArch input_driver: "udev"');
     });
 
-    it("fires onFixInputDriver when the fix button is clicked", () => {
+    it("asks before it acts — the press opens the confirmation and runs nothing", () => {
       const onFixInputDriver = vi.fn();
       const { getByText } = render(
         <ControllerSection {...defaultProps({ retroarchWarning: warning(), onFixInputDriver })} />,
       );
       fireEvent.click(getByText("Fix input_driver to sdl2"));
+      // The rewrite keeps no copy of the config it replaces, so the press must
+      // not be the thing that starts it.
+      expect(onFixInputDriver).not.toHaveBeenCalled();
+      expect(vi.mocked(showModal)).toHaveBeenCalledTimes(1);
+    });
+
+    it("runs the fix on the confirmation's OK, and states what it will change", () => {
+      const onFixInputDriver = vi.fn();
+      const { getByText } = render(
+        <ControllerSection {...defaultProps({ retroarchWarning: warning(), onFixInputDriver })} />,
+      );
+      fireEvent.click(getByText("Fix input_driver to sdl2"));
+
+      const props = lastShownModalProps();
+      expect(props?.strTitle).toBe("Fix RetroArch input_driver?");
+      expect(props?.strDescription).toContain("change input_driver to sdl2 in your RetroArch config");
+      expect(props?.strOKButtonText).toBe("Apply Fix");
+      expect(props?.strCancelButtonText).toBe("Cancel");
+
+      props?.onOK?.();
       expect(onFixInputDriver).toHaveBeenCalledTimes(1);
+    });
+
+    it("declining does nothing at all", () => {
+      const onFixInputDriver = vi.fn();
+      const { getByText } = render(
+        <ControllerSection {...defaultProps({ retroarchWarning: warning(), onFixInputDriver })} />,
+      );
+      fireEvent.click(getByText("Fix input_driver to sdl2"));
+      // The confirm carries no cancel handler, so declining is the absence of
+      // the OK call and nothing else.
+      expect(lastShownModalProps()).not.toHaveProperty("onCancel");
+      expect(onFixInputDriver).not.toHaveBeenCalled();
     });
 
     it("renders the fix-status Field when retroarchFixStatus is non-empty", () => {

--- a/src/components/settings/ControllerSection.test.tsx
+++ b/src/components/settings/ControllerSection.test.tsx
@@ -50,7 +50,7 @@ function defaultProps(overrides: Partial<React.ComponentProps<typeof ControllerS
     steamInputStatus: "",
     retroarchWarning: null,
     retroarchFixStatus: "",
-    loading: false,
+    applying: false,
     onModeChange: vi.fn(),
     onApplyMode: vi.fn(),
     onFixInputDriver: vi.fn(),
@@ -93,12 +93,13 @@ describe("ControllerSection", () => {
       expect(onApplyMode).toHaveBeenCalledTimes(1);
     });
 
-    it("is disabled while loading=true", () => {
-      const { getByText } = render(<ControllerSection {...defaultProps({ loading: true })} />);
-      expect(getByText("Apply to All Shortcuts")).toBeDisabled();
+    it("is disabled and says a run is in flight while applying=true", () => {
+      const { getByText, queryByText } = render(<ControllerSection {...defaultProps({ applying: true })} />);
+      expect(getByText("Applying to all shortcuts…")).toBeDisabled();
+      expect(queryByText("Apply to All Shortcuts")).toBeNull();
     });
 
-    it("is enabled when loading=false", () => {
+    it("is enabled when applying=false", () => {
       const { getByText } = render(<ControllerSection {...defaultProps()} />);
       expect(getByText("Apply to All Shortcuts")).not.toBeDisabled();
     });

--- a/src/components/settings/ControllerSection.tsx
+++ b/src/components/settings/ControllerSection.tsx
@@ -4,12 +4,22 @@
  * Pure renderer: parent owns the mode value, status strings, and warning data.
  *
  * This is the input_driver fix's only home. Main names the condition and jumps
- * here; the button that changes the config exists nowhere else.
+ * here; the button that changes the config exists nowhere else, and it asks
+ * before it acts — the confirmation moved here with the button rather than
+ * being left behind on Main.
  */
 
 import { FC } from "react";
-import { PanelSection, PanelSectionRow, ButtonItem, Field, DropdownItem } from "@decky/ui";
+import { PanelSection, PanelSectionRow, ButtonItem, ConfirmModal, Field, DropdownItem, showModal } from "@decky/ui";
 import type { RetroArchInputCheck } from "../../types";
+
+// The fix rewrites `retroarch.cfg` in place and keeps no copy of what was there
+// (`adapters/steam_config.py`, `fix_retroarch_input_driver`), so it takes the
+// confirm leg of the register's backup-or-confirm rule. The wording is the one
+// the button carried on Main before this became its only home.
+const FIX_INPUT_DRIVER_DESCRIPTION =
+  "This will change input_driver to sdl2 in your RetroArch config. " +
+  "Controllers should work better in RetroArch menus after this change.";
 
 interface ControllerSectionProps {
   steamInputMode: string;
@@ -72,7 +82,20 @@ export const ControllerSection: FC<ControllerSectionProps> = ({
             />
           </PanelSectionRow>
           <PanelSectionRow>
-            <ButtonItem layout="below" onClick={onFixInputDriver}>
+            <ButtonItem
+              layout="below"
+              onClick={() =>
+                showModal(
+                  <ConfirmModal
+                    strTitle="Fix RetroArch input_driver?"
+                    strDescription={FIX_INPUT_DRIVER_DESCRIPTION}
+                    strOKButtonText="Apply Fix"
+                    strCancelButtonText="Cancel"
+                    onOK={onFixInputDriver}
+                  />,
+                )
+              }
+            >
               Fix input_driver to sdl2
             </ButtonItem>
           </PanelSectionRow>

--- a/src/components/settings/ControllerSection.tsx
+++ b/src/components/settings/ControllerSection.tsx
@@ -2,6 +2,9 @@
  * Controller settings — Steam Input mode dropdown, "Apply to All Shortcuts"
  * trigger, and the RetroArch input_driver warning + auto-fix affordance.
  * Pure renderer: parent owns the mode value, status strings, and warning data.
+ *
+ * This is the input_driver fix's only home. Main names the condition and jumps
+ * here; the button that changes the config exists nowhere else.
  */
 
 import { FC } from "react";
@@ -13,7 +16,10 @@ interface ControllerSectionProps {
   steamInputStatus: string;
   retroarchWarning: RetroArchInputCheck | null;
   retroarchFixStatus: string;
-  loading: boolean;
+  /** An apply run is in flight. The button is dead and says so while it is, and
+   *  the parent refuses a second press independently — a disabled control still
+   *  reports one on the device. */
+  applying: boolean;
   onModeChange: (mode: string) => void;
   onApplyMode: () => void;
   onFixInputDriver: () => void;
@@ -24,7 +30,7 @@ export const ControllerSection: FC<ControllerSectionProps> = ({
   steamInputStatus,
   retroarchWarning,
   retroarchFixStatus,
-  loading,
+  applying,
   onModeChange,
   onApplyMode,
   onFixInputDriver,
@@ -45,13 +51,15 @@ export const ControllerSection: FC<ControllerSectionProps> = ({
         />
       </PanelSectionRow>
       <PanelSectionRow>
-        <ButtonItem layout="below" onClick={onApplyMode} disabled={loading}>
-          Apply to All Shortcuts
+        <ButtonItem layout="below" onClick={onApplyMode} disabled={applying}>
+          {applying ? "Applying to all shortcuts…" : "Apply to All Shortcuts"}
         </ButtonItem>
       </PanelSectionRow>
       {steamInputStatus && (
         <PanelSectionRow>
-          <Field label={steamInputStatus} />
+          {/* Focusable for the reason every read-only row on a wide pane is: the
+              region scrolls by moving focus, and rows follow this one. */}
+          <Field label={steamInputStatus} focusable={true} />
         </PanelSectionRow>
       )}
       {retroarchWarning?.warning && (
@@ -60,6 +68,7 @@ export const ControllerSection: FC<ControllerSectionProps> = ({
             <Field
               label={`RetroArch input_driver: "${retroarchWarning.current}"`}
               description="Controller navigation in RetroArch menus may not work with this setting."
+              focusable={true}
             />
           </PanelSectionRow>
           <PanelSectionRow>
@@ -69,7 +78,7 @@ export const ControllerSection: FC<ControllerSectionProps> = ({
           </PanelSectionRow>
           {retroarchFixStatus && (
             <PanelSectionRow>
-              <Field label={retroarchFixStatus} />
+              <Field label={retroarchFixStatus} focusable={true} />
             </PanelSectionRow>
           )}
         </>

--- a/src/components/settings/LibrarySection.test.tsx
+++ b/src/components/settings/LibrarySection.test.tsx
@@ -22,7 +22,14 @@ vi.mock("@decky/ui", () => {
   type AnyProps = Record<string, unknown> & { children?: unknown };
   const passthrough = (tag: string) => (p: AnyProps) => createElement(tag, {}, p.children as never);
   return {
-    PanelSection: passthrough("section"),
+    // The title is rendered rather than dropped: it is what names the group on
+    // the Settings pane, and the section it belongs to is not called Library.
+    PanelSection: (p: AnyProps & { title?: unknown }) =>
+      createElement(
+        "section",
+        { "data-title": typeof p.title === "string" ? p.title : undefined },
+        p.children as never,
+      ),
     PanelSectionRow: passthrough("div"),
     DropdownItem: (p: DropdownItemProps) => {
       captured.items.push(p);
@@ -83,6 +90,23 @@ describe("buildRegionOptions", () => {
 describe("LibrarySection", () => {
   beforeEach(() => {
     captured.items = [];
+  });
+
+  it("titles its group Steam Library, not Library", () => {
+    // The Library PAGE is the RomM side — what gets synced. This group is the
+    // Steam side, and one word for both would name two different things.
+    const { container } = render(
+      <LibrarySection
+        preferredRegion={AUTO_REGION}
+        libraryRegions={[]}
+        onPreferredRegionChange={vi.fn()}
+        platformGroups={false}
+        onPlatformGroupsChange={vi.fn()}
+        namingMode="merge"
+        onNamingModeChange={vi.fn()}
+      />,
+    );
+    expect(container.querySelector("section")?.getAttribute("data-title")).toBe("Steam Library");
   });
 
   it("renders the preferred-region dropdown with anchors + library regions", () => {

--- a/src/components/settings/LibrarySection.tsx
+++ b/src/components/settings/LibrarySection.tsx
@@ -1,9 +1,13 @@
 /**
- * Library-wide sync preferences. Houses set-and-forget library toggles: the
- * preferred-region dropdown (ADR-0021 §3, which region wins when a game has
- * several dumps and the plugin must pick one to bind + name the shortcut after)
- * and the collection platform-groups toggle. Pure renderer: parent owns every
- * value and the save/confirm flow.
+ * Set-and-forget preferences about what the library looks like once it is IN
+ * Steam: the preferred-region dropdown (ADR-0021 §3, which region wins when a
+ * game has several dumps and the plugin must pick one to bind + name the
+ * shortcut after), the collection platform-groups toggle and the naming mode.
+ * Pure renderer: parent owns every value and the save/confirm flow.
+ *
+ * It is titled **Steam Library** rather than Library: the Library page is the
+ * RomM side of the same subject — what gets synced — and these are the Steam
+ * side, so one word for both would name two different things.
  */
 
 import { FC } from "react";
@@ -76,7 +80,7 @@ export const LibrarySection: FC<LibrarySectionProps> = ({
   onNamingModeChange,
 }) => {
   return (
-    <PanelSection title="Library">
+    <PanelSection title="Steam Library">
       <PanelSectionRow>
         <DropdownItem
           label="Preferred region"

--- a/src/components/settings/RegisteredDevicesSection.test.tsx
+++ b/src/components/settings/RegisteredDevicesSection.test.tsx
@@ -20,10 +20,17 @@ vi.mock("@decky/ui", () => ({
       createElement("span", { "data-testid": "field-label" }, p.label as never),
       createElement("span", { "data-testid": "field-desc" }, p.description as never),
     ),
+  // The testid is forwarded when one is passed: the shared table primitive puts
+  // it on the row WRAPPER, which is also the focus stop, so a mock that
+  // hardcoded its own would hide both from every assertion below.
   Focusable: (p: AnyProps & { onActivate?: (e: unknown) => void; style?: unknown }) =>
     createElement(
       "div",
-      { "data-testid": "focusable", tabIndex: p.onActivate ? 0 : undefined, style: p.style },
+      {
+        "data-testid": (p["data-testid"] as string | undefined) ?? "focusable",
+        tabIndex: p.onActivate ? 0 : undefined,
+        style: p.style,
+      },
       p.children as never,
     ),
 }));
@@ -51,9 +58,17 @@ function defaultProps(overrides: Partial<React.ComponentProps<typeof RegisteredD
   };
 }
 
-/** The three cells of a row, in column order. */
-function cells(row: Element): string[] {
-  return Array.from(row.children).map((cell) => cell.textContent);
+/** The grid inside a row wrapper, or the header, whichever was handed in — the
+ *  element that carries the column declaration and holds the cells. The shared
+ *  primitive puts the testid on the row's focusable WRAPPER and the grid one
+ *  level in; a header is its own grid. */
+function grid(el: Element): HTMLElement {
+  return (el.getAttribute("data-testid") === "device-row" ? el.firstElementChild : el) as HTMLElement;
+}
+
+/** The three cells of a row or header, in column order. */
+function cells(el: Element): string[] {
+  return Array.from(grid(el).children).map((cell) => cell.textContent);
 }
 
 // What this plugin registers itself as: `register_device` passes
@@ -78,7 +93,7 @@ const CLIENT_CELL_PX = 143;
 
 /** The px width the rendered `grid-template-columns` gives the Client track. */
 function clientTrackPx(el: Element): number {
-  const tracks = (el as HTMLElement).style.gridTemplateColumns.split(/\s+/);
+  const tracks = grid(el).style.gridTemplateColumns.split(/\s+/);
   expect(tracks).toHaveLength(3);
   const client = tracks[1] ?? "";
   expect(client).toMatch(/^\d+px$/);
@@ -183,8 +198,8 @@ describe("RegisteredDevicesSection", () => {
       const { getByTestId } = render(
         <RegisteredDevicesSection {...defaultProps({ registeredDevices: [makeDevice()] })} />,
       );
-      const header = (getByTestId("devices-header") as HTMLElement).style.gridTemplateColumns;
-      const row = (getByTestId("device-row") as HTMLElement).style.gridTemplateColumns;
+      const header = grid(getByTestId("devices-header")).style.gridTemplateColumns;
+      const row = grid(getByTestId("device-row")).style.gridTemplateColumns;
       expect(header).toBe(row);
       // Non-vacuous: both were read, and both name three tracks.
       expect(header).toMatch(/^\S+\s+\S+\s+\S+$/);
@@ -198,7 +213,8 @@ describe("RegisteredDevicesSection", () => {
       const { getAllByTestId } = render(<RegisteredDevicesSection {...defaultProps({ registeredDevices: devices })} />);
       const rows = getAllByTestId("device-row");
       expect(rows).toHaveLength(2);
-      expect(rows.map((row) => row.parentElement?.getAttribute("tabindex"))).toEqual(["0", "0"]);
+      // The wrapper the primitive puts the testid on IS the stop.
+      expect(rows.map((row) => row.getAttribute("tabindex"))).toEqual(["0", "0"]);
     });
 
     it("puts the name, the client with its version, and the relative time in their own columns", () => {
@@ -233,7 +249,7 @@ describe("RegisteredDevicesSection", () => {
       const { getByTestId } = render(
         <RegisteredDevicesSection {...defaultProps({ registeredDevices: [makeDevice({ name })] })} />,
       );
-      const nameCell = getByTestId("device-row").children[0] as HTMLElement;
+      const nameCell = grid(getByTestId("device-row")).children[0] as HTMLElement;
       expect(nameCell.getAttribute("title")).toBe(name);
       // The clip lives on the flex ITEM holding the name, not on the flex
       // container around it — clipping the container would take the

--- a/src/components/settings/RegisteredDevicesSection.test.tsx
+++ b/src/components/settings/RegisteredDevicesSection.test.tsx
@@ -71,10 +71,11 @@ function cells(el: Element): string[] {
   return Array.from(grid(el).children).map((cell) => cell.textContent);
 }
 
-// What this plugin registers itself as: `register_device` passes
-// `client="decky-romm-sync"` with the plugin version
-// (`py_modules/services/saves/sync_engine/devices.py`). Every row a Deck shows
-// carries it, so it is the string the Client column has to hold.
+// The longest client string the server can hand back — NOT what this plugin
+// registers under now, which is `DISPLAY_NAME`, "Tender" (`domain/identity.py`).
+// RomM keeps the rows earlier versions wrote, and up to 0.32 they said
+// `decky-romm-sync`; those rows do not expire, so this is what the column has to
+// hold. Sizing to today's shorter name would clip them.
 const REAL_CLIENT = "decky-romm-sync";
 const REAL_VERSION = "0.32.0";
 

--- a/src/components/settings/RegisteredDevicesSection.test.tsx
+++ b/src/components/settings/RegisteredDevicesSection.test.tsx
@@ -56,6 +56,35 @@ function cells(row: Element): string[] {
   return Array.from(row.children).map((cell) => cell.textContent);
 }
 
+// What this plugin registers itself as: `register_device` passes
+// `client="decky-romm-sync"` with the plugin version
+// (`py_modules/services/saves/sync_engine/devices.py`). Every row a Deck shows
+// carries it, so it is the string the Client column has to hold.
+const REAL_CLIENT = "decky-romm-sync";
+const REAL_VERSION = "0.32.0";
+
+// The width `decky-romm-sync v0.32.0` needs at the 11px these cells are set in,
+// summed from the fonts' own glyph advances: 131px in Noto Sans, 143px in
+// DejaVu Sans. Steam renders it in Motiva Sans, which is on no machine here, so
+// the column is held to the wider of the two.
+//
+// **This number is not read from the component**, which is the whole point of
+// the test below: it is the requirement the component's own track is checked
+// against, so narrowing that track fails here instead of silently clipping the
+// version on a device nobody is looking at. happy-dom lays nothing out, so
+// comparing the declaration against a measured requirement is the only way this
+// can be checked at all.
+const CLIENT_CELL_PX = 143;
+
+/** The px width the rendered `grid-template-columns` gives the Client track. */
+function clientTrackPx(el: Element): number {
+  const tracks = (el as HTMLElement).style.gridTemplateColumns.split(/\s+/);
+  expect(tracks).toHaveLength(3);
+  const client = tracks[1] ?? "";
+  expect(client).toMatch(/^\d+px$/);
+  return Number.parseInt(client, 10);
+}
+
 describe("RegisteredDevicesSection", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -139,6 +168,26 @@ describe("RegisteredDevicesSection", () => {
       for (let el: Element | null = getByTestId("devices-header"); el; el = el.parentElement) {
         expect(el.getAttribute("tabindex")).toBeNull();
       }
+    });
+
+    it("gives Client a track wide enough for the client name the plugin registers", () => {
+      const device = makeDevice({ client: REAL_CLIENT, client_version: REAL_VERSION });
+      const { getByTestId } = render(<RegisteredDevicesSection {...defaultProps({ registeredDevices: [device] })} />);
+      // The cell really does carry the long string, so the width below is
+      // checked against what is rendered rather than against a hypothetical.
+      expect(cells(getByTestId("device-row"))[1]).toBe("decky-romm-sync v0.32.0");
+      expect(clientTrackPx(getByTestId("device-row"))).toBeGreaterThanOrEqual(CLIENT_CELL_PX);
+    });
+
+    it("declares the same columns on the header as on a row, or they would not line up", () => {
+      const { getByTestId } = render(
+        <RegisteredDevicesSection {...defaultProps({ registeredDevices: [makeDevice()] })} />,
+      );
+      const header = (getByTestId("devices-header") as HTMLElement).style.gridTemplateColumns;
+      const row = (getByTestId("device-row") as HTMLElement).style.gridTemplateColumns;
+      expect(header).toBe(row);
+      // Non-vacuous: both were read, and both name three tracks.
+      expect(header).toMatch(/^\S+\s+\S+\s+\S+$/);
     });
 
     it("renders one row per device, each a focus stop so the table can be walked", () => {

--- a/src/components/settings/RegisteredDevicesSection.test.tsx
+++ b/src/components/settings/RegisteredDevicesSection.test.tsx
@@ -10,10 +10,13 @@ type AnyProps = Record<string, unknown> & { children?: unknown };
 vi.mock("@decky/ui", () => ({
   PanelSection: (p: AnyProps) => createElement("section", {}, p.children as never),
   PanelSectionRow: (p: AnyProps) => createElement("div", { "data-testid": "row" }, p.children as never),
-  Field: (p: AnyProps & { label?: unknown; description?: unknown }) =>
+  // `focusable` renders tabindex="0", which is what makes a row with no control
+  // of its own a focus stop — and a wide pane scrolls only by moving focus, so
+  // a mock that dropped it would make an unreachable group look reachable.
+  Field: (p: AnyProps & { label?: unknown; description?: unknown; focusable?: boolean }) =>
     createElement(
       "div",
-      { "data-testid": "field" },
+      { "data-testid": "field", tabIndex: p.focusable ? 0 : undefined },
       createElement("span", { "data-testid": "field-label" }, p.label as never),
       createElement("span", { "data-testid": "field-desc" }, p.description as never),
     ),
@@ -154,6 +157,13 @@ describe("RegisteredDevicesSection", () => {
       const { container } = render(<RegisteredDevicesSection {...defaultProps({ registeredDevices: devices })} />);
       const matches = container.textContent.match(/\(this device\)/g) ?? [];
       expect(matches).toHaveLength(1);
+    });
+
+    it("makes every row a focus stop, so the list can be walked and scrolled", () => {
+      const devices = [makeDevice({ id: "device-aaaaaaaa" }), makeDevice({ id: "device-bbbbbbbb" })];
+      const { getAllByTestId } = render(<RegisteredDevicesSection {...defaultProps({ registeredDevices: devices })} />);
+      const stops = getAllByTestId("field").map((el) => el.getAttribute("tabindex"));
+      expect(stops).toEqual(["0", "0"]);
     });
 
     it("renders 'ID —' when the id is empty string", () => {

--- a/src/components/settings/RegisteredDevicesSection.test.tsx
+++ b/src/components/settings/RegisteredDevicesSection.test.tsx
@@ -4,21 +4,27 @@ import { createElement } from "react";
 import { RegisteredDevicesSection } from "./RegisteredDevicesSection";
 import type { RegisteredDevice } from "../../types";
 
-// Local re-mock: Field renders both label+description so we can assert the
-// pipe-separated parts string. PanelSection/PanelSectionRow are pass-through.
+// Local re-mock. Two things it must NOT drop, because each is what a rule here
+// is stated against: `focusable` on a Field and `onActivate` on a Focusable both
+// render tabindex="0", which is what makes a row with no control of its own a
+// focus stop — and a wide pane scrolls only by moving focus, so a mock that
+// dropped them would make an unreachable group look reachable.
 type AnyProps = Record<string, unknown> & { children?: unknown };
 vi.mock("@decky/ui", () => ({
   PanelSection: (p: AnyProps) => createElement("section", {}, p.children as never),
   PanelSectionRow: (p: AnyProps) => createElement("div", { "data-testid": "row" }, p.children as never),
-  // `focusable` renders tabindex="0", which is what makes a row with no control
-  // of its own a focus stop — and a wide pane scrolls only by moving focus, so
-  // a mock that dropped it would make an unreachable group look reachable.
   Field: (p: AnyProps & { label?: unknown; description?: unknown; focusable?: boolean }) =>
     createElement(
       "div",
       { "data-testid": "field", tabIndex: p.focusable ? 0 : undefined },
       createElement("span", { "data-testid": "field-label" }, p.label as never),
       createElement("span", { "data-testid": "field-desc" }, p.description as never),
+    ),
+  Focusable: (p: AnyProps & { onActivate?: (e: unknown) => void; style?: unknown }) =>
+    createElement(
+      "div",
+      { "data-testid": "focusable", tabIndex: p.onActivate ? 0 : undefined, style: p.style },
+      p.children as never,
     ),
 }));
 
@@ -45,6 +51,11 @@ function defaultProps(overrides: Partial<React.ComponentProps<typeof RegisteredD
   };
 }
 
+/** The three cells of a row, in column order. */
+function cells(row: Element): string[] {
+  return Array.from(row.children).map((cell) => cell.textContent);
+}
+
 describe("RegisteredDevicesSection", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -67,6 +78,11 @@ describe("RegisteredDevicesSection", () => {
       expect(labels).toContain("Loading...");
       expect(labels).not.toContain("Could not load devices");
     });
+
+    it("draws no column header over a state that has no rows", () => {
+      const { queryByTestId } = render(<RegisteredDevicesSection {...defaultProps({ devicesLoading: true })} />);
+      expect(queryByTestId("devices-header")).toBeNull();
+    });
   });
 
   describe("error state", () => {
@@ -79,6 +95,12 @@ describe("RegisteredDevicesSection", () => {
       expect(labels).toContain("Could not load devices");
       expect(descs).toContain("Network unreachable");
     });
+
+    it("draws no column header, and no row, over an error", () => {
+      const { queryByTestId } = render(<RegisteredDevicesSection {...defaultProps({ devicesError: "boom" })} />);
+      expect(queryByTestId("devices-header")).toBeNull();
+      expect(queryByTestId("device-row")).toBeNull();
+    });
   });
 
   describe("empty state", () => {
@@ -88,91 +110,122 @@ describe("RegisteredDevicesSection", () => {
       expect(labels).toContain("No devices registered");
     });
 
+    it("draws no column header over an empty list", () => {
+      const { queryByTestId } = render(<RegisteredDevicesSection {...defaultProps({ registeredDevices: [] })} />);
+      expect(queryByTestId("devices-header")).toBeNull();
+    });
+
     it("renders nothing meaningful when registeredDevices is null and no loading/error", () => {
       const { queryAllByTestId } = render(<RegisteredDevicesSection {...defaultProps()} />);
       expect(queryAllByTestId("field")).toHaveLength(0);
+      expect(queryAllByTestId("device-row")).toHaveLength(0);
     });
   });
 
-  describe("populated list", () => {
-    it("renders one row per device", () => {
+  describe("the table", () => {
+    it("names its three columns, in order", () => {
+      const { getByTestId } = render(
+        <RegisteredDevicesSection {...defaultProps({ registeredDevices: [makeDevice()] })} />,
+      );
+      expect(cells(getByTestId("devices-header"))).toEqual(["Device", "Client", "Last seen"]);
+    });
+
+    it("does not make the header a focus stop — the column names lead nowhere", () => {
+      const { getByTestId } = render(
+        <RegisteredDevicesSection {...defaultProps({ registeredDevices: [makeDevice()] })} />,
+      );
+      // The header is a plain div, and the Focusable rows are its siblings: no
+      // ancestor of it carries a tabindex either.
+      for (let el: Element | null = getByTestId("devices-header"); el; el = el.parentElement) {
+        expect(el.getAttribute("tabindex")).toBeNull();
+      }
+    });
+
+    it("renders one row per device, each a focus stop so the table can be walked", () => {
       const devices = [
         makeDevice({ id: "device-aaaaaaaa", name: "Steam Deck" }),
         makeDevice({ id: "device-bbbbbbbb", name: "Desktop" }),
       ];
       const { getAllByTestId } = render(<RegisteredDevicesSection {...defaultProps({ registeredDevices: devices })} />);
-      // 2 device rows; no loading/error/empty rows are rendered.
-      expect(getAllByTestId("field")).toHaveLength(2);
+      const rows = getAllByTestId("device-row");
+      expect(rows).toHaveLength(2);
+      expect(rows.map((row) => row.parentElement?.getAttribute("tabindex"))).toEqual(["0", "0"]);
     });
 
-    it("formats the description as 'client vX · platform · last seen Xm ago · ID 8chars'", () => {
+    it("puts the name, the client with its version, and the relative time in their own columns", () => {
       const device = makeDevice({
-        id: "device-aaaaaaaa-rest-of-uuid",
-        client: "Tender",
+        name: "Steam Deck",
+        // What this plugin registers under today is `DISPLAY_NAME`, "Tender"
+        // (`domain/identity.py`). The older spelling is used here because the
+        // column has to render what the SERVER holds, and the server keeps the
+        // rows earlier versions wrote — a real listing shows both.
+        client: "decky-romm-sync",
         client_version: "0.17.1",
-        platform: "linux",
         last_seen: "2025-06-15T11:55:00Z", // 5 minutes ago
       });
-      const { getAllByTestId } = render(
-        <RegisteredDevicesSection {...defaultProps({ registeredDevices: [device] })} />,
-      );
-      const desc = getAllByTestId("field-desc")[0]?.textContent ?? "";
-      expect(desc).toContain("Tender v0.17.1");
-      expect(desc).toContain("linux");
-      expect(desc).toContain("last seen 5m ago");
-      expect(desc).toContain("ID device-a"); // first 8 chars of id
+      const { getByTestId } = render(<RegisteredDevicesSection {...defaultProps({ registeredDevices: [device] })} />);
+      expect(cells(getByTestId("device-row"))).toEqual(["Steam Deck", "decky-romm-sync v0.17.1", "5m ago"]);
     });
 
-    it("omits the platform segment when device.platform is null", () => {
-      const device = makeDevice({ platform: null });
-      const { getAllByTestId } = render(
-        <RegisteredDevicesSection {...defaultProps({ registeredDevices: [device] })} />,
+    it("carries neither the platform nor the id — the two facts the columns dropped", () => {
+      const device = makeDevice({ platform: "linux", id: "device-aaaaaaaa-rest-of-uuid" });
+      const { getByTestId } = render(<RegisteredDevicesSection {...defaultProps({ registeredDevices: [device] })} />);
+      const row = getByTestId("device-row");
+      expect(row.textContent).not.toContain("linux");
+      expect(row.textContent).not.toContain("device-a");
+      // Not smuggled back into a tooltip either.
+      const titles = Array.from(row.querySelectorAll("[title]")).map((el) => el.getAttribute("title"));
+      expect(titles.join(" ")).not.toContain("linux");
+      expect(titles.join(" ")).not.toContain("device-a");
+    });
+
+    it("clips a long device name and hands the whole of it back in a title", () => {
+      const name = "Daniel's living-room machine with a very long name indeed";
+      const { getByTestId } = render(
+        <RegisteredDevicesSection {...defaultProps({ registeredDevices: [makeDevice({ name })] })} />,
       );
-      const desc = getAllByTestId("field-desc")[0]?.textContent ?? "";
-      // No "linux" or platform string — segments are: client, last seen, ID.
-      const segments = desc.split(" · ");
-      expect(segments).toHaveLength(3);
+      const nameCell = getByTestId("device-row").children[0] as HTMLElement;
+      expect(nameCell.getAttribute("title")).toBe(name);
+      // The clip lives on the flex ITEM holding the name, not on the flex
+      // container around it — clipping the container would take the
+      // "(this device)" marker away with the overflow.
+      const nameSpan = nameCell.firstElementChild as HTMLElement;
+      expect(nameSpan.style.overflow).toBe("hidden");
+      expect(nameSpan.style.textOverflow).toBe("ellipsis");
+      expect(nameSpan.style.whiteSpace).toBe("nowrap");
+      expect(nameSpan.style.minWidth).toBe("0");
     });
 
     it("falls back to 'unknown client v?' when client/client_version are null", () => {
       const device = makeDevice({ client: null, client_version: null });
-      const { getAllByTestId } = render(
-        <RegisteredDevicesSection {...defaultProps({ registeredDevices: [device] })} />,
-      );
-      const desc = getAllByTestId("field-desc")[0]?.textContent ?? "";
-      expect(desc).toContain("unknown client v?");
+      const { getByTestId } = render(<RegisteredDevicesSection {...defaultProps({ registeredDevices: [device] })} />);
+      expect(cells(getByTestId("device-row"))[1]).toBe("unknown client v?");
     });
 
     it("renders '(unnamed)' when device.name is null", () => {
       const device = makeDevice({ name: null });
-      const { container } = render(<RegisteredDevicesSection {...defaultProps({ registeredDevices: [device] })} />);
-      expect(container.textContent).toContain("(unnamed)");
+      const { getByTestId } = render(<RegisteredDevicesSection {...defaultProps({ registeredDevices: [device] })} />);
+      expect(cells(getByTestId("device-row"))[0]).toBe("(unnamed)");
     });
 
-    it("renders the '(this device)' badge only on the current device", () => {
+    it("renders 'never' in Last seen when the device has never been seen", () => {
+      const device = makeDevice({ last_seen: null });
+      const { getByTestId } = render(<RegisteredDevicesSection {...defaultProps({ registeredDevices: [device] })} />);
+      expect(cells(getByTestId("device-row"))[2]).toBe("never");
+    });
+
+    it("marks the current device, and only it", () => {
       const devices = [
         makeDevice({ id: "device-aaaa1111", name: "Steam Deck", is_current_device: true }),
         makeDevice({ id: "device-bbbb2222", name: "Desktop", is_current_device: false }),
       ];
-      const { container } = render(<RegisteredDevicesSection {...defaultProps({ registeredDevices: devices })} />);
+      const { getAllByTestId, container } = render(
+        <RegisteredDevicesSection {...defaultProps({ registeredDevices: devices })} />,
+      );
       const matches = container.textContent.match(/\(this device\)/g) ?? [];
       expect(matches).toHaveLength(1);
-    });
-
-    it("makes every row a focus stop, so the list can be walked and scrolled", () => {
-      const devices = [makeDevice({ id: "device-aaaaaaaa" }), makeDevice({ id: "device-bbbbbbbb" })];
-      const { getAllByTestId } = render(<RegisteredDevicesSection {...defaultProps({ registeredDevices: devices })} />);
-      const stops = getAllByTestId("field").map((el) => el.getAttribute("tabindex"));
-      expect(stops).toEqual(["0", "0"]);
-    });
-
-    it("renders 'ID —' when the id is empty string", () => {
-      const device = makeDevice({ id: "" });
-      const { getAllByTestId } = render(
-        <RegisteredDevicesSection {...defaultProps({ registeredDevices: [device] })} />,
-      );
-      const desc = getAllByTestId("field-desc")[0]?.textContent ?? "";
-      expect(desc).toContain("ID —");
+      // On the current device's row, in its Device cell.
+      expect(cells(getAllByTestId("device-row")[0]!)[0]).toBe("Steam Deck(this device)");
     });
   });
 });

--- a/src/components/settings/RegisteredDevicesSection.tsx
+++ b/src/components/settings/RegisteredDevicesSection.tsx
@@ -38,9 +38,12 @@ import { formatRelativeTime } from "./helpers";
 // two plus room for a three-digit minor version. Under-sizing it clips the
 // VERSION, which is the only part of the column that differs between rows.
 //
-// `Last seen` holds `just now` at 44px — the longest thing `formatRelativeTime`
-// answers, the rest being `59m ago`, `23h ago`, `15 Jun`, `unknown` and
-// `never`.
+// `Last seen` holds every answer `formatRelativeTime` gives — `never`,
+// `unknown`, `just now`, `59m ago` at the widest of its minute forms, `23h ago`
+// at the widest of its hour forms, and a date like `15 Jun`. The widest of them
+// measured the same way is `unknown` at 48px in Noto Sans and 50px in DejaVu,
+// which is character count and glyph width disagreeing: it is a character
+// shorter than `just now` and wider on screen.
 const TABLE_COLUMNS = "1fr 144px 72px";
 
 /** Digits that sit under each other down the column rather than shifting with

--- a/src/components/settings/RegisteredDevicesSection.tsx
+++ b/src/components/settings/RegisteredDevicesSection.tsx
@@ -1,17 +1,41 @@
 /**
- * Read-only list of devices currently registered with the RomM save-sync
- * backend. Visible only when save-sync is enabled; parent owns the device
- * list, loading flag, and error message.
+ * The devices currently registered with the RomM save-sync backend, as a table.
+ * Visible only when save-sync is enabled; parent owns the device list, the
+ * loading flag and the error message.
  *
- * Every row here is a focus stop, and the group's whole content is read-only —
- * a wide pane scrolls only by moving focus, so a group with no stop in it is a
- * group nobody can scroll to.
+ * Three facts per row, so three columns with a header row rather than a label
+ * and a description carrying all of them — `docs/architecture/qam-panel.md`,
+ * "Building blocks → Tables". The device's OS and the head of its id are
+ * deliberately not among them: the OS is the same value on every row a Deck
+ * will ever show, and the id only separates two devices that share a name.
+ *
+ * Every device row is a focus stop and the header is not: a wide pane scrolls
+ * only by moving focus, so a group with no stop in it is a group nobody can
+ * scroll to — while a stop on the column names would be a step that leads
+ * nowhere. The states that are not rows (loading, error, no devices) keep their
+ * own stop for the first reason and draw no header, having no columns.
  */
 
 import { FC } from "react";
-import { PanelSection, PanelSectionRow, Field } from "@decky/ui";
+import { Focusable, PanelSection, PanelSectionRow, Field } from "@decky/ui";
 import type { RegisteredDevice } from "../../types";
+import { MUTED, SECONDARY_FONT } from "../qam/pane";
 import { formatRelativeTime } from "./helpers";
+
+// The name is the column with something to say, so it takes what the other two
+// leave. `Client` is sized for "tender v0.32.0" and `Last seen` for the longest
+// thing `formatRelativeTime` answers.
+const TABLE_COLUMNS = "1fr 104px 72px";
+
+/** The three properties that make a cell clip instead of spilling across the
+ *  track beside it, plus the floor reset that lets it shrink at all. They belong
+ *  on the grid ITEM, which is blockified; on an inline span nested inside one
+ *  they do nothing. */
+const CLIP = { minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" } as const;
+
+/** Digits that sit under each other down the column rather than shifting with
+ *  the glyph widths of the row above. */
+const TABULAR = { fontVariantNumeric: "tabular-nums" } as const;
 
 interface RegisteredDevicesSectionProps {
   devicesLoading: boolean;
@@ -19,11 +43,66 @@ interface RegisteredDevicesSectionProps {
   registeredDevices: RegisteredDevice[] | null;
 }
 
+const TableHeader: FC = () => (
+  // Plain text: the column names accompany the rows below them and scroll with
+  // them, so a focus stop here would add a step that leads nowhere.
+  <div
+    data-testid="devices-header"
+    style={{
+      display: "grid",
+      gridTemplateColumns: TABLE_COLUMNS,
+      gap: "8px",
+      padding: "0 16px 4px",
+      fontSize: SECONDARY_FONT,
+      color: MUTED,
+    }}
+  >
+    <span>Device</span>
+    <span>Client</span>
+    <span>Last seen</span>
+  </div>
+);
+
+const DeviceRow: FC<{ device: RegisteredDevice }> = ({ device }) => {
+  const name = device.name ?? "(unnamed)";
+  const client = `${device.client ?? "unknown client"} v${device.client_version ?? "?"}`;
+  const lastSeen = formatRelativeTime(device.last_seen);
+  return (
+    // A row with nothing to press still has to be reachable, or the reader
+    // cannot scroll past it to the rows below: the activate handler is what
+    // makes a Focusable a focus stop.
+    <Focusable onActivate={() => {}} style={{ padding: "4px 16px" }}>
+      <div
+        data-testid="device-row"
+        style={{ display: "grid", gridTemplateColumns: TABLE_COLUMNS, gap: "8px", alignItems: "center" }}
+      >
+        <span style={{ display: "flex", alignItems: "center", gap: "8px", ...CLIP }} title={name}>
+          {/* The clip is on this span rather than only on the cell around it:
+              that cell is a flex container, and clipping it would take the
+              marker beside the name away with the overflow. A flex ITEM is
+              blockified too, so the three properties still apply here. */}
+          <span style={{ flex: "1 1 auto", ...CLIP }}>{name}</span>
+          {device.is_current_device && (
+            <span style={{ flexShrink: 0, color: "#6ab04c", fontSize: SECONDARY_FONT }}>(this device)</span>
+          )}
+        </span>
+        <span style={{ color: MUTED, fontSize: SECONDARY_FONT, ...TABULAR, ...CLIP }} title={client}>
+          {client}
+        </span>
+        <span style={{ color: MUTED, fontSize: SECONDARY_FONT, ...TABULAR, ...CLIP }} title={lastSeen}>
+          {lastSeen}
+        </span>
+      </div>
+    </Focusable>
+  );
+};
+
 export const RegisteredDevicesSection: FC<RegisteredDevicesSectionProps> = ({
   devicesLoading,
   devicesError,
   registeredDevices,
 }) => {
+  const devices = devicesLoading || devicesError ? null : registeredDevices;
   return (
     <PanelSection title="Registered Devices">
       {devicesLoading && (
@@ -36,38 +115,15 @@ export const RegisteredDevicesSection: FC<RegisteredDevicesSectionProps> = ({
           <Field label="Could not load devices" description={devicesError} focusable={true} />
         </PanelSectionRow>
       )}
-      {!devicesLoading && !devicesError && registeredDevices !== null && registeredDevices.length === 0 && (
+      {devices !== null && devices.length === 0 && (
         <PanelSectionRow>
           <Field label="No devices registered" focusable={true} />
         </PanelSectionRow>
       )}
-      {!devicesLoading &&
-        !devicesError &&
-        registeredDevices !== null &&
-        registeredDevices.map((device, i) => {
-          const parts: string[] = [
-            `${device.client ?? "unknown client"} v${device.client_version ?? "?"}`,
-            ...(device.platform ? [device.platform] : []),
-            `last seen ${formatRelativeTime(device.last_seen)}`,
-            `ID ${String(device.id).slice(0, 8) || "—"}`,
-          ];
-          return (
-            <PanelSectionRow key={device.id || `idx-${i}`}>
-              <Field
-                focusable={true}
-                label={
-                  <span>
-                    {device.name ?? "(unnamed)"}
-                    {device.is_current_device && (
-                      <span style={{ color: "#6ab04c", marginLeft: "8px", fontSize: "12px" }}>(this device)</span>
-                    )}
-                  </span>
-                }
-                description={parts.join(" · ")}
-              />
-            </PanelSectionRow>
-          );
-        })}
+      {devices !== null && devices.length > 0 && <TableHeader />}
+      {devices?.map((device, i) => (
+        <DeviceRow key={device.id || `idx-${i}`} device={device} />
+      ))}
     </PanelSection>
   );
 };

--- a/src/components/settings/RegisteredDevicesSection.tsx
+++ b/src/components/settings/RegisteredDevicesSection.tsx
@@ -2,6 +2,10 @@
  * Read-only list of devices currently registered with the RomM save-sync
  * backend. Visible only when save-sync is enabled; parent owns the device
  * list, loading flag, and error message.
+ *
+ * Every row here is a focus stop, and the group's whole content is read-only —
+ * a wide pane scrolls only by moving focus, so a group with no stop in it is a
+ * group nobody can scroll to.
  */
 
 import { FC } from "react";
@@ -24,17 +28,17 @@ export const RegisteredDevicesSection: FC<RegisteredDevicesSectionProps> = ({
     <PanelSection title="Registered Devices">
       {devicesLoading && (
         <PanelSectionRow>
-          <Field label="Loading..." />
+          <Field label="Loading..." focusable={true} />
         </PanelSectionRow>
       )}
       {!devicesLoading && devicesError && (
         <PanelSectionRow>
-          <Field label="Could not load devices" description={devicesError} />
+          <Field label="Could not load devices" description={devicesError} focusable={true} />
         </PanelSectionRow>
       )}
       {!devicesLoading && !devicesError && registeredDevices !== null && registeredDevices.length === 0 && (
         <PanelSectionRow>
-          <Field label="No devices registered" />
+          <Field label="No devices registered" focusable={true} />
         </PanelSectionRow>
       )}
       {!devicesLoading &&
@@ -50,6 +54,7 @@ export const RegisteredDevicesSection: FC<RegisteredDevicesSectionProps> = ({
           return (
             <PanelSectionRow key={device.id || `idx-${i}`}>
               <Field
+                focusable={true}
                 label={
                   <span>
                     {device.name ?? "(unnamed)"}

--- a/src/components/settings/RegisteredDevicesSection.tsx
+++ b/src/components/settings/RegisteredDevicesSection.tsx
@@ -27,11 +27,15 @@ import { formatRelativeTime } from "./helpers";
 // The name is the column with something to say, so it takes what the other two
 // leave.
 //
-// `Client` is sized for the string THIS plugin registers itself under, which is
-// what every row a Deck shows will carry: `register_device` passes
-// `client="decky-romm-sync"` with the plugin version
-// (`services/saves/sync_engine/devices.py`), so the cell reads
-// `decky-romm-sync v0.32.0` — 23 characters, not the 14 of a shorter name. At
+// `Client` is sized for the longest string the SERVER can hand back, which is
+// not what this plugin registers under today. `register_device` passes
+// `client=DISPLAY_NAME` — "Tender" (`domain/identity.py`) — but the rows come
+// from RomM, which keeps what earlier versions wrote, and up to 0.32 that was
+// `decky-romm-sync`. A real listing shows both spellings side by side, plus
+// `web` for the rows RomM's own frontend registers, and the column has to hold
+// the widest of them: `decky-romm-sync v0.32.0`, 23 characters. Sizing it to
+// today's name would clip every row a Deck registered before the rename, and
+// those do not expire. At
 // the 11px these cells are set in that measures 131px in Noto Sans and 143px in
 // DejaVu Sans; the device renders it in Steam's own Motiva Sans, which is on
 // neither this machine nor any check here, so the track takes the wider of the

--- a/src/components/settings/RegisteredDevicesSection.tsx
+++ b/src/components/settings/RegisteredDevicesSection.tsx
@@ -6,8 +6,10 @@
  * Three facts per row, so three columns with a header row rather than a label
  * and a description carrying all of them — `docs/architecture/qam-panel.md`,
  * "Building blocks → Tables". The device's OS and the head of its id are
- * deliberately not among them: the OS is the same value on every row a Deck
- * will ever show, and the id only separates two devices that share a name.
+ * deliberately not among them: `register_device` passes a hardcoded
+ * `platform="linux"` (`services/saves/sync_engine/devices.py`), so the OS
+ * column would repeat one value down every row this plugin registers, and the
+ * id only separates two devices that share a name.
  *
  * Every device row is a focus stop and the header is not: a wide pane scrolls
  * only by moving focus, so a group with no stop in it is a group nobody can
@@ -23,9 +25,23 @@ import { MUTED, SECONDARY_FONT } from "../qam/pane";
 import { formatRelativeTime } from "./helpers";
 
 // The name is the column with something to say, so it takes what the other two
-// leave. `Client` is sized for "tender v0.32.0" and `Last seen` for the longest
-// thing `formatRelativeTime` answers.
-const TABLE_COLUMNS = "1fr 104px 72px";
+// leave.
+//
+// `Client` is sized for the string THIS plugin registers itself under, which is
+// what every row a Deck shows will carry: `register_device` passes
+// `client="decky-romm-sync"` with the plugin version
+// (`services/saves/sync_engine/devices.py`), so the cell reads
+// `decky-romm-sync v0.32.0` — 23 characters, not the 14 of a shorter name. At
+// the 11px these cells are set in that measures 131px in Noto Sans and 143px in
+// DejaVu Sans; the device renders it in Steam's own Motiva Sans, which is on
+// neither this machine nor any check here, so the track takes the wider of the
+// two plus room for a three-digit minor version. Under-sizing it clips the
+// VERSION, which is the only part of the column that differs between rows.
+//
+// `Last seen` holds `just now` at 44px — the longest thing `formatRelativeTime`
+// answers, the rest being `59m ago`, `23h ago`, `15 Jun`, `unknown` and
+// `never`.
+const TABLE_COLUMNS = "1fr 144px 72px";
 
 /** The three properties that make a cell clip instead of spilling across the
  *  track beside it, plus the floor reset that lets it shrink at all. They belong

--- a/src/components/settings/RegisteredDevicesSection.tsx
+++ b/src/components/settings/RegisteredDevicesSection.tsx
@@ -19,9 +19,9 @@
  */
 
 import { FC } from "react";
-import { Focusable, PanelSection, PanelSectionRow, Field } from "@decky/ui";
+import { PanelSection, PanelSectionRow, Field } from "@decky/ui";
 import type { RegisteredDevice } from "../../types";
-import { MUTED, SECONDARY_FONT } from "../qam/pane";
+import { CELL_CLIP, MUTED, PaneTableHeader, PaneTableRow, SECONDARY_FONT } from "../qam/pane";
 import { formatRelativeTime } from "./helpers";
 
 // The name is the column with something to say, so it takes what the other two
@@ -43,15 +43,13 @@ import { formatRelativeTime } from "./helpers";
 // `never`.
 const TABLE_COLUMNS = "1fr 144px 72px";
 
-/** The three properties that make a cell clip instead of spilling across the
- *  track beside it, plus the floor reset that lets it shrink at all. They belong
- *  on the grid ITEM, which is blockified; on an inline span nested inside one
- *  they do nothing. */
-const CLIP = { minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" } as const;
-
 /** Digits that sit under each other down the column rather than shifting with
  *  the glyph widths of the row above. */
 const TABULAR = { fontVariantNumeric: "tabular-nums" } as const;
+
+/** What the two right-hand columns are set in: the pane's secondary line, so
+ *  they read as the quieter half of the row the name leads. */
+const SECONDARY_CELL = { color: MUTED, fontSize: SECONDARY_FONT, ...TABULAR } as const;
 
 interface RegisteredDevicesSectionProps {
   devicesLoading: boolean;
@@ -59,57 +57,37 @@ interface RegisteredDevicesSectionProps {
   registeredDevices: RegisteredDevice[] | null;
 }
 
-const TableHeader: FC = () => (
-  // Plain text: the column names accompany the rows below them and scroll with
-  // them, so a focus stop here would add a step that leads nowhere.
-  <div
-    data-testid="devices-header"
-    style={{
-      display: "grid",
-      gridTemplateColumns: TABLE_COLUMNS,
-      gap: "8px",
-      padding: "0 16px 4px",
-      fontSize: SECONDARY_FONT,
-      color: MUTED,
-    }}
-  >
-    <span>Device</span>
-    <span>Client</span>
-    <span>Last seen</span>
-  </div>
-);
-
 const DeviceRow: FC<{ device: RegisteredDevice }> = ({ device }) => {
   const name = device.name ?? "(unnamed)";
   const client = `${device.client ?? "unknown client"} v${device.client_version ?? "?"}`;
   const lastSeen = formatRelativeTime(device.last_seen);
   return (
-    // A row with nothing to press still has to be reachable, or the reader
-    // cannot scroll past it to the rows below: the activate handler is what
-    // makes a Focusable a focus stop.
-    <Focusable onActivate={() => {}} style={{ padding: "4px 16px" }}>
-      <div
-        data-testid="device-row"
-        style={{ display: "grid", gridTemplateColumns: TABLE_COLUMNS, gap: "8px", alignItems: "center" }}
-      >
-        <span style={{ display: "flex", alignItems: "center", gap: "8px", ...CLIP }} title={name}>
-          {/* The clip is on this span rather than only on the cell around it:
-              that cell is a flex container, and clipping it would take the
-              marker beside the name away with the overflow. A flex ITEM is
-              blockified too, so the three properties still apply here. */}
-          <span style={{ flex: "1 1 auto", ...CLIP }}>{name}</span>
-          {device.is_current_device && (
-            <span style={{ flexShrink: 0, color: "#6ab04c", fontSize: SECONDARY_FONT }}>(this device)</span>
-          )}
-        </span>
-        <span style={{ color: MUTED, fontSize: SECONDARY_FONT, ...TABULAR, ...CLIP }} title={client}>
-          {client}
-        </span>
-        <span style={{ color: MUTED, fontSize: SECONDARY_FONT, ...TABULAR, ...CLIP }} title={lastSeen}>
-          {lastSeen}
-        </span>
-      </div>
-    </Focusable>
+    <PaneTableRow
+      columns={TABLE_COLUMNS}
+      testId="device-row"
+      cells={[
+        {
+          // This cell is a flex container holding the name and the marker, so
+          // the clip it inherits cannot do the work alone: hiding the
+          // container's overflow would take the marker away with it. The name
+          // is a flex ITEM, blockified like a grid one, so the same three
+          // properties apply to it — and the marker keeps its width beside a
+          // name of any length.
+          content: (
+            <>
+              <span style={{ flex: "1 1 auto", ...CELL_CLIP }}>{name}</span>
+              {device.is_current_device && (
+                <span style={{ flexShrink: 0, color: "#6ab04c", fontSize: SECONDARY_FONT }}>(this device)</span>
+              )}
+            </>
+          ),
+          style: { display: "flex", alignItems: "center", gap: "8px" },
+          title: name,
+        },
+        { content: client, style: SECONDARY_CELL, title: client },
+        { content: lastSeen, style: SECONDARY_CELL, title: lastSeen },
+      ]}
+    />
   );
 };
 
@@ -136,7 +114,9 @@ export const RegisteredDevicesSection: FC<RegisteredDevicesSectionProps> = ({
           <Field label="No devices registered" focusable={true} />
         </PanelSectionRow>
       )}
-      {devices !== null && devices.length > 0 && <TableHeader />}
+      {devices !== null && devices.length > 0 && (
+        <PaneTableHeader columns={TABLE_COLUMNS} cells={["Device", "Client", "Last seen"]} testId="devices-header" />
+      )}
       {devices?.map((device, i) => (
         <DeviceRow key={device.id || `idx-${i}`} device={device} />
       ))}

--- a/src/components/settings/SaveSortMigrationSection.tsx
+++ b/src/components/settings/SaveSortMigrationSection.tsx
@@ -3,6 +3,11 @@
  * existing local saves need to be relocated. Pure renderer — the parent owns
  * the in-flight `migrating` flag and the result message; this section only
  * dispatches user intent (migrate / dismiss) back upstream.
+ *
+ * It is the condition's only home: Main names it and jumps here, and Migrate
+ * and Dismiss exist nowhere else. The card itself carries no focus handler —
+ * it sits above the first button of the Save Sync pane, and the region reveals
+ * its own top when focus reaches that button.
  */
 
 import { FC } from "react";
@@ -66,7 +71,7 @@ export const SaveSortMigrationSection: FC<SaveSortMigrationSectionProps> = ({
       </PanelSectionRow>
       {result && (
         <PanelSectionRow>
-          <Field label={result} />
+          <Field label={result} focusable={true} />
         </PanelSectionRow>
       )}
     </PanelSection>

--- a/src/components/settings/SaveSyncSection.tsx
+++ b/src/components/settings/SaveSyncSection.tsx
@@ -67,7 +67,10 @@ export const SaveSyncSection: FC<SaveSyncSectionProps> = ({
             <>
               {deviceInfo && (
                 <PanelSectionRow>
-                  <Field label="Device" description={`Registered as "${deviceInfo.device_name}"`} />
+                  {/* Focusable: the pane scrolls by moving focus, and this row
+                      sits between two toggles, so it is neither end of the
+                      region that gets revealed on its own. */}
+                  <Field label="Device" description={`Registered as "${deviceInfo.device_name}"`} focusable={true} />
                 </PanelSectionRow>
               )}
               <PanelSectionRow>
@@ -135,7 +138,7 @@ export const SaveSyncSection: FC<SaveSyncSectionProps> = ({
               </PanelSectionRow>
               {syncStatus && (
                 <PanelSectionRow>
-                  <Field label={syncStatus} />
+                  <Field label={syncStatus} focusable={true} />
                 </PanelSectionRow>
               )}
             </>

--- a/src/components/sync/paneTable.tsx
+++ b/src/components/sync/paneTable.tsx
@@ -1,103 +1,73 @@
 /**
- * The table pieces the Sync page's two tables are built from — the preview's
- * change counts and the run's units.
+ * What the Sync page's two tables — the preview's change counts and the run's
+ * units — add to the pane's own table.
  *
- * They are here rather than in `qam/pane.tsx` because only this page has two
- * tables that have to read as one family: both are set in the flat, small
- * register a plan of seventeen units needs to fit the Deck's column, and one
- * place holding it is what keeps that a decision rather than a drift.
+ * The table itself is `qam/pane.tsx`'s, shared with the BIOS files and the
+ * registered devices. What stays here is what is this page's alone: the
+ * REGISTER both of its tables are set in, the numeric-column split they both
+ * take, and the pieces that are not tables at all.
  *
- * **Every row is a focus stop.** A region scrolls only by moving focus, so a row
- * nothing can focus is a row nothing can scroll to — and these rows carry no
- * control of their own, so the activate handler is the only thing that makes the
- * `Focusable` a stop rather than a container that passes focus through.
+ * **The register is the reason this module exists, and it is now a value it
+ * passes rather than a second table.** Only this page has two tables that have
+ * to read as one family, and both need to be flat enough that a plan of
+ * seventeen units fits the Deck's column under the whole-run bar. One place
+ * holding that is still what keeps it a decision rather than a drift — that
+ * place is {@link SYNC_TABLE_REGISTER}, and a third table on this page takes it
+ * by naming it rather than by being written again.
  *
  * Structure and vocabulary: `docs/architecture/qam-panel.md`, section Sync.
  */
 
 import type { CSSProperties, FC, ReactNode } from "react";
-import { Focusable } from "@decky/ui";
-import { MUTED, SECONDARY_FONT } from "../qam/pane";
+import {
+  MUTED,
+  PANE_GUTTER,
+  PaneTableHeader,
+  PaneTableRow,
+  SECONDARY_FONT,
+  TABLE_LINE,
+  type TableCell,
+  type TableRegister,
+} from "../qam/pane";
 
-/** The rule under a table header and above a total row — Steam's own hairline
- *  weight, the one the panel already separates its blocks with. */
-export const TABLE_LINE = "1px solid rgba(255, 255, 255, 0.12)";
-
-/** The pane's horizontal gutter, matching `SectionTitle` and `Muted` so a table
- *  lines up with the section it sits under. */
-const GUTTER = "16px";
-
-/**
- * The register both tables are set in — flat enough that a plan of seventeen
- * units fits the column under the whole-run bar, and the same on both so the
- * preview and the run read as one family. The type size and leading are the
- * layout study's `.tbl.compact` (`docs/assets/sync-layouts.html`); the
- * horizontal padding is the pane's own gutter rather than the study's 6 px, so a
- * row lines up with the section title over it.
- */
-const ROW_PADDING = `2px ${GUTTER}`;
-const ROW_FONT = "12px";
-const ROW_LINE_HEIGHT = 1.25;
+export { TABLE_LINE };
 
 /**
- * Every cell clips rather than overflows.
- *
- * A grid track sized `minmax(0, 1fr)` shrinks under its content, and the content
- * then spills across the track beside it — on the Deck a platform name ran into
- * the New column's digit. The clip belongs on the CELL rather than on whatever a
- * caller puts inside it: a grid item is blockified, so `text-overflow` applies
- * to it, where an inline `span` nested in it is not and the same three
- * properties do nothing at all. Callers hand the full string to a `title`.
+ * The register both tables are set in. The type size and leading are the layout
+ * study's `.tbl.compact` (`docs/assets/sync-layouts.html`); the horizontal
+ * padding is the pane's own gutter rather than the study's 6 px, so a row lines
+ * up with the section title over it. The rule under the column names is this
+ * page's too — its tables carry totals, and the header reads as their heading
+ * rather than as a first row.
  */
-const CELL_BASE: CSSProperties = {
-  minWidth: 0,
-  overflow: "hidden",
-  textOverflow: "ellipsis",
-  whiteSpace: "nowrap",
+export const SYNC_TABLE_REGISTER: TableRegister = {
+  rowPadding: `2px ${PANE_GUTTER}`,
+  headerPadding: `0 ${PANE_GUTTER} 3px`,
+  rowFont: "12px",
+  rowLineHeight: 1.25,
+  rule: true,
 };
 
-const numericStyle: CSSProperties = { ...CELL_BASE, textAlign: "right", fontVariantNumeric: "tabular-nums" };
+/** The columns from `numericFrom` rightwards hold numbers, which are read down
+ *  the column rather than across the row: right-aligned so their digits line up,
+ *  and tabular so they do not shift as the values change. */
+const numericStyle: CSSProperties = { textAlign: "right", fontVariantNumeric: "tabular-nums" };
 
-function cellStyle(index: number, numericFrom: number): CSSProperties {
-  return index >= numericFrom ? numericStyle : CELL_BASE;
-}
+const splitNumeric = (cells: readonly ReactNode[], numericFrom: number): TableCell[] =>
+  cells.map((content, index) => (index >= numericFrom ? { content, style: numericStyle } : { content }));
 
-/**
- * Column names over a table. Plain text: they accompany the rows below them and
- * scroll with them, and making the header a focus stop would add a step that
- * leads nowhere. `ScrollRegion` reveals them when focus reaches the first row.
- */
+/** Column names over one of this page's tables. */
 export const TableHeader: FC<{ columns: string; cells: string[]; numericFrom: number }> = ({
   columns,
   cells,
   numericFrom,
-}) => (
-  <div
-    style={{
-      display: "grid",
-      gridTemplateColumns: columns,
-      gap: "8px",
-      padding: `0 ${GUTTER} 3px`,
-      borderBottom: TABLE_LINE,
-      fontSize: SECONDARY_FONT,
-      color: MUTED,
-    }}
-  >
-    {cells.map((cell, index) => (
-      <span key={cell} style={cellStyle(index, numericFrom)}>
-        {cell}
-      </span>
-    ))}
-  </div>
-);
+}) => <PaneTableHeader columns={columns} cells={splitNumeric(cells, numericFrom)} register={SYNC_TABLE_REGISTER} />;
 
 /**
- * One row of a table, and a focus stop.
+ * One row of one of this page's tables.
  *
  * *subline* is the full-width line under the cells, for what a 60px column
  * cannot hold — the collection names behind a count, the error a run ended with.
- * It is inside the row rather than beside it, so it travels with the focus
- * highlight instead of being stranded between two stops.
  */
 export const TableRow: FC<{
   columns: string;
@@ -107,25 +77,13 @@ export const TableRow: FC<{
   style?: CSSProperties | undefined;
   testId?: string | undefined;
 }> = ({ columns, cells, numericFrom, subline, style, testId }) => (
-  <Focusable
-    onActivate={() => {}}
-    data-testid={testId}
-    style={{
-      padding: ROW_PADDING,
-      fontSize: ROW_FONT,
-      lineHeight: ROW_LINE_HEIGHT,
-      ...style,
-    }}
+  <PaneTableRow
+    columns={columns}
+    cells={splitNumeric(cells, numericFrom)}
+    register={SYNC_TABLE_REGISTER}
+    {...(style === undefined ? {} : { style })}
+    {...(testId === undefined ? {} : { testId })}
   >
-    <div style={{ display: "grid", gridTemplateColumns: columns, gap: "8px", alignItems: "center" }}>
-      {cells.map((cell, index) => (
-        // The index IS the identity here: a cell is the column it sits in, and
-        // the columns of one table never reorder.
-        <span key={index} style={cellStyle(index, numericFrom)}>
-          {cell}
-        </span>
-      ))}
-    </div>
     {subline !== undefined && (
       <div
         title={subline}
@@ -140,14 +98,14 @@ export const TableRow: FC<{
         {subline}
       </div>
     )}
-  </Focusable>
+  </PaneTableRow>
 );
 
 /** A full-width line inside the pane's gutter that is not a table row — a
  *  summary sentence under a table, an estimate. Plain text, so it rides along
  *  with the stops around it rather than adding one of its own. */
 export const PaneRow: FC<{ children: ReactNode }> = ({ children }) => (
-  <div style={{ padding: `2px ${GUTTER} 4px` }}>{children}</div>
+  <div style={{ padding: `2px ${PANE_GUTTER} 4px` }}>{children}</div>
 );
 
 /** The thin bar a running row draws under its status, and the whole-run bar's

--- a/src/components/sync/paneTable.tsx
+++ b/src/components/sync/paneTable.tsx
@@ -25,12 +25,13 @@ import {
   PaneTableHeader,
   PaneTableRow,
   SECONDARY_FONT,
-  TABLE_LINE,
   type TableCell,
   type TableRegister,
 } from "../qam/pane";
 
-export { TABLE_LINE };
+/** The rule this page draws over a total row, which is the pane's own — passed
+ *  straight through so a caller reaches it beside the table it belongs to. */
+export { TABLE_LINE } from "../qam/pane";
 
 /**
  * The register both tables are set in. The type size and leading are the layout

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -80,6 +80,8 @@ import type {
   SyncCollectionsData,
   ServerRetryProgressEvent,
   Page,
+  NavTarget,
+  SettingsSection,
 } from "./types";
 import { setLaunchOptionsConfirmed } from "./utils/steamShortcuts";
 import { removeShortcutsPaced } from "./utils/shortcutRemoval";
@@ -102,13 +104,27 @@ import { publishCommittedVersionSwitch } from "./utils/versionSwitchApplication"
 
 // Module-level page state survives QAM remounts (e.g. after modal close)
 let currentPage: Page = "main";
+// The section the last navigation named, held beside the page for the same
+// reason: without it a QAM remounted mid-edit would come back on Settings' first
+// section rather than the one the reader was sent to.
+let currentSection: SettingsSection | null = null;
 
 const QAMPanel: FC = () => {
   const [page, setPageState] = useState<Page>(currentPage); // NOSONAR(typescript:S6754) — setter intentionally renamed; setPage wraps it below to provide custom navigation behavior.
+  const [settingsSection, setSettingsSectionState] = useState<SettingsSection | null>(currentSection); // NOSONAR(typescript:S6754) — set through setPage, which owns both halves of a navigation.
   const rootRef = useRef<HTMLDivElement>(null);
-  const setPage = (p: Page) => {
+  const setPage = (p: Page, section: SettingsSection | null = null) => {
     currentPage = p;
+    currentSection = section;
     setPageState(p);
+    setSettingsSectionState(section);
+  };
+  // What a page hands back when the reader presses one of its doors. A bare
+  // page id is the whole target for every page but Settings, whose notices name
+  // the section that holds the action they are about.
+  const navigate = (target: NavTarget) => {
+    if (typeof target === "string") setPage(target);
+    else setPage(target.page, target.section);
   };
 
   useEffect(() => {
@@ -154,7 +170,12 @@ const QAMPanel: FC = () => {
       content = <SyncPage onBack={() => setPage("main")} />;
       break;
     case "settings":
-      content = <SettingsPage onBack={() => setPage("main")} />;
+      content = (
+        <SettingsPage
+          onBack={() => setPage("main")}
+          {...(settingsSection === null ? {} : { section: settingsSection })}
+        />
+      );
       break;
     case "library":
       content = <LibraryPage onBack={() => setPage("main")} />;
@@ -166,7 +187,7 @@ const QAMPanel: FC = () => {
       content = <DownloadQueue onBack={() => setPage("main")} />;
       break;
     default:
-      content = <MainPage onNavigate={(p) => setPage(p)} />;
+      content = <MainPage onNavigate={navigate} />;
   }
 
   // B goes back one page, from wherever focus is — bound here rather than on a

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -6,3 +6,26 @@
 /** Every page the QAM panel can show. A surface that cannot navigate to itself
  *  narrows this with `Exclude<Page, "...">` rather than restating the union. */
 export type Page = "main" | "sync" | "settings" | "library" | "data" | "downloads";
+
+/**
+ * The Settings page's sections, in the order its list shows them — the first is
+ * the one a navigation that names none opens on.
+ *
+ * The order and the union are one declaration so they cannot drift: a section
+ * added here is a section the page's list has to label, and the type stops a
+ * navigation naming one that does not exist.
+ */
+export const SETTINGS_SECTIONS = ["connections", "save-sync", "controller", "steam-library", "advanced"] as const;
+
+/** One section of the Settings page, as a navigation may name it. */
+export type SettingsSection = (typeof SETTINGS_SECTIONS)[number];
+
+/**
+ * Where a navigation lands: a page, or the Settings page opened on one of its
+ * sections.
+ *
+ * The section rides on the page rather than travelling beside it, so no target
+ * can pair a section with a page that has none — the notices on Main each name
+ * the section that holds the action they are about.
+ */
+export type NavTarget = Exclude<Page, "main"> | { page: "settings"; section: SettingsSection };

--- a/src/utils/entryFocus.ts
+++ b/src/utils/entryFocus.ts
@@ -11,9 +11,12 @@
  * {@link useEntryFocusOnBodySwap} for a page whose body changes under the reader
  * while the page stays open — the Sync page's left column.
  *
- * The frame and the swap take {@link firstBodyStop} as it stands. The router
- * takes {@link pageEntryStop}, which lets the page it has just mounted name the
- * area focus belongs in and otherwise answers exactly the same thing.
+ * The two that open a page — the frame and the router — take
+ * {@link pageEntryStop}, which lets the page they have just mounted name the
+ * area focus belongs in and otherwise answers exactly what
+ * {@link firstBodyStop} would. The swap takes `firstBodyStop` as it stands: its
+ * root is one body of a page already open rather than a whole page, and no body
+ * that swaps declares an area.
  */
 
 import { useEffect, useLayoutEffect, useRef, type RefObject } from "react";
@@ -79,14 +82,22 @@ export function firstBodyStop(root: ParentNode): HTMLElement | null {
 }
 
 /**
- * Marks the part of a page entry focus belongs in — a declaration, read by the
- * panel's router (`src/index.tsx`) and by nothing else.
+ * Marks the part of a page entry focus belongs in — a declaration, read through
+ * {@link pageEntryStop} and therefore by both of the placers that open a page:
+ * the panel's router (`src/index.tsx`) for the narrow pages, and the wide-page
+ * frame (`src/components/qam/WidePage.tsx`) for its own body.
  *
  * It is the other half of `WidePage`'s `OWNS_ENTRY_FOCUS_ATTR` rather than a
- * second spelling of it, which is why it is a second attribute: that one tells
- * the router to place NOTHING, because the page places its own; this one tells
- * it WHERE. Carrying both would ask the router to honour a declaration it has
- * already been told to stay out of, and no page carries both.
+ * second spelling of it, which is why it is a second attribute: that one says
+ * WHO places entry focus — it tells the router to place none, because the frame
+ * places its own — and this one says WHERE, to whichever of them places it.
+ *
+ * **A wide page carries both, and they answer different questions rather than
+ * the same one twice.** Settings is one: the frame's root says "I place my own"
+ * and the list's selected row says "here". The router never reaches the second —
+ * it looks for `OWNS_ENTRY_FOCUS_ATTR` first and, finding it, sets no timer at
+ * all — so no declaration ever asks it to honour a page it was told to stay out
+ * of.
  *
  * It names an AREA, not the stop: {@link firstBodyStop} still picks the element
  * inside it, so one rule decides which node takes focus wherever focus is
@@ -103,18 +114,25 @@ export const ENTRY_STOP_ATTR = "data-romm-entry-stop";
 export const ENTRY_FOCUS_DELAY_MS = 50;
 
 /**
- * The stop the panel's router opens a page on: inside the page's own
- * declaration where it makes one, and the first stop of the whole body
- * otherwise.
+ * The stop a page opens on: inside the page's own declaration where it makes
+ * one, and the first stop of the whole body otherwise.
  *
- * Main is the only page that declares one, on the menu's Sync entry — its three
- * status rows act on nothing, so opening on the first of them spends the
- * reader's first press moving to what they came for. The cost of that is
- * Steam's: it scrolls the focused element into view, so on a Main tall enough to
- * scroll the panel opens part-way down. Stated in
+ * Two things declare, for two different reasons. Main declares on the menu's
+ * Sync entry — its three status rows act on nothing, so opening on the first of
+ * them spends the reader's first press moving to what they came for. The cost of
+ * that is Steam's: it scrolls the focused element into view, so on a Main tall
+ * enough to scroll the panel opens part-way down. Stated in
  * `docs/architecture/qam-panel.md`, section Main, and deliberately not defended
  * against here — a rule that opened somewhere else depending on what is on
  * screen is the thing this declaration replaced.
+ *
+ * A list-and-detail page (`components/qam/ListDetail.tsx`) declares on its
+ * SELECTED row, and there the declaration is what makes the page keep the state
+ * it was opened with rather than a preference about where to land: focus selects
+ * on that layout, so opening on the first row would select the first row. It
+ * takes nothing away from a page opened without a section named: such a page
+ * either selects its own first row, which is what the fallback would have
+ * picked, or selects nothing at all and so declares nothing.
  */
 export function pageEntryStop(root: ParentNode): HTMLElement | null {
   const declared = root.querySelector<HTMLElement>(`[${ENTRY_STOP_ATTR}]`);

--- a/src/utils/qamExpansion.test.tsx
+++ b/src/utils/qamExpansion.test.tsx
@@ -289,6 +289,13 @@ describe("useWideQamPanel", () => {
     // ours, because it is Steam's own button class.
     expect(css).toContain(`.${mod.WIDE_ROOT_CLASS} button.DialogButton[disabled].gpfocus`);
     expect(css).toContain("outline: outset #fff 2px");
+    // A deliberate override of Steam's own styling: its tabbed page reserves
+    // 40 px under the content scroller, and that scroller sits inside the box
+    // WidePage measured and gave the tab as its height — so the reserve comes
+    // out of our page. Scoped to our root, and written against the readable
+    // class rather than the hashed one, which changes with Steam's bundle.
+    expect(css).toContain(`.${mod.WIDE_ROOT_CLASS} ._TabContentsScroll`);
+    expect(css).toContain("padding-bottom: 0");
   });
 
   it("falls back to the panel's id prefix when the probe is undefined", async () => {

--- a/src/utils/qamExpansion.ts
+++ b/src/utils/qamExpansion.ts
@@ -12,13 +12,12 @@
  * Friends tab toggles it back. `useWideQamPanel` covers the three paths a
  * mounted page can observe; `collapseQamOnDismount` is the fourth.
  *
- * The injected sheet carries one rule that is not about width: a focus outline
- * for a DISABLED button, which Steam's own stylesheet omits. It rides here
- * because the sheet is already scoped to the wide root and a second injector
- * for one selector would be a second thing to clear. A wide page keeps its
- * buttons rendered-and-disabled rather than hidden, so a reader walking the
- * page with the stick lands on them, and without the rule the focus ring
- * simply vanishes for that row.
+ * The injected sheet carries two rules that are not about width: a focus
+ * outline for a DISABLED button, which Steam's own stylesheet omits, and a
+ * deliberate override of Steam's bottom padding on a tabbed page's content
+ * scroller. Both ride here because the sheet is already scoped to the wide root
+ * and a second injector would be a second thing to clear; both are stated in
+ * full at `WIDE_PANEL_CSS`.
  */
 
 import { useEffect, type RefObject } from "react";
@@ -58,11 +57,42 @@ const TAB_PANEL_SELECTOR = quickAccessMenuClasses?.TabGroupPanel
 // is Steam's other focus form, taken verbatim from the one it uses where a fill
 // will not read (`outline: outset #fff 2px`, `chunk~2dcc5aaf7.css`), and it is
 // scoped to a wide page of ours.
+//
+// **The third rule overrides Steam's own styling, deliberately. It is not a
+// defect fix, and Steam's rule is not wrong** — it is simply applied to a box
+// that is ours. Steam's tabbed page gives its content scroller a
+// `padding-bottom: 40px` (rule `._1X4dtbZ_AMX_DXT-SGiK01`, read off the live
+// stylesheet in the QAM). That scroller sits INSIDE the body `WidePage` measured
+// and handed the tab as its height, so on a tabbed page 40 px of a height the
+// frame sized to the panel go to a reserve nothing of ours asked for — and the
+// reader meets a band under Library that Settings and Sync do not have, those
+// being untabbed and rendering no such scroller at all. Measured at the dev
+// window's metrics: our body ran to y=752 inside a panel box ending at 764.3
+// while the tab's content stopped at 712, and the tab's own scrolling region
+// went from a `clientHeight` of 550 to 602 with the rule applied. What
+// overriding it is worth is that difference: 40 px of content back on every
+// tabbed wide page.
+//
+// It is ours to override because the box is ours: the scroller is rendered
+// inside a page of ours at a height of our own measuring, and that measurement
+// already stops the page at the panel's edge. Nothing outside a wide page is
+// touched — the selector is scoped to our root, which is also what wins it: two
+// classes against Steam's one, in a sheet appended after Steam's.
+//
+// **Written against the readable class, not the hashed one.** Steam ships both
+// on that element (`_TabContentsScroll` beside `_1X4dtbZ_AMX_DXT-SGiK01`), and
+// the hashed name is a build artefact that changes with Steam's bundle. Either
+// could go, and the degradation is what makes reaching for someone else's class
+// safe here: a selector that stops matching leaves Steam's padding standing,
+// which is today's behaviour — the band comes back on tabbed pages and nothing
+// else changes. Taking a padding away can only give room back, so there is no
+// reading of a missed match that clips or overlaps content.
 const WIDE_PANEL_CSS = `
 ${TAB_PANEL_SELECTOR}:has(.${WIDE_ROOT_CLASS}) { max-width: none; }
 ${TAB_PANEL_SELECTOR}:has(.${WIDE_ROOT_CLASS}) > * { max-width: none; }
 .${WIDE_ROOT_CLASS} button.DialogButton[disabled].gpfocus,
 .${WIDE_ROOT_CLASS} button.DialogButton.Disabled.gpfocus { outline: outset #fff 2px; }
+.${WIDE_ROOT_CLASS} ._TabContentsScroll { padding-bottom: 0; }
 `;
 
 // The stylesheet a wide page has up, held by reference rather than looked up by

--- a/src/utils/qamExpansion.ts
+++ b/src/utils/qamExpansion.ts
@@ -69,9 +69,10 @@ const TAB_PANEL_SELECTOR = quickAccessMenuClasses?.TabGroupPanel
 // being untabbed and rendering no such scroller at all. Measured at the dev
 // window's metrics: our body ran to y=752 inside a panel box ending at 764.3
 // while the tab's content stopped at 712, and the tab's own scrolling region
-// went from a `clientHeight` of 550 to 602 with the rule applied. What
-// overriding it is worth is that difference: 40 px of content back on every
-// tabbed wide page.
+// went from a `clientHeight` of 550 to 590 with this rule alone. What overriding
+// it is worth is that difference: 40 px of content back on every tabbed wide
+// page. The 602 the page reaches today is this rule and the frame's own gap
+// going together — two changes, and only one of them is this one.
 //
 // It is ours to override because the box is ours: the scroller is rendered
 // inside a page of ours at a height of our own measuring, and that measurement


### PR DESCRIPTION
Eight stacked blocks on a narrow page become five sections as list and detail on the wide frame: Connections, Save
Sync, Controller, Steam Library, Advanced. Nothing a control does changes — what changes is where it lives and how it
is reached.

Connections holds the services the plugin talks to, so the RomM server and the SteamGridDB key stop being two
unrelated blocks. Save Sync absorbs the registered devices and the save-sort migration. Controller keeps the
`input_driver` fix. The section called Library becomes Steam Library, because a Library page now exists and the two are
different questions: the page is what RomM has, the section is what Steam does with it.

The two controls that existed twice now exist once. A navigation can name a section — `NavTarget` carries it on the
page, so no target can pair a section with a page that has none — and Main's notices use it: the `input_driver`
warning opens Controller, the save-sorting notice opens Save Sync, and the playtime notice gains Open Connections
where it previously had only Dismiss. Main no longer carries the fix or the migration card.

The `input_driver` fix keeps the confirmation it had on Main. The button that survived never had one, and the fix
rewrites `retroarch.cfg` in place keeping no copy, so the confirm is the only guard available to it. The wording is the
one the removed button carried.

The registered devices become a table, because three facts per row is what the Tables rule is about. The device's
platform and the head of its id are not among them: the platform is passed hardcoded at registration and would repeat
one value down every row, and the id only separates two devices that share a name. The Client column is sized for the
string the plugin actually registers itself under, measured rather than estimated, and a test holds the track to that
width — happy-dom lays nothing out, but it keeps the declaration, so the number is checkable even where the rendering
is not.

That table is now the only one. The Sync page's pair, the Platforms detail's BIOS files and the devices were three
implementations of one shape; they are one primitive in `qam/pane.tsx` with the register passed per page. The Sync
page's flatter register was the reason its tables lived apart, and it is now a value it hands over rather than a second
copy of the shape. Two properties stayed per cell rather than per page: a row is a focus stop unless one of its cells
carries a control, and a cell clips unless it holds a control — a focus ring is drawn with `outline`, outside the
border box, so hiding that cell's overflow would cut the ring off.

From #1020: a failed save of the RomM URL no longer leaves the rejected value in the field, and Apply to All Shortcuts
refuses a second press while one run is in flight.

RetroAchievements is not built here. Connections is its home when #1627 builds the sign-in state; this cut adds no
placeholder for it.

Layout study for the device table: `docs/assets/device-list-layouts.html`.

Closes #1816
