### PR TITLE
test(loop): take the loop that is running, then unpin pytest-asyncio

### DIFF
--- a/.claude/rules/testing-backend.md
+++ b/.claude/rules/testing-backend.md
@@ -26,6 +26,12 @@ so that service needs the real loop object. Take it in an **async** fixture — 
 `tests/contract/_harness.py` builds the real `Plugin`, or afterwards through an autouse fixture that rebinds each
 service's `_loop`, the way `tests/services/test_downloads.py` does.
 
+Neither shape is available where the test **body** builds the service: no fixture does the constructing, and at fixture
+time there is no service yet to rebind. Then an async autouse fixture captures the running loop into a module-level
+holder and the body reads it at construction — `tests/services/test_migration_save_sort.py`, whose
+`_capture_running_loop` fills that holder through `monkeypatch`, so teardown empties it again instead of leaving a
+closed loop there for the rest of the session.
+
 ## Property-based tests — pure decision kernels (hypothesis)
 
 The pure decision kernels carry a property tier on top of hand-enumerated cases. The in-tree ones

--- a/.claude/rules/testing-backend.md
+++ b/.claude/rules/testing-backend.md
@@ -21,9 +21,10 @@ helper body, which has to name a loop before any test is running. That one passe
 it, so nothing is created and nothing is left unclosed (#806).
 
 Neither answers for a service that touches its loop from a **worker thread** (an executor callback calling
-`call_soon_threadsafe`): off the loop thread there is no running loop to resolve against, so that service needs the real
-loop object, rebound by an autouse async fixture — the shape in `tests/contract/_harness.py` and
-`tests/services/test_downloads.py`.
+`call_soon_threadsafe`, as the download progress does): off the loop thread there is no running loop to resolve against,
+so that service needs the real loop object. Take it in an **async** fixture — at construction, the way
+`tests/contract/_harness.py` builds the real `Plugin`, or afterwards through an autouse fixture that rebinds each
+service's `_loop`, the way `tests/services/test_downloads.py` does.
 
 ## Property-based tests — pure decision kernels (hypothesis)
 

--- a/.claude/rules/testing-backend.md
+++ b/.claude/rules/testing-backend.md
@@ -10,6 +10,21 @@ input, missing data, API errors, network failures), and **edge cases** (empty st
 boundaries). Tests mirror the source structure (`tests/services/`, `tests/adapters/`, …), one test file per source
 module. Shared mocks live in `tests/conftest.py`.
 
+## The loop a test hands a service
+
+A service takes its event loop in a frozen `*ServiceConfig`, and `asyncio.get_event_loop()` is banned (ruff TID251) —
+pytest-asyncio 1.4.0 removed the implicit thread-default loop it used to answer with. The ban's message names
+`asyncio.get_running_loop()`, which is right for code already **inside** the loop (an async fixture, an async test, a
+helper only async code enters) and is exactly the call that raises in the other position: a **synchronous** fixture or
+helper body, which has to name a loop before any test is running. That one passes `running_loop()` from
+`tests/fakes/running_loop.py` — a forwarder that resolves against whichever loop is running when the service reaches for
+it, so nothing is created and nothing is left unclosed (#806).
+
+Neither answers for a service that touches its loop from a **worker thread** (an executor callback calling
+`call_soon_threadsafe`): off the loop thread there is no running loop to resolve against, so that service needs the real
+loop object, rebound by an autouse async fixture — the shape in `tests/contract/_harness.py` and
+`tests/services/test_downloads.py`.
+
 ## Property-based tests — pure decision kernels (hypothesis)
 
 The pure decision kernels carry a property tier on top of hand-enumerated cases. The in-tree ones

--- a/main.py
+++ b/main.py
@@ -111,7 +111,7 @@ class Plugin:
             raise
 
     async def _main(self):  # Decky lifecycle — must be async
-        self.loop = asyncio.get_event_loop()
+        self.loop = asyncio.get_running_loop()
 
         # ── 1. Wire adapters ────────────────────────────────────────────────
         # Bootstrap loads + migrates settings as part of adapter construction

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ select = [
 # per-file-ignore, in tests least of all — tests are where the banned call lived.
 # That is the whole of the claim. The ban reaches only what ruff walks, so the
 # trees `extend-exclude` drops — `py_modules/_vendor`, `./scripts`, `.claude`,
-# `.worktrees` — never see it; no call site in them spells it today (the one
+# `.worktrees` — never see it; no tracked call site in them spells it today (the one
 # tracked file that names it at all is `.claude/rules/testing-backend.md`, which
 # states the ban in prose and which ruff would not read either way), and
 # `./scripts` has no ruff coverage from anywhere (see the force-exclude note

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ select = [
     "PIE",   # flake8-pie
     "PERF",  # perflint
     "TC",   # flake8-type-checking
+    "TID251", # banned-api — the table below is the whole of what this enables
 ]
 
 [tool.ruff.lint.per-file-ignores]
@@ -76,6 +77,18 @@ select = [
 # os.path) — ASYNC's event-loop concern is a production-only worry, not
 # a test one, so the group is disabled under tests/ (same rationale as ARG).
 "tests/**" = ["ARG", "ASYNC"]
+# TID251 is deliberately absent from every entry above: the ban below has no
+# exception, in tests least of all — tests are where the banned call lived.
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+# TID251 flags the attribute call, not only an import of the name, so this reaches
+# every spelling the repo used. ``asyncio.get_event_loop()`` answered with the
+# thread's default loop, which is how a synchronous pytest fixture got hold of the
+# loop its test would run on; pytest-asyncio 1.4.0 stopped creating that implicit
+# loop and the call raised instead (#806). Code already inside the loop asks for
+# the running loop; a sync fixture hands the service ``tests/fakes/running_loop.py``,
+# which resolves one at the moment the service uses it.
+"asyncio.get_event_loop".msg = "Use asyncio.get_running_loop() — get_event_loop() has no implicit loop left to answer with (#806)."
 
 [tool.ruff.lint.isort]
 known-first-party = ["lib", "domain", "services", "adapters"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,8 +81,11 @@ select = [
 # per-file-ignore, in tests least of all — tests are where the banned call lived.
 # That is the whole of the claim. The ban reaches only what ruff walks, so the
 # trees `extend-exclude` drops — `py_modules/_vendor`, `./scripts`, `.claude`,
-# `.worktrees` — never see it; none of them spells the call today, and `./scripts`
-# has no ruff coverage from anywhere (see the force-exclude note above).
+# `.worktrees` — never see it; no call site in them spells it today (the one
+# tracked file that names it at all is `.claude/rules/testing-backend.md`, which
+# states the ban in prose and which ruff would not read either way), and
+# `./scripts` has no ruff coverage from anywhere (see the force-exclude note
+# above).
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 # TID251 flags the attribute call, not only an import of the name, so this reaches

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,8 +77,12 @@ select = [
 # os.path) — ASYNC's event-loop concern is a production-only worry, not
 # a test one, so the group is disabled under tests/ (same rationale as ARG).
 "tests/**" = ["ARG", "ASYNC"]
-# TID251 is deliberately absent from every entry above: the ban below has no
-# exception, in tests least of all — tests are where the banned call lived.
+# TID251 is deliberately absent from every entry above: the ban below carries no
+# per-file-ignore, in tests least of all — tests are where the banned call lived.
+# That is the whole of the claim. The ban reaches only what ruff walks, so the
+# trees `extend-exclude` drops — `py_modules/_vendor`, `./scripts`, `.claude`,
+# `.worktrees` — never see it; none of them spells the call today, and `./scripts`
+# has no ruff coverage from anywhere (see the force-exclude note above).
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 # TID251 flags the attribute call, not only an import of the name, so this reaches

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -35,7 +35,7 @@ pytest==9.1.1
     #   -r requirements-dev.txt
     #   pytest-asyncio
     #   pytest-cov
-pytest-asyncio==1.3.0
+pytest-asyncio==1.4.0
     # via -r requirements-dev.txt
 pytest-cov==7.1.0
     # via -r requirements-dev.txt
@@ -46,4 +46,6 @@ ruff==0.15.22
 sortedcontainers==2.4.0
     # via hypothesis
 typing-extensions==4.16.0
-    # via import-linter
+    # via
+    #   import-linter
+    #   pytest-asyncio

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 pytest>=9.1.1,<10.0
-pytest-asyncio>=1.3.0,<1.4  # 1.4.0 changed event-loop semantics; tracked in #806
+pytest-asyncio>=1.3.0,<2.0
 pytest-cov>=7.1.0,<8.0
 hypothesis>=6.155.7,<7.0  # property-based tests for the save-sync decision kernels (#1028)
 ruff>=0.15.20,<0.16

--- a/tests/adapters/romm/test_http.py
+++ b/tests/adapters/romm/test_http.py
@@ -13,6 +13,7 @@ from fakes.fake_renderer_gc import FakeRendererGc
 from fakes.fake_renderer_rss import FakeRendererRss
 from fakes.fake_unit_of_work import FakeUnitOfWorkFactory
 from fakes.library_peers import FakeArtworkManager
+from fakes.running_loop import running_loop
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.romm.http import RommHttpAdapter
@@ -86,7 +87,7 @@ def plugin():
             romm_api=p._romm_api,
             steam_config=steam_config,
             settings=p.settings,
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=decky.logger,
             plugin_dir=decky.DECKY_PLUGIN_DIR,
             launcher_exe=f"{decky.DECKY_USER_HOME}/.local/share/romm-tender/bin/rom-launcher",
@@ -110,7 +111,7 @@ def plugin():
             settings=p.settings,
             romm_api=p._romm_api,
             settings_persister=MagicMock(),
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=decky.logger,
             min_required_version=Plugin._MIN_REQUIRED_VERSION,
             forget_device=MagicMock(),
@@ -829,7 +830,7 @@ def _setup_plugin(plugin):
     plugin.settings["romm_pass"] = "pass"
     plugin.settings["romm_api_token"] = "rmm_token"
     plugin.settings["romm_allow_insecure_ssl"] = False
-    plugin.loop = asyncio.get_event_loop()
+    plugin.loop = running_loop()
     plugin._connection_service = ConnectionService(
         config=ConnectionServiceConfig(
             settings=plugin.settings,
@@ -1324,10 +1325,9 @@ class TestTestConnectionErrors:
     @pytest.mark.asyncio
     async def test_auth_error_on_401(self, plugin):
         """Returns auth_error when platforms endpoint returns 401."""
-        import asyncio
 
         _setup_plugin(plugin)
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         # Heartbeat succeeds, platforms raises auth error
         plugin._romm_api.heartbeat.return_value = {"status": "ok"}
         plugin._romm_api.list_platforms.side_effect = RommAuthError("401")
@@ -1339,10 +1339,9 @@ class TestTestConnectionErrors:
     @pytest.mark.asyncio
     async def test_connection_error_on_refused(self, plugin):
         """Returns connection_error when server is unreachable."""
-        import asyncio
 
         _setup_plugin(plugin)
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.heartbeat.side_effect = RommConnectionError("refused")
         result = await plugin.test_connection()
         assert result["success"] is False
@@ -1352,10 +1351,9 @@ class TestTestConnectionErrors:
     @pytest.mark.asyncio
     async def test_ssl_error(self, plugin):
         """Returns ssl_error on SSL certificate failure."""
-        import asyncio
 
         _setup_plugin(plugin)
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.heartbeat.side_effect = RommSSLError("cert fail")
         result = await plugin.test_connection()
         assert result["success"] is False
@@ -1365,10 +1363,9 @@ class TestTestConnectionErrors:
     @pytest.mark.asyncio
     async def test_success_on_happy_path(self, plugin):
         """Returns success when both heartbeat and platforms succeed."""
-        import asyncio
 
         _setup_plugin(plugin)
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.9.0"}, "status": "ok"}
         plugin._romm_api.list_platforms.return_value = [{"id": 1, "slug": "n64"}]
         result = await plugin.test_connection()
@@ -1380,10 +1377,9 @@ class TestTestConnectionErrors:
     @pytest.mark.asyncio
     async def test_server_reachable_but_api_failed(self, plugin):
         """When heartbeat succeeds but platforms fails with non-auth error, message is prefixed."""
-        import asyncio
 
         _setup_plugin(plugin)
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.9.0"}}
         plugin._romm_api.list_platforms.side_effect = RommServerError("500", status_code=500)
         result = await plugin.test_connection()
@@ -1398,10 +1394,9 @@ class TestVersionDetection:
     @pytest.mark.asyncio
     async def test_version_extracted_from_heartbeat(self, plugin):
         """Extracts version from SYSTEM.VERSION in heartbeat response."""
-        import asyncio
 
         _setup_plugin(plugin)
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.9.0"}}
         plugin._romm_api.list_platforms.return_value = []
         result = await plugin.test_connection()
@@ -1411,10 +1406,9 @@ class TestVersionDetection:
     @pytest.mark.asyncio
     async def test_old_version_rejected(self, plugin):
         """Versions below 4.9.0 are rejected with version_error."""
-        import asyncio
 
         _setup_plugin(plugin)
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.5.0"}}
         plugin._romm_api.list_platforms.return_value = []
         result = await plugin.test_connection()
@@ -1425,10 +1419,9 @@ class TestVersionDetection:
     @pytest.mark.asyncio
     async def test_46_version_rejected(self, plugin):
         """RomM 4.6.x is below the 4.9.0 minimum and is rejected."""
-        import asyncio
 
         _setup_plugin(plugin)
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.6.1"}}
         plugin._romm_api.list_platforms.return_value = []
         result = await plugin.test_connection()
@@ -1438,10 +1431,9 @@ class TestVersionDetection:
     @pytest.mark.asyncio
     async def test_47_version_rejected(self, plugin):
         """RomM 4.7.x is below the 4.9.0 minimum and is rejected."""
-        import asyncio
 
         _setup_plugin(plugin)
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.7.0"}}
         plugin._romm_api.list_platforms.return_value = []
         result = await plugin.test_connection()
@@ -1451,10 +1443,9 @@ class TestVersionDetection:
     @pytest.mark.asyncio
     async def test_minimum_version_accepted(self, plugin):
         """RomM 4.9.0 meets the minimum version requirement."""
-        import asyncio
 
         _setup_plugin(plugin)
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.9.0"}}
         plugin._romm_api.list_platforms.return_value = []
         result = await plugin.test_connection()
@@ -1463,10 +1454,9 @@ class TestVersionDetection:
     @pytest.mark.asyncio
     async def test_former_minimum_now_rejected(self, plugin):
         """RomM 4.8.1 (the former minimum) is below 4.9.0 and is now rejected."""
-        import asyncio
 
         _setup_plugin(plugin)
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.8.1"}}
         plugin._romm_api.list_platforms.return_value = []
         result = await plugin.test_connection()
@@ -1476,10 +1466,9 @@ class TestVersionDetection:
     @pytest.mark.asyncio
     async def test_development_version_accepted(self, plugin):
         """Development builds pass through without version check."""
-        import asyncio
 
         _setup_plugin(plugin)
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "development"}}
         plugin._romm_api.list_platforms.return_value = []
         result = await plugin.test_connection()
@@ -1489,10 +1478,9 @@ class TestVersionDetection:
     @pytest.mark.asyncio
     async def test_missing_version_in_heartbeat(self, plugin):
         """Handles heartbeat without SYSTEM.VERSION gracefully."""
-        import asyncio
 
         _setup_plugin(plugin)
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.heartbeat.return_value = {"status": "ok"}
         plugin._romm_api.list_platforms.return_value = []
         result = await plugin.test_connection()
@@ -1502,10 +1490,9 @@ class TestVersionDetection:
     @pytest.mark.asyncio
     async def test_version_cleared_on_connection_failure(self, plugin):
         """Version is cleared when heartbeat fails."""
-        import asyncio
 
         _setup_plugin(plugin)
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.get_version.return_value = "4.9.0"  # previously detected
         plugin._romm_api.heartbeat.side_effect = RommConnectionError("refused")
         result = await plugin.test_connection()
@@ -1515,10 +1502,9 @@ class TestVersionDetection:
     @pytest.mark.asyncio
     async def test_timeout_error(self, plugin):
         """Returns timeout_error on request timeout."""
-        import asyncio
 
         _setup_plugin(plugin)
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.heartbeat.side_effect = RommTimeoutError("timed out")
         result = await plugin.test_connection()
         assert result["success"] is False

--- a/tests/adapters/romm/test_http.py
+++ b/tests/adapters/romm/test_http.py
@@ -1325,7 +1325,6 @@ class TestTestConnectionErrors:
     @pytest.mark.asyncio
     async def test_auth_error_on_401(self, plugin):
         """Returns auth_error when platforms endpoint returns 401."""
-
         _setup_plugin(plugin)
         plugin.loop = asyncio.get_running_loop()
         # Heartbeat succeeds, platforms raises auth error
@@ -1339,7 +1338,6 @@ class TestTestConnectionErrors:
     @pytest.mark.asyncio
     async def test_connection_error_on_refused(self, plugin):
         """Returns connection_error when server is unreachable."""
-
         _setup_plugin(plugin)
         plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.heartbeat.side_effect = RommConnectionError("refused")
@@ -1351,7 +1349,6 @@ class TestTestConnectionErrors:
     @pytest.mark.asyncio
     async def test_ssl_error(self, plugin):
         """Returns ssl_error on SSL certificate failure."""
-
         _setup_plugin(plugin)
         plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.heartbeat.side_effect = RommSSLError("cert fail")
@@ -1363,7 +1360,6 @@ class TestTestConnectionErrors:
     @pytest.mark.asyncio
     async def test_success_on_happy_path(self, plugin):
         """Returns success when both heartbeat and platforms succeed."""
-
         _setup_plugin(plugin)
         plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.9.0"}, "status": "ok"}
@@ -1377,7 +1373,6 @@ class TestTestConnectionErrors:
     @pytest.mark.asyncio
     async def test_server_reachable_but_api_failed(self, plugin):
         """When heartbeat succeeds but platforms fails with non-auth error, message is prefixed."""
-
         _setup_plugin(plugin)
         plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.9.0"}}
@@ -1394,7 +1389,6 @@ class TestVersionDetection:
     @pytest.mark.asyncio
     async def test_version_extracted_from_heartbeat(self, plugin):
         """Extracts version from SYSTEM.VERSION in heartbeat response."""
-
         _setup_plugin(plugin)
         plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.9.0"}}
@@ -1406,7 +1400,6 @@ class TestVersionDetection:
     @pytest.mark.asyncio
     async def test_old_version_rejected(self, plugin):
         """Versions below 4.9.0 are rejected with version_error."""
-
         _setup_plugin(plugin)
         plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.5.0"}}
@@ -1419,7 +1412,6 @@ class TestVersionDetection:
     @pytest.mark.asyncio
     async def test_46_version_rejected(self, plugin):
         """RomM 4.6.x is below the 4.9.0 minimum and is rejected."""
-
         _setup_plugin(plugin)
         plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.6.1"}}
@@ -1431,7 +1423,6 @@ class TestVersionDetection:
     @pytest.mark.asyncio
     async def test_47_version_rejected(self, plugin):
         """RomM 4.7.x is below the 4.9.0 minimum and is rejected."""
-
         _setup_plugin(plugin)
         plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.7.0"}}
@@ -1443,7 +1434,6 @@ class TestVersionDetection:
     @pytest.mark.asyncio
     async def test_minimum_version_accepted(self, plugin):
         """RomM 4.9.0 meets the minimum version requirement."""
-
         _setup_plugin(plugin)
         plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.9.0"}}
@@ -1454,7 +1444,6 @@ class TestVersionDetection:
     @pytest.mark.asyncio
     async def test_former_minimum_now_rejected(self, plugin):
         """RomM 4.8.1 (the former minimum) is below 4.9.0 and is now rejected."""
-
         _setup_plugin(plugin)
         plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.8.1"}}
@@ -1466,7 +1455,6 @@ class TestVersionDetection:
     @pytest.mark.asyncio
     async def test_development_version_accepted(self, plugin):
         """Development builds pass through without version check."""
-
         _setup_plugin(plugin)
         plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "development"}}
@@ -1478,7 +1466,6 @@ class TestVersionDetection:
     @pytest.mark.asyncio
     async def test_missing_version_in_heartbeat(self, plugin):
         """Handles heartbeat without SYSTEM.VERSION gracefully."""
-
         _setup_plugin(plugin)
         plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.heartbeat.return_value = {"status": "ok"}
@@ -1490,7 +1477,6 @@ class TestVersionDetection:
     @pytest.mark.asyncio
     async def test_version_cleared_on_connection_failure(self, plugin):
         """Version is cleared when heartbeat fails."""
-
         _setup_plugin(plugin)
         plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.get_version.return_value = "4.9.0"  # previously detected
@@ -1502,7 +1488,6 @@ class TestVersionDetection:
     @pytest.mark.asyncio
     async def test_timeout_error(self, plugin):
         """Returns timeout_error on request timeout."""
-
         _setup_plugin(plugin)
         plugin.loop = asyncio.get_running_loop()
         plugin._romm_api.heartbeat.side_effect = RommTimeoutError("timed out")

--- a/tests/contract/_harness.py
+++ b/tests/contract/_harness.py
@@ -223,7 +223,7 @@ def build_contract_harness(tmp_path: Any) -> ContractHarness:
     # async fixture so this is the *same* loop the callables will await on —
     # binding the loop captured at module import (a different loop) would make
     # ``run_in_executor`` raise "got Future attached to a different loop".
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
 
     # 3. Wire the real services with the patched bundle.
     cfg = WiringConfig(

--- a/tests/fakes/running_loop.py
+++ b/tests/fakes/running_loop.py
@@ -32,9 +32,10 @@ class _RunningLoop:
         return "<running loop — resolved on use>"
 
 
-# One shared instance: it holds no state, and every service constructed by a sync
-# fixture used to receive one and the same thread-default loop object, so sharing
-# keeps the identity those fixtures always had.
+# One shared instance: it holds no state, and within a single test every service a
+# sync fixture built used to receive one and the same thread-default loop object —
+# so sharing keeps the identity those fixtures had wherever it was observable.
+# Across tests it never held: pytest-asyncio made a fresh loop per test.
 _RUNNING_LOOP = _RunningLoop()
 
 

--- a/tests/fakes/running_loop.py
+++ b/tests/fakes/running_loop.py
@@ -1,0 +1,48 @@
+"""The event loop a *synchronous* fixture hands a service at construction time.
+
+A service takes its loop in a frozen ``*ServiceConfig``, so a fixture has to name
+one before any test is running — and a sync fixture body has no running loop to
+name. ``asyncio.get_event_loop()`` used to answer there with the thread's default
+loop, which pytest-asyncio then happened to run the test on; 1.4.0 dropped that
+implicit loop and the call raises (#806).
+
+What this hands over instead is not a loop but a forwarder: every attribute is
+resolved against ``asyncio.get_running_loop()`` at the moment the service reaches
+for it, so the service lands on the loop its test actually runs — the one
+pytest-asyncio built for an async test, or the one a sync test drives through
+``run_until_complete``. A sync test that never touches the loop never resolves
+anything. Nothing is created here, so nothing is left unclosed.
+
+Only the construction-time hand-off needs this. Code that is already inside the
+loop — an async fixture, an async test, a sync helper an async test calls — asks
+``asyncio.get_running_loop()`` directly and gets the loop itself.
+"""
+
+import asyncio
+from typing import Any, cast
+
+
+class _RunningLoop:
+    """Forwards every attribute to the loop running when it is asked for."""
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(asyncio.get_running_loop(), name)
+
+    def __repr__(self) -> str:
+        return "<running loop — resolved on use>"
+
+
+# One shared instance: it holds no state, and every service constructed by a sync
+# fixture used to receive one and the same thread-default loop object, so sharing
+# keeps the identity those fixtures always had.
+_RUNNING_LOOP = _RunningLoop()
+
+
+def running_loop() -> asyncio.AbstractEventLoop:
+    """The loop a sync fixture passes as ``loop=``, resolved when the service uses it.
+
+    Typed as the loop it stands in for: the seam takes an
+    ``asyncio.AbstractEventLoop`` and every call that reaches this object is
+    answered by a real one.
+    """
+    return cast("asyncio.AbstractEventLoop", _RUNNING_LOOP)

--- a/tests/fakes/test_running_loop.py
+++ b/tests/fakes/test_running_loop.py
@@ -37,8 +37,11 @@ def test_one_placeholder_answers_for_whichever_loop_is_running():
 
 def test_it_refuses_when_no_loop_is_running():
     """No loop is no answer. Silently standing in for one is what the ban is against."""
+    # Taken before the block on purpose: what must refuse is the USE, not the
+    # handing-out. Holding one is always allowed — a sync fixture does it.
+    placeholder = running_loop()
     with pytest.raises(RuntimeError, match="no running event loop"):
-        running_loop().create_future()
+        placeholder.create_future()
 
 
 async def test_it_refuses_from_a_worker_thread():
@@ -52,9 +55,11 @@ async def test_it_refuses_from_a_worker_thread():
     """
     loop = asyncio.get_running_loop()
 
+    placeholder = running_loop()
+
     def reach_it_from_off_the_loop() -> str:
         with pytest.raises(RuntimeError, match="no running event loop"):
-            running_loop().call_soon_threadsafe(lambda: None)
+            placeholder.call_soon_threadsafe(lambda: None)
         return "refused"
 
     assert await loop.run_in_executor(None, reach_it_from_off_the_loop) == "refused"

--- a/tests/fakes/test_running_loop.py
+++ b/tests/fakes/test_running_loop.py
@@ -41,6 +41,35 @@ def test_it_refuses_when_no_loop_is_running():
         running_loop().create_future()
 
 
+async def test_it_refuses_from_a_worker_thread():
+    """A worker thread is a second way to stand where no loop runs, and it refuses there too.
+
+    This is the bad path that decided a design: ``tests/contract/_harness.py``
+    hands the real ``Plugin`` the loop OBJECT because its ``DownloadService``
+    reaches ``call_soon_threadsafe`` from an executor thread — which is exactly
+    the position below, and where the forwarder answers with nothing. A service
+    whose loop is touched off the loop thread needs the real object, not this.
+    """
+    loop = asyncio.get_running_loop()
+
+    def reach_it_from_off_the_loop() -> str:
+        with pytest.raises(RuntimeError, match="no running event loop"):
+            running_loop().call_soon_threadsafe(lambda: None)
+        return "refused"
+
+    assert await loop.run_in_executor(None, reach_it_from_off_the_loop) == "refused"
+
+
+def test_every_holder_is_handed_the_same_object():
+    """One instance, shared — the identity the sharing comment claims.
+
+    Nothing here depends on it, since every attribute is resolved per use; it is
+    pinned because the comment at ``running_loop.py`` states it as the reason
+    the module hands out one instance rather than building one per call.
+    """
+    assert running_loop() is running_loop()
+
+
 def test_its_repr_resolves_nothing():
     """Printing it must be safe where using it is not — a failing assertion renders its arguments."""
     assert "running loop" in repr(running_loop())

--- a/tests/fakes/test_running_loop.py
+++ b/tests/fakes/test_running_loop.py
@@ -47,8 +47,8 @@ async def test_it_refuses_from_a_worker_thread():
     This is the bad path that decided a design: ``tests/contract/_harness.py``
     hands the real ``Plugin`` the loop OBJECT because its ``DownloadService``
     reaches ``call_soon_threadsafe`` from an executor thread — which is exactly
-    the position below, and where the forwarder answers with nothing. A service
-    whose loop is touched off the loop thread needs the real object, not this.
+    the position below, and where the forwarder raises instead of answering. A
+    service whose loop is touched off the loop thread needs the real object.
     """
     loop = asyncio.get_running_loop()
 

--- a/tests/fakes/test_running_loop.py
+++ b/tests/fakes/test_running_loop.py
@@ -1,0 +1,46 @@
+"""What the sync-fixture loop placeholder promises the services that hold it."""
+
+import asyncio
+
+import pytest
+
+from fakes.running_loop import running_loop
+
+
+async def test_it_forwards_to_the_loop_the_test_is_running_on():
+    """The hop a service actually makes — ``run_in_executor`` — lands on the test's loop."""
+    assert await running_loop().run_in_executor(None, lambda: "done") == "done"
+    assert running_loop().create_future().get_loop() is asyncio.get_running_loop()
+
+
+def test_one_placeholder_answers_for_whichever_loop_is_running():
+    """Held once at construction, resolved per use.
+
+    A sync fixture hands out the placeholder before any loop exists and the
+    service keeps that one object for its lifetime, so the question it has to
+    answer is not "which loop was there at construction" but "which loop is
+    running now" — the shape a sync test driving its own ``run_until_complete``
+    produces, where the loop is not the one pytest-asyncio would have made.
+    """
+    placeholder = running_loop()
+
+    async def which_loop():
+        return placeholder.create_future().get_loop()
+
+    for _ in range(2):
+        loop = asyncio.new_event_loop()
+        try:
+            assert loop.run_until_complete(which_loop()) is loop
+        finally:
+            loop.close()
+
+
+def test_it_refuses_when_no_loop_is_running():
+    """No loop is no answer. Silently standing in for one is what the ban is against."""
+    with pytest.raises(RuntimeError, match="no running event loop"):
+        running_loop().create_future()
+
+
+def test_its_repr_resolves_nothing():
+    """Printing it must be safe where using it is not — a failing assertion renders its arguments."""
+    assert "running loop" in repr(running_loop())

--- a/tests/services/library/conftest.py
+++ b/tests/services/library/conftest.py
@@ -23,6 +23,7 @@ from fakes.fake_renderer_gc import FakeRendererGc
 from fakes.fake_renderer_rss import FakeRendererRss
 from fakes.fake_settings_persister import FakeSettingsPersister
 from fakes.fake_unit_of_work import FakeUnitOfWork, FakeUnitOfWorkFactory
+from fakes.running_loop import running_loop
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.cover_art_file_store import CoverArtFileStoreAdapter
@@ -67,7 +68,7 @@ def plugin(tmp_path):
 
     metadata_service = MetadataService(
         config=MetadataServiceConfig(
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=decky.logger,
             log_debug=p._log_debug,
             uow_factory=FakeUnitOfWorkFactory(uow=uow),
@@ -81,7 +82,7 @@ def plugin(tmp_path):
             steam_config=steam_config,
             cover_art_file_store=CoverArtFileStoreAdapter(),
             cover_cache_dir=str(tmp_path / "covers"),
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=decky.logger,
             get_pending_sync=dict,
             uow_factory=FakeUnitOfWorkFactory(uow=uow),
@@ -118,7 +119,7 @@ def plugin(tmp_path):
             romm_api=p._romm_api,
             steam_config=steam_config,
             settings=p.settings,
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=decky.logger,
             plugin_dir=decky.DECKY_PLUGIN_DIR,
             launcher_exe=f"{decky.DECKY_USER_HOME}/.local/share/romm-tender/bin/rom-launcher",
@@ -140,7 +141,7 @@ def plugin(tmp_path):
     p._shortcut_removal_service = ShortcutRemovalService(
         config=ShortcutRemovalServiceConfig(
             steam_config=steam_config,
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=decky.logger,
             artwork_remover=artwork_service,
             uow_factory=FakeUnitOfWorkFactory(uow=uow),
@@ -156,8 +157,8 @@ def plugin(tmp_path):
 @pytest.fixture(autouse=True)
 async def _set_event_loop(plugin):
     """Ensure plugin.loop matches the running event loop for async tests."""
-    plugin.loop = asyncio.get_event_loop()
-    rebind_loop(plugin._sync_service, asyncio.get_event_loop())
-    plugin._artwork_service._loop = asyncio.get_event_loop()
-    plugin._shortcut_removal_service._loop = asyncio.get_event_loop()
-    plugin._metadata_service._loop = asyncio.get_event_loop()
+    plugin.loop = asyncio.get_running_loop()
+    rebind_loop(plugin._sync_service, asyncio.get_running_loop())
+    plugin._artwork_service._loop = asyncio.get_running_loop()
+    plugin._shortcut_removal_service._loop = asyncio.get_running_loop()
+    plugin._metadata_service._loop = asyncio.get_running_loop()

--- a/tests/services/library/test_chunk_dispatcher.py
+++ b/tests/services/library/test_chunk_dispatcher.py
@@ -53,7 +53,7 @@ class TestApplyChunking:
         from services.library import chunk_dispatcher
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 2)
 
@@ -103,7 +103,7 @@ class TestApplyChunking:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         _seed_platform(
@@ -145,7 +145,7 @@ class TestApplyChunking:
         committed — the whole point of chunking (#1025)."""
         from services.library import chunk_dispatcher
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 2)
 
@@ -209,7 +209,7 @@ class TestApplyChunking:
         from services.library import chunk_dispatcher
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 2)
 
@@ -268,7 +268,7 @@ class TestApplyChunking:
         unit) under chunk 1's identity, so a late ack commits just that chunk."""
         from services.library import chunk_dispatcher
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 2)
 
@@ -387,7 +387,7 @@ class TestWholeUnitStaging:
 
     @pytest.mark.asyncio
     async def test_delta_and_full_set_are_staged_into_their_own_fields(self, plugin, fake_romm_api):
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         # rom 10 is content-unchanged (skipped from the delta); rom 11 changed its
         # name, so the delta is {11} while the built set is {10, 11}.
@@ -639,7 +639,7 @@ class TestInterChunkCancelGuard:
         from services.library import chunk_dispatcher
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         _seed_platform(
             fake_romm_api,

--- a/tests/services/library/test_cover_preparer.py
+++ b/tests/services/library/test_cover_preparer.py
@@ -196,7 +196,7 @@ class TestCoverRefreshPass:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         plugin._sync_service._cover_preparer._download_artwork = AsyncMock(return_value={})
         plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event

--- a/tests/services/library/test_session_budget.py
+++ b/tests/services/library/test_session_budget.py
@@ -231,7 +231,7 @@ class TestSessionBudgetMonitor:
     async def test_session_budget_status_happy(self, plugin):
         from domain.session_budget import CLIFF_KB, EFFECTIVE_CEILING_KB, POST_RUN_ADVISORY_KB
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         plugin._renderer_rss.rss_kb = 1_100_000
 
         result = await plugin.get_session_budget_status()
@@ -258,7 +258,7 @@ class TestSessionBudgetMonitor:
     async def test_session_budget_status_rss_none(self, plugin):
         from domain.session_budget import CLIFF_KB, EFFECTIVE_CEILING_KB, POST_RUN_ADVISORY_KB
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         plugin._renderer_rss.rss_kb = None  # measurement unavailable → fail-open
 
         result = await plugin.get_session_budget_status()
@@ -274,7 +274,7 @@ class TestSessionBudgetMonitor:
     @pytest.mark.asyncio
     async def test_session_budget_status_resume_not_ready_at_high_rss(self, plugin):
         # A still-high RSS (a paused run before a Steam restart): resume would re-pause.
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         plugin._renderer_rss.rss_kb = 2_100_000  # 2.1 + 0.5 = 2.6 ≥ 2.2 ceiling
 
         result = await plugin.get_session_budget_status()
@@ -285,7 +285,7 @@ class TestSessionBudgetMonitor:
     async def test_session_budget_status_returns_retained_delta(self, plugin):
         # A prior clean run's delta is retained in the box and surfaced on a QAM
         # remount even though the live RSS read is a separate poll.
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         plugin._renderer_rss.rss_kb = 1_234_000
         plugin._sync_service._box.last_run_delta_kb = 800_000
 

--- a/tests/services/library/test_sync_orchestrator.py
+++ b/tests/services/library/test_sync_orchestrator.py
@@ -30,6 +30,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from fakes.running_loop import running_loop
 
 from adapters.persistence import (
     PersistenceAdapter,
@@ -200,7 +201,7 @@ class TestSyncPreview:
     async def test_returns_correct_summary(self, plugin, fake_romm_api):
         import decky
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         decky.emit.reset_mock()
         _use_fake_romm(plugin, fake_romm_api)
 
@@ -256,7 +257,7 @@ class TestSyncPreview:
         """
         import decky
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         decky.emit.reset_mock()
         _use_fake_romm(plugin, fake_romm_api)
         _seed_platform(
@@ -290,7 +291,7 @@ class TestSyncPreview:
     async def test_populates_pending_delta(self, plugin, fake_romm_api):
         import decky
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         decky.emit.reset_mock()
         _use_fake_romm(plugin, fake_romm_api)
 
@@ -322,7 +323,7 @@ class TestSyncPreview:
         """
         import decky
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         decky.emit.reset_mock()
         _use_fake_romm(plugin, fake_romm_api)
 
@@ -354,7 +355,7 @@ class TestSyncPreview:
         """
         import decky
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         decky.emit.reset_mock()
         _use_fake_romm(plugin, fake_romm_api)
 
@@ -391,7 +392,7 @@ class TestSyncPreview:
     async def test_resets_sync_running_on_completion(self, plugin, fake_romm_api):
         import decky
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         decky.emit.reset_mock()
         _use_fake_romm(plugin, fake_romm_api)
 
@@ -425,7 +426,7 @@ class TestPreviewCoverRefreshCount:
     def _preview_setup(plugin, fake_romm_api):
         import decky
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         decky.emit.reset_mock()
         _use_fake_romm(plugin, fake_romm_api)
 
@@ -535,7 +536,7 @@ class TestPreviewRestampPlatformCount:
     def _preview_setup(plugin, fake_romm_api):
         import decky
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         decky.emit.reset_mock()
         _use_fake_romm(plugin, fake_romm_api)
 
@@ -687,7 +688,7 @@ class TestSyncApplyDelta:
         """Snapshots within the TTL window apply normally."""
         import decky
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         decky.emit.reset_mock()
         plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
         self._setup_pending_delta(plugin, "preview-xyz")
@@ -707,7 +708,7 @@ class TestSyncApplyDelta:
         """Apply dispatches ``_do_sync_per_unit`` with no prefetched cache (always live fetch)."""
         import decky
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         decky.emit.reset_mock()
         plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
         self._setup_pending_delta(plugin)
@@ -735,7 +736,7 @@ class TestSyncApplyDelta:
         inside ``_do_sync_per_unit`` (covered in TestDoSyncPerUnit)."""
         import decky
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         decky.emit.reset_mock()
         plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
         self._setup_pending_delta(plugin)
@@ -750,7 +751,7 @@ class TestSyncApplyDelta:
     async def test_clears_pending_delta(self, plugin, tmp_path):
         import decky
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         decky.emit.reset_mock()
         plugin._persistence = PersistenceAdapter(str(tmp_path), str(tmp_path), decky.logger)
 
@@ -794,7 +795,7 @@ class TestGetPendingPreview:
     def _preview_setup(plugin, fake_romm_api):
         import decky
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         decky.emit.reset_mock()
         _use_fake_romm(plugin, fake_romm_api)
         _seed_platform(
@@ -1151,7 +1152,7 @@ class TestRunKindOnTheWire:
         return [c[0][1] for c in decky.emit.call_args_list if c[0][0] == "sync_progress"]
 
     def test_start_sync_claims_the_slot_as_an_apply_run(self, plugin):
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = running_loop()
         plugin._sync_service._orchestrator._do_sync_per_unit = AsyncMock()
 
         assert plugin._sync_service.start_sync()["success"] is True
@@ -1160,7 +1161,7 @@ class TestRunKindOnTheWire:
 
     @pytest.mark.asyncio
     async def test_apply_delta_claims_the_slot_as_an_apply_run(self, plugin):
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         plugin._sync_service._orchestrator._do_sync_per_unit = AsyncMock()
         plugin._sync_service._box.stage_preview(
             preview_id="p1",
@@ -1176,7 +1177,7 @@ class TestRunKindOnTheWire:
     async def test_every_preview_frame_says_preview_including_the_terminal(self, plugin, fake_romm_api):
         import decky
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         decky.emit.reset_mock()
         _use_fake_romm(plugin, fake_romm_api)
         _seed_platform(
@@ -1202,7 +1203,7 @@ class TestRunKindOnTheWire:
     async def test_every_apply_frame_says_apply(self, plugin, fake_romm_api):
         import decky
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         _seed_platform(
             fake_romm_api,
@@ -1254,7 +1255,7 @@ class TestRunKindOnTheWire:
     async def test_the_per_unit_error_terminal_carries_it(self, plugin, fake_romm_api):
         import decky
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         _seed_platform(
             fake_romm_api,
@@ -1280,7 +1281,7 @@ class TestRunKindOnTheWire:
     async def test_a_finished_run_leaves_no_kind_behind(self, plugin, fake_romm_api):
         """The idle snapshot states no kind, so a later mount reads "not
         established" rather than the previous run's answer."""
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         _seed_platform(
             fake_romm_api,
@@ -1534,7 +1535,7 @@ class TestDoSyncPerUnit:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         # No platforms enabled → empty work queue.
         plugin.settings["enabled_platforms"] = {}
@@ -1554,7 +1555,7 @@ class TestDoSyncPerUnit:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         fake_romm_api.platforms = [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 2}]
@@ -1584,7 +1585,7 @@ class TestDoSyncPerUnit:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         # N64: skip-eligible — stamp matches the server count, 2 persisted rows
@@ -1641,7 +1642,7 @@ class TestDoSyncPerUnit:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         _seed_platform(
@@ -1686,7 +1687,7 @@ class TestDoSyncPerUnit:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         # Live-fetch platforms (no last_sync, empty registry) so both
@@ -1735,7 +1736,7 @@ class TestDoSyncPerUnit:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         _seed_platform(
@@ -1777,7 +1778,7 @@ class TestDoSyncPerUnit:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         _seed_platform(
@@ -1815,7 +1816,7 @@ class TestDoSyncPerUnit:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         plugin._core_info.available_cores = [
             {"core_so": "pcsx_rearmed_libretro", "label": "PCSX ReARMed", "is_default": True},
@@ -1857,7 +1858,7 @@ class TestDoSyncPerUnit:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         # The options no longer carry the pinned label → label_to_invocation → None.
         plugin._core_info.available_cores = [
@@ -1908,7 +1909,7 @@ class TestDoSyncPerUnit:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         # roms matches platform count + zero updates → incremental skip.
@@ -1964,7 +1965,7 @@ class TestDoSyncPerUnit:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         # rom_id 10 is the live N64 ROM (synced this run). rom_id 99 is a leftover
@@ -2012,7 +2013,7 @@ class TestDoSyncPerUnit:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         _seed_completed_run(plugin, at="2025-01-01T00:00:00Z")
@@ -2048,7 +2049,7 @@ class TestDoSyncPerUnit:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         # Old colliding row from before the reassignment: rom 1 bound to app 5000.
@@ -2098,7 +2099,7 @@ class TestDoSyncPerUnit:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         # rom 1 collides (app 5000 re-bound to rom 2 this run); rom 99 is a
@@ -2137,7 +2138,7 @@ class TestDoSyncPerUnit:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         _seed_platform(
             fake_romm_api,
@@ -2189,7 +2190,7 @@ class TestDoSyncPerUnit:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         _seed_platform(fake_romm_api, platform_id=1, name="N64", slug="n64", roms=roms)
         plugin.settings["enabled_platforms"] = {"1": True}
@@ -2248,7 +2249,7 @@ class TestDoSyncPerUnit:
         game's reported name is the region-canonical (USA) name."""
         import decky
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         decky.emit.reset_mock()
         _use_fake_romm(plugin, fake_romm_api)
         _seed_platform(
@@ -2276,7 +2277,7 @@ class TestDoSyncPerUnit:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         # rom 1 was the bound USA dump (app 5000); it is GONE from the server now.
         _seed_rom_row(
@@ -2357,7 +2358,7 @@ class TestDoSyncPerUnit:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         # A 2-version Zelda group on N64: rom 10 bound + installed (active
@@ -2448,7 +2449,7 @@ class TestDoSyncPerUnit:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         # rom 11 (the unbound sibling) lives on N64 + in the collection; rom 10 is
@@ -2510,7 +2511,7 @@ class TestDoSyncPerUnit:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         # No prior sync → full fetch path → skipped=False → artwork pipeline runs.
@@ -2544,7 +2545,7 @@ class TestDoSyncPerUnit:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         # Two live-fetch platforms (no last_sync, empty registry).
@@ -2590,7 +2591,7 @@ class TestDoSyncPerUnit:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         _seed_platform(
@@ -2631,7 +2632,7 @@ class TestDoSyncPerUnit:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         _seed_platform(
@@ -2689,7 +2690,7 @@ class TestSyncRunLifecycle:
 
     @pytest.mark.asyncio
     async def test_clean_run_persists_completed_with_platforms(self, plugin, fake_romm_api):
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         _seed_platform(fake_romm_api, platform_id=1, name="N64", slug="n64", roms=[{"id": 10, "name": "A"}])
@@ -2721,7 +2722,7 @@ class TestSyncRunLifecycle:
         completed run would reset the preview baseline (next preview would
         report every platform as 'added'). The prior completed run stays the
         baseline source, matching the JSON era's return-early behaviour."""
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         # A prior real sync completed with N64 synced — this is the baseline
@@ -2747,7 +2748,7 @@ class TestSyncRunLifecycle:
 
     @pytest.mark.asyncio
     async def test_cancelled_run_persists_cancelled(self, plugin, fake_romm_api):
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         _seed_platform(fake_romm_api, platform_id=1, name="N64", slug="n64", roms=[{"id": 10, "name": "A"}])
@@ -2780,7 +2781,7 @@ class TestSyncRunLifecycle:
         ``box.run_interrupted`` so a crash is never blamed on the user's Cancel."""
         from services.library import sync_orchestrator
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         _seed_platform(fake_romm_api, platform_id=1, name="N64", slug="n64", roms=[{"id": 10, "name": "A"}])
@@ -2807,7 +2808,7 @@ class TestSyncRunLifecycle:
 
     @pytest.mark.asyncio
     async def test_exception_in_unit_loop_persists_errored(self, plugin, fake_romm_api):
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         # build_work_queue succeeds, then list_roms raises during the unit fetch.
@@ -2846,7 +2847,7 @@ class TestSyncRunLifecycle:
         the nulling lives — put a null back before the terminal write and it is
         what keeps this test true.
         """
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         _seed_platform(fake_romm_api, platform_id=1, name="N64", slug="n64", roms=[{"id": 10, "name": "A"}])
@@ -3225,7 +3226,7 @@ class TestRealOrchestratorLateAckRecovery:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         _seed_platform(
@@ -3289,7 +3290,7 @@ class TestRealOrchestratorLateAckRecovery:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         _seed_platform(
@@ -3416,7 +3417,7 @@ class TestDoSyncPerUnitErrors:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         # ``list_platforms`` runs in the executor; the fake raises
         # CancelledError exactly like an asyncio cancel would propagate.
@@ -3442,7 +3443,7 @@ class TestDoSyncPerUnitErrors:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         fake_romm_api.list_platforms_side_effect = RuntimeError("RomM down")
         plugin.settings["enabled_platforms"] = {"1": True}
@@ -3466,7 +3467,7 @@ class TestDoSyncPerUnitErrors:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         # build_work_queue succeeds (platforms listing returns a unit), then
@@ -3509,7 +3510,7 @@ class TestDoSyncPerUnitErrors:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         fake_romm_api.platforms = [{"id": 1, "name": "N64", "slug": "n64", "rom_count": 3}]
@@ -3562,7 +3563,7 @@ class TestDoSyncPerUnitErrors:
         """
         from domain.sync_state import SyncCancelled
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         # One live-fetch platform (no last_sync, empty registry) so the unit
@@ -3630,7 +3631,7 @@ class TestDoSyncPerUnitErrors:
         ``_do_sync_per_unit``. The SyncRun is left ``running`` — it is NOT marked
         cancelled by the cooperative swallow path.
         """
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         _seed_platform(
@@ -3708,7 +3709,7 @@ class TestDoSyncPerUnitErrors:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         # Two units in the queue; CANCELLING gates the loop before either fires.
@@ -3743,7 +3744,7 @@ class TestSyncOneUnitCollectionAndCancel:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         # Seed a real (non-virtual) collection with two ROMs.
@@ -3819,7 +3820,7 @@ class TestSyncOneUnitCollectionAndCancel:
     @pytest.mark.asyncio
     async def test_cancel_after_fetch_returns_zero_applied(self, plugin, fake_romm_api):
         """CANCELLING flipped after fetch_platform_unit → unit returns 0."""
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         # Real fetcher will be called for the unit. Wrap list_roms so the
@@ -3857,7 +3858,7 @@ class TestSyncOneUnitCollectionAndCancel:
     @pytest.mark.asyncio
     async def test_cancel_after_artwork_returns_zero_applied(self, plugin, fake_romm_api):
         """CANCELLING flipped after the artwork download → unit returns 0."""
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         # Real fetcher runs; artwork download is intercepted to flip state mid-flight.
@@ -3894,7 +3895,7 @@ class TestSyncOneUnitCollectionAndCancel:
         count: those ROMs were verified already-correct in Steam, so they are
         processed — same as a wholesale-skipped unit's ROMs — and the terminal
         frame's "N of M games processed" numerator must not drop them."""
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         # rom 10 is content-unchanged (delta-skipped); rom 11 is brand-new, so
@@ -3934,7 +3935,7 @@ class TestSyncOneUnitCollectionAndCancel:
         """Same invariant at the sibling guard: a cancel landing during the
         cover-refresh pass — after the delta is computed, before the artwork
         download — still returns the delta-skip count."""
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         # rom 10 is content-unchanged (delta-skipped); the cancel lands inside
@@ -3974,7 +3975,7 @@ class TestSyncOneUnitCollectionAndCancel:
         ``_wait_for_unit_complete`` returns None while the box is already
         CANCELLING (the cancel branch), so the unit's in-flight state is
         intentionally dropped and a stray late ack can't commit it (#1052)."""
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         # Live-fetch path so the unit reaches the apply branch where
@@ -4025,7 +4026,7 @@ class TestSyncOneUnitCollectionAndCancel:
         commit to read, and the dispatch identity (``unit_complete_event`` +
         ``active_unit_id`` + ``active_chunk_index``) is cleared. The box flips
         CANCELLING so the outer loop stops (#1052 / #1367)."""
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         _seed_platform(
@@ -4078,7 +4079,7 @@ class TestPerUnitMetadataStamping:
         """The orchestrator threads the acked ROM dicts into ``commit_unit_results``
         so the reporter can stamp ``rom_metadata`` in the same write UoW as the
         ``roms`` upsert (atomic — no separate metadata hop)."""
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         _seed_platform(
@@ -4138,7 +4139,7 @@ class TestPerUnitMetadataStamping:
         per-unit commit, so no ``rom_metadata`` is written for a skipped unit
         (populated metadata from prior real fetches is preserved, #738).
         """
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         # roms matches platform rom_count + zero updates → incremental skip.
@@ -4175,7 +4176,7 @@ class TestPerUnitMetadataStamping:
         """Group-aware persist (ADR-0021): the WHOLE unit fetch is threaded into
         ``commit_unit_results`` (every sibling gets an identity row), while the
         frontend ack — a subset — decides which representatives bind."""
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         _seed_platform(
@@ -4239,7 +4240,7 @@ class TestPlatformCompletionStamp:
     async def test_stamp_written_after_final_platform_chunk(self, plugin, fake_romm_api):
         """A platform unit that completes stamps ``platform_sync_state`` with the
         server ROM count and the clock's completion timestamp (real commit)."""
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         _seed_platform(
@@ -4282,7 +4283,7 @@ class TestPlatformCompletionStamp:
         stamp, and it records the unit's whole ``rom_count`` (not the chunk size)."""
         from services.library import chunk_dispatcher
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 2)
 
@@ -4328,7 +4329,7 @@ class TestPlatformCompletionStamp:
         is only partially applied, so the next run must re-fetch it."""
         from services.library import chunk_dispatcher
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 2)
 
@@ -4370,7 +4371,7 @@ class TestPlatformCompletionStamp:
     async def test_no_stamp_on_heartbeat_timeout(self, plugin, fake_romm_api):
         """A heartbeat timeout (wait returns None while NOT cancelling) abandons the
         chunk without committing it — no stamp, even on a single-chunk platform."""
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         _seed_platform(
@@ -4406,7 +4407,7 @@ class TestPlatformCompletionStamp:
     async def test_no_stamp_for_collection_unit(self, plugin, fake_romm_api):
         """Collection units have no incremental-skip gate, so they are never stamped —
         every chunk's commit carries ``platform_stamp=None``."""
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         _seed_platform(
@@ -4458,7 +4459,7 @@ class TestPlatformCompletionStamp:
         """
         from services.library import chunk_dispatcher
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 2)
 
@@ -4503,7 +4504,7 @@ class TestPlatformCompletionStamp:
         """A collection spans platforms, so its commits pass no generation — marking
         a foreign platform's row would drop it from that platform's counted rows
         and suppress that platform's skip (#1504)."""
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         _seed_platform(
@@ -4556,7 +4557,7 @@ class TestPlatformCompletionStamp:
         """
         from services.library import chunk_dispatcher
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         monkeypatch.setattr(chunk_dispatcher, "_APPLY_CHUNK_SIZE", 2)
 
@@ -4601,7 +4602,7 @@ class TestPlatformCompletionStamp:
         """A heartbeat timeout abandons the chunk without committing it, and its late-ack
         commit (unreachable today, #1367) carries no stamp — but the apply-start clear
         already removed the pre-existing stamp, so none survives the interruption."""
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         _seed_platform(
@@ -4638,7 +4639,7 @@ class TestPlatformCompletionStamp:
     async def test_completing_reapply_refreshes_stale_stamp(self, plugin, fake_romm_api):
         """A platform that re-applies to completion replaces a stale stamp with a fresh
         one (current server count + the injected completion clock), not the old values."""
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         _seed_platform(
@@ -4679,7 +4680,7 @@ class TestPlatformCompletionStamp:
     async def test_skipped_platform_keeps_its_stamp(self, plugin, fake_romm_api):
         """An incremental-skipped platform returns before the apply-start clear, so its
         completion stamp is preserved untouched (the skip is what the stamp exists for)."""
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         # Stamp + one matching bound row + unchanged server → the fetch incremental-skips.
@@ -4715,7 +4716,7 @@ class TestPlatformCompletionStamp:
     async def test_fetch_failure_before_chunk_loop_keeps_stamp(self, plugin, fake_romm_api):
         """A fetch that raises before the chunk loop is not an apply start, so the old
         stamp is preserved (fetch failure ≠ apply started)."""
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         _seed_platform_stamp(plugin, "n64", at="2020-01-01T00:00:00+00:00", rom_count=5)
 
@@ -4766,7 +4767,7 @@ class TestRegression738CacheCorruption:
         """
         from domain.rom_metadata import RomMetadata
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
 
         # Pre-existing populated metadata rows (the "160 entries" scenario
@@ -4852,7 +4853,7 @@ class TestFetchNarrationInterplay:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         _seed_platform(fake_romm_api, platform_id=1, name="N64", slug="n64", roms=[{"id": 10, "name": "A"}])
         plugin.settings["enabled_platforms"] = {"1": True}
@@ -4876,7 +4877,7 @@ class TestFetchNarrationInterplay:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         _seed_platform(
             fake_romm_api,
@@ -4924,7 +4925,7 @@ class TestComponentGroupKeyStamping:
         # only, RomM listing them as siblings. Both must persist under the SAME
         # component key (igdb), so the ss-only dump does not split into its own
         # group (the #1368 bug). A platform unit is a complete view → recompute.
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         _seed_platform(
             fake_romm_api,
@@ -4974,7 +4975,7 @@ class TestDeltaRestrictedApply:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         plugin._sync_service._cover_preparer._download_artwork = AsyncMock(return_value={})
         plugin._sync_service._chunk_dispatcher._wait_for_unit_complete = _fake_wait_set_event
@@ -5085,7 +5086,7 @@ class TestSessionBudgetGate:
         """Seed a 2-ROM platform and force one shortcut per chunk (2 chunks)."""
         from services.library import chunk_dispatcher
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         _seed_platform(
             fake_romm_api,
@@ -5145,7 +5146,7 @@ class TestSessionBudgetGate:
         """Seed a 1-ROM platform (→ one chunk = the run's first chunk)."""
         from services.library import chunk_dispatcher
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         _seed_platform(fake_romm_api, platform_id=1, name="N64", slug="n64", roms=[{"id": 10, "name": "Solo"}])
         plugin.settings["enabled_platforms"] = {"1": True}
@@ -5225,7 +5226,7 @@ class TestSessionBudgetGate:
     async def test_preview_flags_pause_likely_when_run_would_cross(self, plugin, fake_romm_api):
         import decky
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         decky.emit.reset_mock()
         _use_fake_romm(plugin, fake_romm_api)
         _seed_platform(fake_romm_api, platform_id=1, name="N64", slug="n64", roms=[{"id": 1, "name": "A"}])
@@ -5241,7 +5242,7 @@ class TestSessionBudgetGate:
     async def test_preview_pause_likely_false_with_headroom(self, plugin, fake_romm_api):
         import decky
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         decky.emit.reset_mock()
         _use_fake_romm(plugin, fake_romm_api)
         _seed_platform(fake_romm_api, platform_id=1, name="N64", slug="n64", roms=[{"id": 1, "name": "A"}])
@@ -5256,7 +5257,7 @@ class TestSessionBudgetGate:
     async def test_preview_pause_likely_false_when_rss_unavailable(self, plugin, fake_romm_api):
         import decky
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         decky.emit.reset_mock()
         _use_fake_romm(plugin, fake_romm_api)
         _seed_platform(fake_romm_api, platform_id=1, name="N64", slug="n64", roms=[{"id": 1, "name": "A"}])
@@ -5274,7 +5275,7 @@ class TestSessionBudgetGate:
         # (which priced unchanged at the create rate) would have crossed here.
         import decky
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         decky.emit.reset_mock()
         _use_fake_romm(plugin, fake_romm_api)
         _seed_platform(
@@ -5309,7 +5310,7 @@ class TestSessionBudgetGate:
     async def test_completed_run_recommends_restart_when_rss_high(self, plugin, fake_romm_api):
         import decky
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         _seed_platform(fake_romm_api, platform_id=1, name="N64", slug="n64", roms=[{"id": 10, "name": "A"}])
         plugin.settings["enabled_platforms"] = {"1": True}
@@ -5408,7 +5409,7 @@ class TestSessionBudgetGate:
         # so a fully-incremental-skip run (nothing applied, no gate ever fires) still
         # records a baseline and reports an honest ≈ +0.0 GB delta instead of wiping
         # last_run_delta_kb to None on every no-op re-sync.
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         # roms matches platform count + zero updates → the platform incremental-skips.
         _seed_platform_stamp(plugin, "n64", at="2025-01-01T00:00:00Z", rom_count=1)
@@ -5489,7 +5490,7 @@ class TestRunProgressCounters:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         plugin._sync_service._cover_preparer._download_artwork = AsyncMock(return_value={})
         plugin._sync_service._box.sync_state = SyncState.RUNNING
@@ -5673,7 +5674,7 @@ class TestRunProgressCounters:
     async def test_status_callable_reports_unknown_before_any_run(self, plugin):
         # A fresh backend process (or a plugin reload) has no counters: the pair is
         # None, and the banner drops the sentence rather than showing zeros.
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
 
         result = await plugin.get_session_budget_status()
 
@@ -5696,7 +5697,7 @@ class TestProcessedGamesNumerator:
         import decky
 
         decky.emit.reset_mock()
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         _use_fake_romm(plugin, fake_romm_api)
         plugin._sync_service._cover_preparer._download_artwork = AsyncMock(return_value={})
         plugin._sync_service._box.sync_state = SyncState.RUNNING

--- a/tests/services/prune/test_executor.py
+++ b/tests/services/prune/test_executor.py
@@ -90,7 +90,7 @@ def _executor(rows: list[Rom], settings: dict[str, Any], emitted: list[tuple[str
 
     return PruneExecutor(
         config=PruneExecutorConfig(
-            loop=asyncio.get_event_loop(),
+            loop=asyncio.get_running_loop(),
             logger=logging.getLogger("prune-test"),
             emit=emit,
             romm_api=cast("Any", _Unusable()),

--- a/tests/services/prune/test_finalize.py
+++ b/tests/services/prune/test_finalize.py
@@ -146,7 +146,7 @@ class Fixture:
         self.installed = _FakeInstalledRemover(self.order)
         self.recovery = _FakeRecovery()
         self.recovery_store = _FakeRecoveryStore()
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         self.finalizer = GroupFinalizer(
             config=GroupFinalizerConfig(
                 loop=loop,

--- a/tests/services/prune/test_liveness.py
+++ b/tests/services/prune/test_liveness.py
@@ -52,7 +52,7 @@ def _prober(
     reader = _FakeRomReader(answers, user)
     prober = LivenessProber(
         config=LivenessProberConfig(
-            loop=asyncio.get_event_loop(),
+            loop=asyncio.get_running_loop(),
             logger=logging.getLogger("prune-liveness-test"),
             romm_api=cast("Any", reader),
             settings=settings if settings is not None else dict(_NAMESPACE_SETTINGS),
@@ -122,7 +122,7 @@ class TestNamespaceBinding:
 
         prober = LivenessProber(
             config=LivenessProberConfig(
-                loop=asyncio.get_event_loop(),
+                loop=asyncio.get_running_loop(),
                 logger=logging.getLogger("prune-liveness-test"),
                 romm_api=cast("Any", _SwitchingReader({})),
                 settings=settings,
@@ -146,7 +146,7 @@ class TestNamespaceBinding:
 
         prober = LivenessProber(
             config=LivenessProberConfig(
-                loop=asyncio.get_event_loop(),
+                loop=asyncio.get_running_loop(),
                 logger=logging.getLogger("prune-liveness-test"),
                 romm_api=cast("Any", _SwitchingReader({})),
                 settings=settings,
@@ -253,7 +253,7 @@ class TestEndpointConfirmation:
         reader = _FakeRomReader({7: RommNotFoundError("gone"), 8: RommNotFoundError("gone")})
         prober = LivenessProber(
             config=LivenessProberConfig(
-                loop=asyncio.get_event_loop(),
+                loop=asyncio.get_running_loop(),
                 logger=logging.getLogger("prune-liveness-test"),
                 romm_api=cast("Any", reader),
                 settings=dict(_NAMESPACE_SETTINGS),

--- a/tests/services/prune/test_planning.py
+++ b/tests/services/prune/test_planning.py
@@ -82,7 +82,7 @@ def _planner(
 
     planner = GroupPlanner(
         config=GroupPlannerConfig(
-            loop=asyncio.get_event_loop(),
+            loop=asyncio.get_running_loop(),
             logger=logging.getLogger("test"),
             results=PruneResultReporter(config=PruneResultReporterConfig(emit=_noop_emit)),
             registry=PruneRegistry(config=PruneRegistryConfig(uow_factory=FakeUnitOfWorkFactory(uow))),

--- a/tests/services/prune/test_save_locks.py
+++ b/tests/services/prune/test_save_locks.py
@@ -46,7 +46,7 @@ class _FakeSaveCoordinator:
 def _coordinator(inventories: list[dict[str, Any]]) -> tuple[SaveLockCoordinator, _FakeSaveCoordinator]:
     saves = _FakeSaveCoordinator(inventories)
     return (
-        SaveLockCoordinator(config=SaveLockCoordinatorConfig(loop=asyncio.get_event_loop(), save_coordinator=saves)),
+        SaveLockCoordinator(config=SaveLockCoordinatorConfig(loop=asyncio.get_running_loop(), save_coordinator=saves)),
         saves,
     )
 

--- a/tests/services/prune/test_steam_actions.py
+++ b/tests/services/prune/test_steam_actions.py
@@ -80,7 +80,7 @@ def _runner(
 
     runner = SteamActionRunner(
         config=SteamActionRunnerConfig(
-            loop=asyncio.get_event_loop(),
+            loop=asyncio.get_running_loop(),
             results=PruneResultReporter(config=PruneResultReporterConfig(emit=_noop_emit)),
             registry=PruneRegistry(config=PruneRegistryConfig(uow_factory=FakeUnitOfWorkFactory(uow))),
             switch_version=switch_version,

--- a/tests/services/saves/_helpers.py
+++ b/tests/services/saves/_helpers.py
@@ -1,6 +1,5 @@
 """Shared factories and fakes for the SaveService test suite."""
 
-import asyncio
 import hashlib
 import logging
 from datetime import UTC, datetime
@@ -16,6 +15,7 @@ from fakes.fake_save_api import FakeSaveApi
 from fakes.fake_save_location_reader import FakeSaveLocationReader
 from fakes.fake_settings_persister import FakeSettingsPersister
 from fakes.fake_unit_of_work import FakeUnitOfWork, FakeUnitOfWorkFactory
+from fakes.running_loop import running_loop
 from fakes.system_time import FakeClock
 
 from adapters.gavel_native import GavelNativeAdapter
@@ -57,7 +57,7 @@ def make_service(tmp_path, fake_api=None, *, emit=None, **overrides) -> tuple["S
         "settings": {"log_level": "debug"},
         "settings_persister": FakeSettingsPersister(),
         "save_file_store": save_file_store,
-        "loop": asyncio.get_event_loop(),
+        "loop": running_loop(),
         "logger": logging.getLogger("test"),
         "clock": FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
         "retrodeck_paths": FakeRetroDeckPaths(

--- a/tests/services/test_achievements.py
+++ b/tests/services/test_achievements.py
@@ -14,6 +14,7 @@ from fakes.fake_renderer_rss import FakeRendererRss
 from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
 from fakes.fake_unit_of_work import FakeUnitOfWork, FakeUnitOfWorkFactory
 from fakes.library_peers import FakeArtworkManager
+from fakes.running_loop import running_loop
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.steam_config import SteamConfigAdapter
@@ -81,7 +82,7 @@ def plugin(clock):
             romm_api=p._romm_api,
             steam_config=steam_config,
             settings=p.settings,
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=decky.logger,
             plugin_dir=decky.DECKY_PLUGIN_DIR,
             launcher_exe=f"{decky.DECKY_USER_HOME}/.local/share/romm-tender/bin/rom-launcher",
@@ -103,7 +104,7 @@ def plugin(clock):
         config=AchievementsServiceConfig(
             romm_api=p._romm_api,
             uow_factory=FakeUnitOfWorkFactory(uow=uow),
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=decky.logger,
             clock=clock,
             log_debug=p._log_debug,
@@ -132,9 +133,9 @@ def plugin(clock):
 @pytest.fixture(autouse=True)
 async def _set_event_loop(plugin):
     """Ensure service loops match the running event loop for async tests."""
-    plugin._achievements_service._loop = asyncio.get_event_loop()
+    plugin._achievements_service._loop = asyncio.get_running_loop()
     # ``get_cached_game_detail`` runs its work on an executor worker.
-    plugin.loop = asyncio.get_event_loop()
+    plugin.loop = asyncio.get_running_loop()
 
 
 @pytest.fixture

--- a/tests/services/test_artwork.py
+++ b/tests/services/test_artwork.py
@@ -12,6 +12,7 @@ import decky
 import pytest
 from fakes.fake_cover_art_file_store import FakeCoverArtFileStore
 from fakes.fake_unit_of_work import FakeUnitOfWork, FakeUnitOfWorkFactory
+from fakes.running_loop import running_loop
 from models.cover import CoverRevalidation
 
 from domain.artwork_paths import cover_meta_filename
@@ -163,15 +164,13 @@ def uow() -> FakeUnitOfWork:
 
 @pytest.fixture
 def artwork_service(steam_config, file_store, romm_api, pending_sync_data, uow, cover_cache_dir):
-    # _loop is replaced by the autouse fixture below for async tests; for
-    # sync tests it is never touched, so a MagicMock is fine here.
     return ArtworkService(
         config=ArtworkServiceConfig(
             romm_api=romm_api,
             steam_config=steam_config,
             cover_art_file_store=file_store,
             cover_cache_dir=cover_cache_dir,
-            loop=MagicMock(),
+            loop=running_loop(),
             logger=decky.logger,
             get_pending_sync=lambda: pending_sync_data,
             uow_factory=FakeUnitOfWorkFactory(uow=uow),

--- a/tests/services/test_artwork.py
+++ b/tests/services/test_artwork.py
@@ -181,7 +181,7 @@ def artwork_service(steam_config, file_store, romm_api, pending_sync_data, uow, 
 
 @pytest.fixture(autouse=True)
 async def _set_event_loop(artwork_service):
-    artwork_service._loop = asyncio.get_event_loop()
+    artwork_service._loop = asyncio.get_running_loop()
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────

--- a/tests/services/test_data_location.py
+++ b/tests/services/test_data_location.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 
 import pytest
+from fakes.running_loop import running_loop
 from models.data_location import SourceDescription, UserDataLocations
 
 from services.data_location import DataLocationService, DataLocationServiceConfig
@@ -42,7 +42,7 @@ def _make(locations: UserDataLocations, store: FakeDataLocationStore | None = No
         config=DataLocationServiceConfig(
             locations=locations,
             store=used,
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=logging.getLogger("test"),
         ),
     )

--- a/tests/services/test_downloads.py
+++ b/tests/services/test_downloads.py
@@ -18,6 +18,7 @@ from fakes.fake_renderer_rss import FakeRendererRss
 from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
 from fakes.fake_unit_of_work import FakeUnitOfWork, FakeUnitOfWorkFactory
 from fakes.library_peers import FakeArtworkManager
+from fakes.running_loop import running_loop
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.adoption_move import AdoptionMoveAdapter
@@ -159,7 +160,7 @@ def plugin():
             romm_api=p._romm_api,
             steam_config=steam_config,
             settings=p.settings,
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=decky.logger,
             plugin_dir=decky.DECKY_PLUGIN_DIR,
             launcher_exe=f"{decky.DECKY_USER_HOME}/.local/share/romm-tender/bin/rom-launcher",
@@ -217,7 +218,7 @@ def plugin():
             # Late-bound like production: DownloadService is constructed below.
             sibling_supersede=lambda: p._download_service.supersede_sibling_installs,
             uow_factory=FakeUnitOfWorkFactory(p._uow),
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=decky.logger,
             log_debug=lambda msg: None,
             emit=decky.emit,
@@ -229,7 +230,7 @@ def plugin():
             romm_api=p._romm_api,
             download_file_store=download_file_store,
             resolve_system=p._resolve_system,
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=decky.logger,
             emit=decky.emit,
             clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
@@ -249,7 +250,7 @@ def plugin():
     p._rom_removal_service = RomRemovalService(
         config=RomRemovalServiceConfig(
             logger=decky.logger,
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
             emit=decky.emit,
             rom_file_store=RomFileAdapter(),
@@ -271,10 +272,10 @@ async def _set_event_loop(plugin):
     awaits it, and it offloads onto *its own* loop — a stale one raises "attached
     to a different loop" from inside the gate rather than at the seam.
     """
-    plugin.loop = asyncio.get_event_loop()
-    plugin._download_service._loop = asyncio.get_event_loop()
-    plugin._rom_removal_service._loop = asyncio.get_event_loop()
-    plugin._rom_adoption_service._loop = asyncio.get_event_loop()
+    plugin.loop = asyncio.get_running_loop()
+    plugin._download_service._loop = asyncio.get_running_loop()
+    plugin._rom_removal_service._loop = asyncio.get_running_loop()
+    plugin._rom_adoption_service._loop = asyncio.get_running_loop()
 
 
 class TestStartDownload:
@@ -382,7 +383,7 @@ class TestCancelDownload:
     @pytest.mark.asyncio
     async def test_cancels_active_download(self, plugin):
         # Create a real future that raises CancelledError when awaited
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         fut = loop.create_future()
         fut.cancel()
 
@@ -406,7 +407,7 @@ class TestCancelDownload:
         import decky
 
         decky.emit.reset_mock()
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
 
         roms_dir = tmp_path / "retrodeck" / "roms" / "n64"
         roms_dir.mkdir(parents=True)
@@ -450,7 +451,7 @@ class TestCancelDownload:
         import decky
 
         decky.emit.reset_mock()
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[42] = {
             "rom_id": 42,
             "rom_name": "Zelda",
@@ -1555,7 +1556,7 @@ class TestDoDownloadSingleFile:
                 f.write(b"\x00" * 512)
 
         _seed_rom(plugin._uow, 42)
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[42] = {"rom_id": 42, "status": "downloading", "progress": 0}
 
         with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
@@ -1636,7 +1637,7 @@ class TestDoDownloadSingleFile:
                     last_synced_at="2025-01-01T00:00:00",
                 )
             )
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[7] = {"rom_id": 7, "status": "downloading", "progress": 0}
 
         with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
@@ -1672,7 +1673,7 @@ class TestDoDownloadSingleFile:
                 f.write(b"\x00" * 512)
 
         _seed_rom(plugin._uow, 42)  # bound (app_id 1042)
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[42] = {"rom_id": 42, "status": "downloading", "progress": 0}
 
         with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
@@ -1726,7 +1727,7 @@ class TestDoDownloadSingleFile:
                     last_synced_at="2025-01-01T00:00:00",
                 )
             )
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[7] = {"rom_id": 7, "status": "downloading", "progress": 0}
 
         with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
@@ -1778,7 +1779,7 @@ class TestDoDownloadOverrideRebake:
         if override is not None:
             with plugin._uow:
                 plugin._uow.roms.set_emulator_override(rom_id, override)
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[rom_id] = {"rom_id": rom_id, "status": "downloading", "progress": 0}
 
         with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
@@ -1876,7 +1877,7 @@ class TestDoDownloadMultiFile:
                 f.write(zip_bytes)
 
         _seed_rom(plugin._uow, 55, platform_slug="psx")
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[55] = {"rom_id": 55, "status": "downloading", "progress": 0}
 
         with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
@@ -1966,7 +1967,7 @@ class TestDoDownloadMultiFile:
                 f.write(zip_bytes)
 
         _seed_rom(plugin._uow, 99, platform_slug="switch")
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[99] = {"rom_id": 99, "status": "downloading", "progress": 0}
 
         with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
@@ -2046,7 +2047,7 @@ class TestDoDownloadMultiFile:
         def fake_download(_rom_id, _filename, _dest, _progress_callback=None, *, resume=False, on_meta=None):
             raise OSError("network died mid-download")
 
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[99] = {"rom_id": 99, "status": "downloading", "progress": 0}
 
         with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
@@ -2118,7 +2119,7 @@ class TestDoDownloadMultiFile:
                 f.write(zip_bytes)
 
         _seed_rom(plugin._uow, 4778, platform_slug="ps3")
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[4778] = {"rom_id": 4778, "status": "downloading", "progress": 0}
 
         with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
@@ -2190,7 +2191,7 @@ class TestDoDownloadMultiFile:
         def fake_download(_rom_id, _filename, _dest, _progress_callback=None, *, resume=False, on_meta=None):
             raise OSError("network died mid-download")
 
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[4778] = {"rom_id": 4778, "status": "downloading", "progress": 0}
 
         with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
@@ -2251,7 +2252,7 @@ class TestDoDownloadMultiFile:
             fake.files[dest] = b"ZIPDATA"
 
         _seed_rom(plugin._uow, 55, platform_slug="psx")
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[55] = {
             "rom_id": 55,
             "rom_name": "Final Fantasy VII",
@@ -2348,7 +2349,7 @@ class TestDoDownloadBundledM3uPlatformGate:
                 f.write(zip_bytes)
 
         _seed_rom(plugin._uow, 111, platform_slug="switch")
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[111] = {"rom_id": 111, "status": "downloading", "progress": 0}
 
         with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
@@ -2415,7 +2416,7 @@ class TestDoDownloadBundledM3uPlatformGate:
                 f.write(zip_bytes)
 
         _seed_rom(plugin._uow, 112, platform_slug="psx")
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[112] = {"rom_id": 112, "status": "downloading", "progress": 0}
 
         with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
@@ -2466,7 +2467,7 @@ class TestEsDeCollapseRename:
                 f.write(zip_bytes)
 
         _seed_rom(plugin._uow, rom_id, platform_slug=platform)
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[rom_id] = {"rom_id": rom_id, "status": "downloading", "progress": 0}
 
         with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
@@ -2639,7 +2640,7 @@ class TestEsDeCollapseRename:
                 f.write(b"\x00" * 100)
 
         _seed_rom(plugin._uow, 73, platform_slug="gba")
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[73] = {"rom_id": 73, "status": "downloading", "progress": 0}
 
         with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
@@ -2691,7 +2692,7 @@ class TestEsDeCollapseRename:
                 f.write(zip_bytes)
 
         _seed_rom(plugin._uow, 74, platform_slug="psx")
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[74] = {"rom_id": 74, "status": "downloading", "progress": 0}
 
         with (
@@ -2758,7 +2759,7 @@ class TestDoDownloadNestedSingleFile:
                 f.write(b"\x00" * 64)
 
         _seed_rom(plugin._uow, 1, platform_slug="gba")
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[1] = {"rom_id": 1, "status": "downloading", "progress": 0}
 
         with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
@@ -2806,7 +2807,7 @@ class TestDoDownloadNestedSingleFile:
                 f.write(b"\x00" * 128)
 
         _seed_rom(plugin._uow, 7, platform_slug="dc")
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[7] = {"rom_id": 7, "status": "downloading", "progress": 0}
 
         with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
@@ -3185,7 +3186,7 @@ class TestPathTraversalPlatformSlug:
             "platform_name": "Nintendo 64",
         }
 
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
 
         # Track make_dirs to prove the slug is rejected BEFORE any directory work.
         made_dirs: list[str] = []
@@ -3340,7 +3341,7 @@ class TestDoDownloadCancelled:
         def fake_download_cancel(_rom_id, _filename, dest, _progress_callback=None, *, resume=False, on_meta=None):
             raise asyncio.CancelledError()
 
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[42] = {"rom_id": 42, "status": "downloading", "progress": 0}
 
         with (
@@ -3392,7 +3393,7 @@ class TestDoDownloadZipFailure:
             with open(dest, "wb") as f:
                 f.write(b"not a zip file")
 
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[66] = {"rom_id": 66, "status": "downloading", "progress": 0}
 
         with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
@@ -3452,7 +3453,7 @@ class TestDoDownloadPostDecodeTraversal:
         }
 
         _seed_rom(plugin._uow, 88, platform_slug="psx")
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[88] = {"rom_id": 88, "status": "downloading", "progress": 0}
 
         with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
@@ -3523,7 +3524,7 @@ class TestDoDownloadPostDecodeTraversal:
         }
 
         _seed_rom(plugin._uow, 91, platform_slug="switch")
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[91] = {"rom_id": 91, "status": "downloading", "progress": 0}
 
         with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
@@ -3576,7 +3577,7 @@ class TestDoDownloadFailureEmit:
         def fake_download(_rom_id, _filename, _dest, _progress_callback=None, *, resume=False, on_meta=None):
             raise OSError("simulated network drop")
 
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[42] = {"rom_id": 42, "status": "downloading", "progress": 0}
 
         with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
@@ -3635,7 +3636,7 @@ class TestDoDownloadInvariantFailure:
             with open(dest, "wb") as f:
                 f.write(b"\x00" * 64)
 
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         # rom_id=0 violates RomInstall's invariant (rom_id must be positive).
         plugin._download_service._download_queue[0] = {"rom_id": 0, "status": "downloading", "progress": 0}
 
@@ -3692,7 +3693,7 @@ class TestDoDownloadInvariantFailure:
             with open(dest, "wb") as f:
                 f.write(zip_bytes)
 
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[0] = {"rom_id": 0, "status": "downloading", "progress": 0}
 
         with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
@@ -3921,7 +3922,7 @@ class TestUrlEncodedFilenameRename:
                 f.write(zip_bytes)
 
         _seed_rom(plugin._uow, 99, platform_slug="psx")
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[99] = {"rom_id": 99, "status": "downloading", "progress": 0}
 
         with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
@@ -3980,7 +3981,7 @@ class TestUrlEncodedFilenameRename:
                 f.write(zip_bytes)
 
         _seed_rom(plugin._uow, 55, platform_slug="psx")
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[55] = {"rom_id": 55, "status": "downloading", "progress": 0}
 
         with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
@@ -4725,7 +4726,7 @@ class TestDoDownloadRedownloadPreservesExisting:
         def fake_download(_rom_id, _filename, _dest, _progress_callback=None, *, resume=False, on_meta=None):
             raise OSError("network died mid-redownload")
 
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[42] = {"rom_id": 42, "status": "downloading", "progress": 0}
 
         with patch.object(plugin._romm_api, "download_rom_content", side_effect=fake_download):
@@ -4778,7 +4779,7 @@ class TestDoDownloadCancelReconcile:
         }
 
         _seed_rom(plugin._uow, 42)
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[42] = {
             "rom_id": 42,
             "status": "downloading",
@@ -4861,7 +4862,7 @@ class TestDoDownloadCancelReconcile:
         }
 
         _seed_rom(plugin._uow, 77, platform_slug="psx")
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[77] = {
             "rom_id": 77,
             "status": "downloading",
@@ -4956,7 +4957,7 @@ class TestDoDownloadCancelEmitsEvent:
         def fake_download_cancel(_rom_id, _filename, _dest, _progress_callback=None, *, resume=False, on_meta=None):
             raise asyncio.CancelledError()
 
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[42] = {
             "rom_id": 42,
             "status": "downloading",
@@ -5077,7 +5078,7 @@ class TestConcurrencyReservation:
                 f.write(b"\x00" * 512)
 
         _seed_rom(plugin._uow, 42)
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._reserved_bytes[42] = 999
         plugin._download_service._download_queue[42] = {"rom_id": 42, "status": "queued", "progress": 0}
 
@@ -5127,7 +5128,7 @@ class TestConcurrencyReservation:
                 f.write(b"\x00" * 64)
 
         _seed_rom(plugin._uow, 3)
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[3] = {"rom_id": 3, "status": "queued", "progress": 0}
 
         # Run the third download as a task — it must emit "queued" then block on
@@ -5248,7 +5249,7 @@ class TestCooperativeCancel:
                 # the loop never runs to completion — the transfer aborts.
                 progress_callback(i, 500)
 
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[42] = {"rom_id": 42, "status": "downloading", "progress": 0}
 
         with (
@@ -5267,7 +5268,7 @@ class TestCooperativeCancel:
     @pytest.mark.asyncio
     async def test_cancel_download_sets_token_and_cancels_task(self, plugin):
         """``cancel_download`` flips the token AND cancels the asyncio task."""
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         token = _DownloadControl()
         plugin._download_service._control_tokens[42] = token
 
@@ -5382,7 +5383,7 @@ class TestPauseResume:
             control.paused = True
             raise asyncio.CancelledError()
 
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[42] = {
             "rom_id": 42,
             "status": "downloading",
@@ -5436,7 +5437,7 @@ class TestPauseResume:
             control.cancelled = True
             raise asyncio.CancelledError()
 
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[42] = {"rom_id": 42, "status": "downloading", "progress": 0}
 
         with (
@@ -5480,7 +5481,7 @@ class TestPauseResume:
                 f.write(b"\x00" * 256)
 
         _seed_rom(plugin._uow, 42)
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[42] = {
             "rom_id": 42,
             "status": "downloading",
@@ -5531,7 +5532,7 @@ class TestPauseResume:
                 f.write(b"\x00" * 256)
 
         _seed_rom(plugin._uow, 42)
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
         plugin._download_service._download_queue[42] = {
             "rom_id": 42,
             "status": "downloading",
@@ -5632,7 +5633,7 @@ class TestPauseResume:
             "total_bytes": 1024,
             "resumable": True,
         }
-        plugin._download_service._loop = asyncio.get_event_loop()
+        plugin._download_service._loop = asyncio.get_running_loop()
 
         # get_rom is fetched via run_in_executor; the real loop runs it.
         captured_resume: list[bool] = []
@@ -5684,7 +5685,7 @@ class TestPauseResume:
     @pytest.mark.asyncio
     async def test_pause_download_sets_paused_flag_and_cancels_task(self, plugin):
         """pause_download flips control.paused (not cancelled) and cancels the task."""
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         control = _DownloadControl()
         plugin._download_service._control_tokens[42] = control
 

--- a/tests/services/test_firmware.py
+++ b/tests/services/test_firmware.py
@@ -20,6 +20,7 @@ from fakes.fake_renderer_rss import FakeRendererRss
 from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
 from fakes.fake_unit_of_work import FakeUnitOfWork, FakeUnitOfWorkFactory
 from fakes.library_peers import FakeArtworkManager
+from fakes.running_loop import running_loop
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.firmware_file import FirmwareFileAdapter
@@ -127,7 +128,7 @@ def _make_firmware_service(
     return FirmwareService(
         config=FirmwareServiceConfig(
             romm_api=romm_api if romm_api is not None else MagicMock(),
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=logger if logger is not None else decky.logger,
             clock=clock if clock is not None else _make_clock(),
             firmware_file_store=store,
@@ -262,7 +263,7 @@ def plugin():
             romm_api=p._romm_api,
             steam_config=steam_config,
             settings=p.settings,
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=decky.logger,
             plugin_dir=decky.DECKY_PLUGIN_DIR,
             launcher_exe=f"{decky.DECKY_USER_HOME}/.local/share/romm-tender/bin/rom-launcher",
@@ -286,7 +287,7 @@ def plugin():
 @pytest.fixture(autouse=True)
 async def _set_event_loop(plugin, fw):
     """Ensure plugin.loop and the firmware sub-services match the running event loop."""
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     plugin.loop = loop
     _set_loop(fw, loop)
 
@@ -1170,7 +1171,7 @@ class TestGetFirmwareStatus:
             {"id": 3, "file_name": "gba_bios.bin", "file_path": "bios/gba/gba_bios.bin", "file_size_bytes": 300},
         ]
         # A real loop so the executor-run reads hit the shared fake UoW.
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
         # "dc": a bound ROM. "ps2": only an unbound ROM. "gba": no ROM rows.
         _seed_rom(plugin._uow, rom_id=42, platform_slug="dc", app_id=1)
         _seed_rom(plugin._uow, rom_id=43, platform_slug="ps2", app_id=None)
@@ -1214,7 +1215,7 @@ class TestGetFirmwareStatus:
     async def test_handles_api_error_with_offline_fallback(self, plugin, fw):
         # Real loop: only the HTTP list_firmware fails; the installed-slugs read
         # against the fake UoW still succeeds.
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
 
         with patch.object(plugin._romm_api, "list_firmware", side_effect=Exception("Connection refused")):
             result = await fw.get_firmware_status()
@@ -1562,7 +1563,7 @@ class TestGetFirmwareStatusBiosAggregates:
             core_info=_dc_core_info(),
             retrodeck_paths=FakeRetroDeckPaths(bios=str(bios_dir)),
         )
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
 
         with patch.object(plugin._romm_api, "list_firmware", side_effect=Exception("offline")):
             result = await fw.get_firmware_status()
@@ -1592,7 +1593,7 @@ class TestGetFirmwareStatusBiosAggregates:
             firmware_folder_verdicts=FakeFolderVerdicts(),
             core_info=_test_core_info(),
         )
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
 
         with patch.object(plugin._romm_api, "list_firmware", side_effect=Exception("offline")):
             result = await fw.get_firmware_status()
@@ -1617,7 +1618,7 @@ class TestGetFirmwareStatusBiosAggregates:
             firmware_folder_verdicts=FakeFolderVerdicts(),
             core_info=FakeCoreInfoProvider(options=[]),
         )
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
 
         with patch.object(plugin._romm_api, "list_firmware", side_effect=Exception("offline")):
             result = await fw.get_firmware_status()
@@ -1651,7 +1652,7 @@ class TestGetFirmwareStatusBiosAggregates:
                 "md5_hash": "",
             },
         ]
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
 
         real_exists = fw._config.firmware_file_store.exists
         checked: list[str] = []
@@ -2543,7 +2544,7 @@ class TestDownloadFirmware:
                 f.write(content)
 
         fw._demand._retrodeck_paths = FakeRetroDeckPaths(bios=str(bios_dir))
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
 
         with (
             patch.object(plugin._romm_api, "get_firmware", return_value=fw_detail),
@@ -2573,7 +2574,7 @@ class TestDownloadFirmware:
             "md5_hash": "",
         }
 
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
 
         with (
             patch.object(plugin._romm_api, "get_firmware", return_value=fw_detail),
@@ -2601,7 +2602,7 @@ class TestDownloadFirmware:
         }
 
         fw._demand._retrodeck_paths = FakeRetroDeckPaths(bios=str(bios_dir))
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
 
         download_called = []
 
@@ -2654,7 +2655,7 @@ class TestDownloadAllFirmware:
             },
         ]
 
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
 
         download_called_ids = []
 
@@ -2696,7 +2697,7 @@ class TestDownloadAllFirmware:
             declares_directory=True,
             folder=FolderVerdict(satisfied=False),
         )
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
         download_called_ids = []
 
         async def fake_download_firmware(fw_id, _placements):
@@ -2747,7 +2748,7 @@ class TestDownloadPlatformFirmwareFile:
     async def test_downloads_the_named_file_of_that_platform(self, plugin, fw, tmp_path):
         bios_dir = tmp_path / "retrodeck" / "bios"
         bios_dir.mkdir(parents=True)
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
         fetched = []
 
         async def fake_download_one(fw_id, _placements):
@@ -2771,7 +2772,7 @@ class TestDownloadPlatformFirmwareFile:
         bios_dir = tmp_path / "retrodeck" / "bios"
         bios_dir.mkdir(parents=True)
         (bios_dir / "existing.bin").write_bytes(b"\x00" * 50)
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
 
         async def fake_download_one(fw_id, _placements):
             raise AssertionError(f"nothing to fetch, but firmware {fw_id} was requested")
@@ -2791,7 +2792,7 @@ class TestDownloadPlatformFirmwareFile:
     async def test_a_name_the_platform_does_not_hold_is_refused(self, plugin, fw, tmp_path):
         bios_dir = tmp_path / "retrodeck" / "bios"
         bios_dir.mkdir(parents=True)
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
 
         async def fake_download_one(fw_id, _placements):
             raise AssertionError(f"nothing to fetch, but firmware {fw_id} was requested")
@@ -2813,7 +2814,7 @@ class TestDownloadPlatformFirmwareFile:
         # the caller intact rather than folded into a count of errors.
         bios_dir = tmp_path / "retrodeck" / "bios"
         bios_dir.mkdir(parents=True)
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
 
         async def fake_download_one(_fw_id, _placements):
             return {"success": False, "reason": "server_unreachable", "message": "RomM is unreachable"}
@@ -2853,7 +2854,7 @@ class TestDownloadPlatformFirmwareFile:
             declares_directory=True,
             folder=FolderVerdict(satisfied=False),
         )
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
 
         async def fake_download_one(fw_id, _placements):
             raise AssertionError(f"a folder declaration must not be fetched, but firmware {fw_id} was requested")
@@ -2871,7 +2872,7 @@ class TestDownloadPlatformFirmwareFile:
 
     @pytest.mark.asyncio
     async def test_a_failed_listing_fetch_answers_with_zero(self, plugin, fw):
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
         fw._listing._firmware_cache = None
         with patch.object(plugin._romm_api, "list_firmware", side_effect=OSError("Connection reset")):
             result = await fw.download_platform_firmware_file("dc", "missing.bin")
@@ -3161,7 +3162,7 @@ class TestDeletePlatformBios:
             firmware_file_store=store,
             retrodeck_paths=FakeRetroDeckPaths(bios=str(bios_dir)),
         )
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
         _declare(fw, ("scph5501.bin", "PS1 US BIOS", True), ("scph5502.bin", "PS1 EU BIOS", True))
 
         # The downloaded file has a BiosFile record to prune (firmware slug "ps").
@@ -3233,7 +3234,7 @@ class TestDeletePlatformBios:
             retrodeck_paths=FakeRetroDeckPaths(bios=str(bios_dir)),
             core_info=_test_core_info(),
         )
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
         _resolver(fw).declare("IPL.bin", required_by=[_TEST_CORE], description="GameCube IPL")
         _resolver(fw).declare(
             "codehandler.bin",
@@ -3418,7 +3419,7 @@ class TestDeletePlatformBios:
             retrodeck_paths=FakeRetroDeckPaths(bios=str(bios_dir)),
             core_info=_test_core_info(),
         )
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
         for slug in ("psx", "ps"):
             plugin._uow.bios_files.save(
                 BiosFile.mark_downloaded(
@@ -3876,7 +3877,7 @@ class TestCheckPlatformBiosNoCoreFields:
         )
         fw = _make_firmware_service(romm_api=plugin._romm_api, core_info=core_info)
         # no emulator declares anything here
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
 
         with patch.object(plugin._romm_api, "list_firmware", side_effect=Exception("offline")):
             result = await fw.check_platform_bios("sms")
@@ -3948,7 +3949,7 @@ class TestDownloadRequiredFirmware:
         fw._config.core_info.active_core = (_TEST_CORE, "Test Core")
         _declare(fw, ("required.bin", "Required BIOS", True), ("optional.bin", "Optional firmware", False))
 
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
 
         download_called_ids = []
 
@@ -4096,7 +4097,7 @@ class TestDownloadRequiredFirmware:
 
         _declare(fw, ("existing.bin", "Already downloaded", True), ("missing.bin", "Not yet downloaded", True))
 
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
 
         download_called_ids = []
 
@@ -4139,7 +4140,7 @@ class TestCheckPlatformBiosOffline:
             core_info=_dc_core_info(),
             retrodeck_paths=FakeRetroDeckPaths(bios=str(bios_dir)),
         )
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
 
         with patch.object(plugin._romm_api, "list_firmware", side_effect=Exception("offline")):
             result = await fw.check_platform_bios("dc")
@@ -4182,7 +4183,7 @@ class TestCheckPlatformBiosOffline:
             firmware_resolver=FakeFirmwareResolver(unread_cores=frozenset({"n64_libretro"})),
             core_info=FakeCoreInfoProvider(options=[libretro_option("n64_libretro", "Mupen64")]),
         )
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
 
         with patch.object(plugin._romm_api, "list_firmware", side_effect=Exception("offline")):
             result = await fw.check_platform_bios("n64")
@@ -4486,7 +4487,7 @@ class TestDownloadFirmwareErrors:
                 f.write(content)
 
         fw._demand._retrodeck_paths = FakeRetroDeckPaths(bios=str(bios_dir))
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
 
         with (
             patch.object(plugin._romm_api, "get_firmware", return_value=fw_detail),
@@ -4806,7 +4807,7 @@ class TestBadPathFirmwareCallables:
         import logging
 
         fw = self._build_service(fake_romm_api)
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
         fake_romm_api.fail_on_next(OSError("connection reset"))
 
         with caplog.at_level(logging.ERROR):
@@ -4826,7 +4827,7 @@ class TestBadPathFirmwareCallables:
         import logging
 
         fw = self._build_service(fake_romm_api)
-        _set_loop(fw, asyncio.get_event_loop())
+        _set_loop(fw, asyncio.get_running_loop())
         fake_romm_api.fail_on_next(OSError("connection reset"))
 
         with caplog.at_level(logging.ERROR):

--- a/tests/services/test_game_detail.py
+++ b/tests/services/test_game_detail.py
@@ -23,6 +23,7 @@ from fakes.fake_save_api import FakeSaveApi
 from fakes.fake_save_location_reader import FakeSaveLocationReader
 from fakes.fake_unit_of_work import FakeUnitOfWork, FakeUnitOfWorkFactory
 from fakes.library_peers import FakeArtworkManager
+from fakes.running_loop import running_loop
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.firmware_file import FirmwareFileAdapter
@@ -73,7 +74,7 @@ def plugin(tmp_path):
             romm_api=MagicMock(),
             steam_config=steam_config,
             settings=p.settings,
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=decky.logger,
             plugin_dir=decky.DECKY_PLUGIN_DIR,
             launcher_exe=f"{decky.DECKY_USER_HOME}/.local/share/romm-tender/bin/rom-launcher",
@@ -104,7 +105,7 @@ def plugin(tmp_path):
             resolve_upload_conflict=_GAVEL,
             compute_sync_action=_GAVEL.compute_sync_action,
             settings={"log_level": "debug"},
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=logging.getLogger("test"),
             clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
             settings_persister=MagicMock(),
@@ -135,7 +136,7 @@ def plugin(tmp_path):
             romm_api=fake_api,
             retry=_make_retry(),
             device_id_provider=p._save_sync_service,
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=logging.getLogger("test"),
             clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
             log_debug=p._log_debug,
@@ -147,7 +148,7 @@ def plugin(tmp_path):
         config=AchievementsServiceConfig(
             romm_api=MagicMock(),
             uow_factory=FakeUnitOfWorkFactory(uow=uow),
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=logging.getLogger("test"),
             clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
             log_debug=p._log_debug,
@@ -157,7 +158,7 @@ def plugin(tmp_path):
     p._firmware_service = FirmwareService(
         config=FirmwareServiceConfig(
             romm_api=MagicMock(),
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=logging.getLogger("test"),
             clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
             firmware_file_store=FirmwareFileAdapter(),
@@ -316,7 +317,7 @@ def _seed_metadata(plugin, rom_id, *, cached_at, summary="", genres=(), app_id=N
 
 @pytest.fixture(autouse=True)
 async def _set_event_loop(plugin):
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     plugin.loop = loop
     plugin._save_sync_service._loop = loop
     plugin._playtime_service._loop = loop

--- a/tests/services/test_launch_gate.py
+++ b/tests/services/test_launch_gate.py
@@ -7,6 +7,7 @@ import logging
 from typing import TYPE_CHECKING, Any, cast
 
 import pytest
+from fakes.running_loop import running_loop
 
 from services.launch_gate import (
     LaunchGateService,
@@ -168,7 +169,7 @@ def _make_service(
             save_file_store=cast(
                 "SaveFileStore", save_file_store if save_file_store is not None else FakeSaveFileStore()
             ),
-            loop=loop if loop is not None else asyncio.get_event_loop(),
+            loop=loop if loop is not None else running_loop(),
             logger=logger,
         ),
     )

--- a/tests/services/test_metadata.py
+++ b/tests/services/test_metadata.py
@@ -6,6 +6,7 @@ import pytest
 # conftest.py patches decky before this import; use _make_testable_plugin for test-only attrs
 from _factories import _make_testable_plugin
 from fakes.fake_unit_of_work import FakeUnitOfWork, FakeUnitOfWorkFactory
+from fakes.running_loop import running_loop
 
 from adapters.debug_logger import SettingsAwareDebugLogger
 from adapters.steam_config import SteamConfigAdapter
@@ -81,7 +82,7 @@ def plugin(uow):
 
     metadata_service = MetadataService(
         config=MetadataServiceConfig(
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=decky.logger,
             log_debug=p._log_debug,
             uow_factory=FakeUnitOfWorkFactory(uow=uow),
@@ -94,8 +95,8 @@ def plugin(uow):
 @pytest.fixture(autouse=True)
 async def _set_event_loop(plugin):
     """Ensure plugin.loop and service loop match the running event loop for async tests."""
-    plugin.loop = asyncio.get_event_loop()
-    plugin._metadata_service._loop = asyncio.get_event_loop()
+    plugin.loop = asyncio.get_running_loop()
+    plugin._metadata_service._loop = asyncio.get_running_loop()
 
 
 class TestGetRomMetadata:

--- a/tests/services/test_migration.py
+++ b/tests/services/test_migration.py
@@ -23,6 +23,7 @@ from fakes.fake_save_location_reader import FakeSaveLocationReader
 from fakes.fake_settings_persister import FakeSettingsPersister
 from fakes.fake_unit_of_work import FakeUnitOfWork, FakeUnitOfWorkFactory
 from fakes.library_peers import FakeArtworkManager
+from fakes.running_loop import running_loop
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.firmware_file import FirmwareFileAdapter
@@ -91,7 +92,7 @@ def plugin(tmp_path, fake_romm_api):
     p._firmware_service = FirmwareService(
         config=FirmwareServiceConfig(
             romm_api=fake_romm_api,
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=decky.logger,
             clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
             firmware_file_store=FirmwareFileAdapter(),
@@ -110,7 +111,7 @@ def plugin(tmp_path, fake_romm_api):
             romm_api=fake_romm_api,
             steam_config=steam_config,
             settings=p.settings,
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=decky.logger,
             plugin_dir=decky.DECKY_PLUGIN_DIR,
             launcher_exe=f"{decky.DECKY_USER_HOME}/.local/share/romm-tender/bin/rom-launcher",
@@ -151,7 +152,7 @@ def plugin(tmp_path, fake_romm_api):
         config=MigrationServiceConfig(
             migration_file_store=MigrationFileAdapter(),
             settings=p.settings,
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=decky.logger,
             settings_persister=p._settings_persister,
             emit=RecordingEmitter(),
@@ -226,7 +227,7 @@ def _seed_bios(uow, *, platform_slug, file_name, file_path, firmware_id=None):
 @pytest.fixture(autouse=True)
 async def _set_event_loop(plugin):
     """Ensure plugin.loop and migration service loop match the running event loop."""
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     plugin.loop = loop
     plugin._migration_service._loop = loop
     # The save-sort half took its own copy of the loop at construction, so
@@ -1679,7 +1680,7 @@ class TestDetectSaveSortChangeThreadSafety:
         Before the fix, this would call ``loop.create_task`` from a
         worker thread, which is undefined behavior.
         """
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         plugin._migration_service._loop = loop
 
         # Initial state: a populated OLD layout. Detect should observe a
@@ -1741,7 +1742,7 @@ class TestMigrationFailureInjection:
         uow = uow if uow is not None else FakeUnitOfWork()
         defaults: dict[str, Any] = {
             "settings": {},
-            "loop": asyncio.get_event_loop(),
+            "loop": running_loop(),
             "logger": decky.logger,
             "settings_persister": FakeSettingsPersister(),
             "emit": RecordingEmitter(),
@@ -2001,7 +2002,7 @@ class TestBackgroundTaskTracking:
     @pytest.mark.asyncio
     async def test_shutdown_cancels_pending_tasks_and_empties_set(self, plugin):
         """``shutdown()`` cancels in-flight tasks and the set is empty after."""
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         plugin._migration_service._loop = loop
 
         # Spawn a task that blocks forever via an unset Event.

--- a/tests/services/test_migration_save_sort.py
+++ b/tests/services/test_migration_save_sort.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -16,7 +17,6 @@ from fakes.fake_relaunch_options_resolver import FakeRelaunchOptionsResolver
 from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
 from fakes.fake_save_location_reader import FakeSaveLocationReader
 from fakes.fake_unit_of_work import FakeUnitOfWork, FakeUnitOfWorkFactory
-from fakes.running_loop import running_loop
 
 from adapters.migration_file import MigrationFileAdapter
 from domain.rom import Rom
@@ -26,6 +26,27 @@ from services.migration import MigrationService, MigrationServiceConfig
 
 if TYPE_CHECKING:
     from models.state import SaveSortSettings
+
+_TEST_LOOP: dict[str, asyncio.AbstractEventLoop] = {}
+
+
+@pytest.fixture(autouse=True)
+async def _set_event_loop():
+    """Give the services built here the loop their test runs on.
+
+    ``detect_save_sort_change`` may be reached from a worker thread (via
+    ``SyncEngine._refresh_save_sort_state`` → ``run_in_executor``) and schedules
+    its emit with ``asyncio.run_coroutine_threadsafe``, which reaches ``_loop``
+    for a ``call_soon_threadsafe``. That is a call from off the loop thread —
+    and in a synchronous test from no loop at all — which is exactly where
+    ``fakes.running_loop`` refuses rather than answering.
+
+    It captures the loop rather than rebinding a service's ``_loop``, because
+    ``_make_service`` builds its service inside the test body — after every
+    fixture has run, so there is nothing yet to rebind. Otherwise this is
+    ``tests/services/test_downloads.py``'s ``_set_event_loop``.
+    """
+    _TEST_LOOP["loop"] = asyncio.get_running_loop()
 
 
 def _no_corename(core_so: str) -> str | None:
@@ -116,7 +137,7 @@ def _make_service(
         config=MigrationServiceConfig(
             migration_file_store=migration_file_store if migration_file_store is not None else MigrationFileAdapter(),
             settings={},
-            loop=running_loop(),
+            loop=_TEST_LOOP["loop"],
             logger=logging.getLogger("test"),
             settings_persister=MagicMock(),
             emit=MagicMock(),
@@ -177,6 +198,35 @@ class TestDetectSaveSortChange:
         assert uow.kv_config.set_count == set_count_before
         with uow:
             assert uow.kv_config.get("save_sort_settings_previous") is None
+
+    def test_a_sync_test_can_schedule_the_emit_for_real(self, tmp_path):
+        """A detected change from a SYNCHRONOUS test, with nothing taken out of the path.
+
+        Every other test on this path replaces ``_loop`` with a ``MagicMock`` or
+        stubs ``run_coroutine_threadsafe``, so all of them keep passing over a
+        service holding something it cannot schedule on — which is what the
+        sync-fixture placeholder is, reached from a thread with no loop running.
+        Here the real call gets the real loop: ``detect_save_sort_change`` must
+        not raise, and one turn of that loop delivers the emit.
+
+        An async test proves none of this — there the placeholder resolves to the
+        running loop and the scheduling works either way.
+        """
+        old = {"sort_by_content": True, "sort_by_core": False}
+        new = {"sort_by_content": False, "sort_by_core": True}
+        svc, _uow = _make_service(
+            tmp_path,
+            sort_settings=(False, True),
+            state_overrides={"save_sort_settings": old},
+        )
+        emit = AsyncMock()
+        svc._save_sort._emit = emit
+
+        svc.detect_save_sort_change()
+        # The schedule only queued a callback — nothing runs until the loop does.
+        _TEST_LOOP["loop"].run_until_complete(asyncio.sleep(0))
+
+        emit.assert_awaited_once_with("save_sort_changed", {"old_settings": old, "new_settings": new})
 
 
 class TestDetectSaveSortChangeContentDir:

--- a/tests/services/test_migration_save_sort.py
+++ b/tests/services/test_migration_save_sort.py
@@ -27,12 +27,15 @@ from services.migration import MigrationService, MigrationServiceConfig
 if TYPE_CHECKING:
     from models.state import SaveSortSettings
 
+# Empty except for the duration of one test: the fixture below fills the key through
+# ``monkeypatch``, which removes it again at teardown, so a read outside a test is a
+# ``KeyError`` rather than a loop that has since been closed.
 _TEST_LOOP: dict[str, asyncio.AbstractEventLoop] = {}
 
 
 @pytest.fixture(autouse=True)
-async def _set_event_loop():
-    """Give the services built here the loop their test runs on.
+async def _capture_running_loop(monkeypatch: pytest.MonkeyPatch):
+    """Capture the loop this test runs on for the services built in its body.
 
     ``detect_save_sort_change`` may be reached from a worker thread (via
     ``SyncEngine._refresh_save_sort_state`` → ``run_in_executor``) and schedules
@@ -41,12 +44,13 @@ async def _set_event_loop():
     and in a synchronous test from no loop at all — which is exactly where
     ``fakes.running_loop`` refuses rather than answering.
 
-    It captures the loop rather than rebinding a service's ``_loop``, because
-    ``_make_service`` builds its service inside the test body — after every
-    fixture has run, so there is nothing yet to rebind. Otherwise this is
-    ``tests/services/test_downloads.py``'s ``_set_event_loop``.
+    This is deliberately NOT ``tests/services/test_downloads.py``'s
+    ``_set_event_loop``, which rebinds each service's ``_loop`` after the fact:
+    ``_make_service`` builds its service inside the test body, after every
+    fixture has run, so there is nothing yet to rebind. Hence capture, and hence
+    the name — restoring the consistency would put the rebind before the object.
     """
-    _TEST_LOOP["loop"] = asyncio.get_running_loop()
+    monkeypatch.setitem(_TEST_LOOP, "loop", asyncio.get_running_loop())
 
 
 def _no_corename(core_so: str) -> str | None:

--- a/tests/services/test_migration_save_sort.py
+++ b/tests/services/test_migration_save_sort.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import os
@@ -17,6 +16,7 @@ from fakes.fake_relaunch_options_resolver import FakeRelaunchOptionsResolver
 from fakes.fake_retrodeck_paths import FakeRetroDeckPaths
 from fakes.fake_save_location_reader import FakeSaveLocationReader
 from fakes.fake_unit_of_work import FakeUnitOfWork, FakeUnitOfWorkFactory
+from fakes.running_loop import running_loop
 
 from adapters.migration_file import MigrationFileAdapter
 from domain.rom import Rom
@@ -116,7 +116,7 @@ def _make_service(
         config=MigrationServiceConfig(
             migration_file_store=migration_file_store if migration_file_store is not None else MigrationFileAdapter(),
             settings={},
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=logging.getLogger("test"),
             settings_persister=MagicMock(),
             emit=MagicMock(),

--- a/tests/services/test_playtime.py
+++ b/tests/services/test_playtime.py
@@ -1,6 +1,5 @@
 """Tests for PlaytimeService — SQLite ``rom_playtime`` aggregate + native play-session ingest."""
 
-import asyncio
 import logging
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -9,6 +8,7 @@ import pytest
 from _factories import _make_retry
 from fakes.fake_romm_api import FakeRommApi
 from fakes.fake_unit_of_work import FakeUnitOfWork, FakeUnitOfWorkFactory
+from fakes.running_loop import running_loop
 from fakes.system_time import FakeClock
 
 from domain.playtime import PendingPlaySession, Playtime
@@ -76,7 +76,7 @@ def make_service(fake_api=None, clock=None, uow=None, device_id: str | None = "d
         "romm_api": fake,
         "retry": _make_retry(),
         "device_id_provider": FakeDeviceIdProvider(device_id),
-        "loop": asyncio.get_event_loop(),
+        "loop": running_loop(),
         "logger": logging.getLogger("test"),
         "clock": clk,
         "log_debug": lambda _msg: None,

--- a/tests/services/test_rom_adoption.py
+++ b/tests/services/test_rom_adoption.py
@@ -275,7 +275,7 @@ class Harness:
 
 @pytest.fixture
 async def h():
-    return Harness(asyncio.get_event_loop())
+    return Harness(asyncio.get_running_loop())
 
 
 # ── the download gate ────────────────────────────────────────────────────

--- a/tests/services/test_rom_removal.py
+++ b/tests/services/test_rom_removal.py
@@ -85,7 +85,7 @@ def service(logger, queue_cleanup, rom_files, uow, emitter):
 @pytest.fixture(autouse=True)
 async def _sync_loop(service):
     """Keep service loop in sync with the running event loop."""
-    service._loop = asyncio.get_event_loop()
+    service._loop = asyncio.get_running_loop()
 
 
 def _make_rom(rom_id: int, *, platform_slug: str = "n64", bound: bool = True) -> Rom:
@@ -907,7 +907,7 @@ class TestDownloadQueueCleanup:
         svc = RomRemovalService(
             config=RomRemovalServiceConfig(
                 logger=logger,
-                loop=asyncio.get_event_loop(),
+                loop=asyncio.get_running_loop(),
                 clock=FakeClock(),
                 emit=RecordingEmitter(),
                 rom_file_store=rom_files,

--- a/tests/services/test_shortcut_relocation.py
+++ b/tests/services/test_shortcut_relocation.py
@@ -62,7 +62,7 @@ def _make(
             launcher_at_home=at_home,
             steam_config=steam_config,  # type: ignore[arg-type]
             uow_factory=factory,
-            loop=asyncio.get_event_loop(),
+            loop=asyncio.get_running_loop(),
             logger=logging.getLogger("test_shortcut_relocation"),
         ),
     )

--- a/tests/services/test_shortcut_removal.py
+++ b/tests/services/test_shortcut_removal.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 import decky
 import pytest
 from fakes.fake_unit_of_work import FakeUnitOfWork, FakeUnitOfWorkFactory
+from fakes.running_loop import running_loop
 
 from adapters.steam_config import SteamConfigAdapter
 from domain.rom import Rom
@@ -86,7 +87,7 @@ def svc(steam_config, artwork_remover_mock, uow_factory):
     return ShortcutRemovalService(
         config=ShortcutRemovalServiceConfig(
             steam_config=steam_config,
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=decky.logger,
             artwork_remover=artwork_remover_mock,
             uow_factory=uow_factory,
@@ -96,7 +97,7 @@ def svc(steam_config, artwork_remover_mock, uow_factory):
 
 @pytest.fixture(autouse=True)
 async def _set_event_loop(svc):
-    svc._loop = asyncio.get_event_loop()
+    svc._loop = asyncio.get_running_loop()
 
 
 # ── TestRemoveAllShortcuts ────────────────────────────────────────────────────
@@ -436,7 +437,7 @@ def _artwork_integration_service(uow, steam_config, tmp_path) -> ShortcutRemoval
             steam_config=steam_config,
             cover_art_file_store=CoverArtFileStoreAdapter(),
             cover_cache_dir=str(tmp_path / "covers"),
-            loop=asyncio.get_event_loop(),
+            loop=asyncio.get_running_loop(),
             logger=decky.logger,
             get_pending_sync=dict,
             uow_factory=FakeUnitOfWorkFactory(uow),
@@ -445,13 +446,13 @@ def _artwork_integration_service(uow, steam_config, tmp_path) -> ShortcutRemoval
     svc = ShortcutRemovalService(
         config=ShortcutRemovalServiceConfig(
             steam_config=steam_config,
-            loop=asyncio.get_event_loop(),
+            loop=asyncio.get_running_loop(),
             logger=decky.logger,
             artwork_remover=artwork_svc,
             uow_factory=FakeUnitOfWorkFactory(uow),
         ),
     )
-    svc._loop = asyncio.get_event_loop()
+    svc._loop = asyncio.get_running_loop()
     return svc
 
 

--- a/tests/services/test_steamgrid.py
+++ b/tests/services/test_steamgrid.py
@@ -14,6 +14,7 @@ from fakes.fake_settings_persister import FakeSettingsPersister
 from fakes.fake_sgdb_artwork_cache import FakeSgdbArtworkCache
 from fakes.fake_unit_of_work import FakeUnitOfWork, FakeUnitOfWorkFactory
 from fakes.library_peers import FakeArtworkManager
+from fakes.running_loop import running_loop
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.debug_logger import SettingsAwareDebugLogger
@@ -69,7 +70,7 @@ def plugin(sgdb_artwork_cache, fake_romm_api, fake_steamgrid_db_api, uow):
             romm_api=p._romm_api,
             steam_config=steam_config,
             settings=p.settings,
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=decky.logger,
             plugin_dir=decky.DECKY_PLUGIN_DIR,
             launcher_exe=f"{decky.DECKY_USER_HOME}/.local/share/romm-tender/bin/rom-launcher",
@@ -99,7 +100,7 @@ def plugin(sgdb_artwork_cache, fake_romm_api, fake_steamgrid_db_api, uow):
             steam_config=steam_config,
             sgdb_artwork_cache=sgdb_artwork_cache,
             settings=p.settings,
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=decky.logger,
             settings_persister=FakeSettingsPersister(),
             get_pending_sync=lambda: p._sync_service._pending_sync,
@@ -114,7 +115,7 @@ def plugin(sgdb_artwork_cache, fake_romm_api, fake_steamgrid_db_api, uow):
 @pytest.fixture(autouse=True)
 async def _set_event_loop(plugin):
     """Ensure plugin.loop matches the running event loop for async tests."""
-    plugin.loop = asyncio.get_event_loop()
+    plugin.loop = asyncio.get_running_loop()
 
 
 def _cached_path(cache: FakeSgdbArtworkCache, rom_id: int, asset_type: str) -> str:
@@ -124,7 +125,7 @@ def _cached_path(cache: FakeSgdbArtworkCache, rom_id: int, asset_type: str) -> s
 class TestVerifySgdbApiKey:
     @pytest.mark.asyncio
     async def test_valid_api_key(self, plugin, fake_steamgrid_db_api):
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
         fake_steamgrid_db_api.seed_verify_response({"success": True})
 
         result = await plugin.verify_sgdb_api_key("valid-key-123")
@@ -135,7 +136,7 @@ class TestVerifySgdbApiKey:
 
     @pytest.mark.asyncio
     async def test_invalid_api_key_401(self, plugin, fake_steamgrid_db_api):
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
         fake_steamgrid_db_api.verify_api_key_side_effect = SgdbApiError(401, "Unauthorized")
 
         result = await plugin.verify_sgdb_api_key("bad-key")
@@ -145,7 +146,7 @@ class TestVerifySgdbApiKey:
 
     @pytest.mark.asyncio
     async def test_invalid_api_key_403(self, plugin, fake_steamgrid_db_api):
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
         fake_steamgrid_db_api.verify_api_key_side_effect = SgdbApiError(403, "Forbidden")
 
         result = await plugin.verify_sgdb_api_key("bad-key")
@@ -155,7 +156,7 @@ class TestVerifySgdbApiKey:
 
     @pytest.mark.asyncio
     async def test_empty_string_falls_back_to_saved_key(self, plugin, fake_steamgrid_db_api):
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
         plugin.settings["steamgriddb_api_key"] = "saved-key-456"
         fake_steamgrid_db_api.seed_verify_response({"success": True})
 
@@ -167,7 +168,7 @@ class TestVerifySgdbApiKey:
 
     @pytest.mark.asyncio
     async def test_masked_value_falls_back_to_saved_key(self, plugin, fake_steamgrid_db_api):
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
         plugin.settings["steamgriddb_api_key"] = "saved-key-789"
         fake_steamgrid_db_api.seed_verify_response({"success": True})
 
@@ -178,7 +179,7 @@ class TestVerifySgdbApiKey:
 
     @pytest.mark.asyncio
     async def test_no_key_configured(self, plugin):
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
         # No saved key, no provided key
         result = await plugin.verify_sgdb_api_key("")
         assert result["success"] is False
@@ -186,14 +187,14 @@ class TestVerifySgdbApiKey:
 
     @pytest.mark.asyncio
     async def test_no_key_at_all_default_param(self, plugin):
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
         result = await plugin.verify_sgdb_api_key()
         assert result["success"] is False
         assert "No API key configured" in result["message"]
 
     @pytest.mark.asyncio
     async def test_network_error(self, plugin, fake_steamgrid_db_api):
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
         fake_steamgrid_db_api.verify_api_key_side_effect = ConnectionError("DNS resolution failed")
 
         result = await plugin.verify_sgdb_api_key("some-key")
@@ -203,7 +204,7 @@ class TestVerifySgdbApiKey:
 
     @pytest.mark.asyncio
     async def test_sgdb_rejects_key(self, plugin, fake_steamgrid_db_api):
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
         fake_steamgrid_db_api.seed_verify_response({"success": False})
 
         result = await plugin.verify_sgdb_api_key("rejected-key")
@@ -213,7 +214,7 @@ class TestVerifySgdbApiKey:
 
     @pytest.mark.asyncio
     async def test_http_500_error(self, plugin, fake_steamgrid_db_api):
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
         fake_steamgrid_db_api.verify_api_key_side_effect = SgdbApiError(500, "Internal Server Error")
 
         result = await plugin.verify_sgdb_api_key("some-key")
@@ -226,7 +227,7 @@ class TestVerifySgdbApiKey:
         """Defence-in-depth: a stray urllib.error.HTTPError should still be handled."""
         import urllib.error
 
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
         fake_steamgrid_db_api.verify_api_key_side_effect = urllib.error.HTTPError(
             "https://steamgriddb.com", 502, "Bad Gateway", http.client.HTTPMessage(), None
         )
@@ -244,7 +245,7 @@ class TestGetSgdbArtworkBase64:
         import base64
 
         plugin.settings["steamgriddb_api_key"] = "some-key"
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         # Pre-populate the in-memory cache
         sgdb_artwork_cache.files[_cached_path(sgdb_artwork_cache, 42, "hero")] = b"fake png data"
@@ -257,7 +258,7 @@ class TestGetSgdbArtworkBase64:
     @pytest.mark.asyncio
     async def test_no_api_key_returns_no_api_key_true(self, plugin):
         # No API key in settings
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         result = await plugin.get_sgdb_artwork_base64(42, 1)
         assert result["base64"] is None
@@ -266,7 +267,7 @@ class TestGetSgdbArtworkBase64:
     @pytest.mark.asyncio
     async def test_invalid_asset_type(self, plugin):
         plugin.settings["steamgriddb_api_key"] = "some-key"
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         result = await plugin.get_sgdb_artwork_base64(42, 99)
         assert result["base64"] is None
@@ -276,7 +277,7 @@ class TestGetSgdbArtworkBase64:
     async def test_state_only_no_romm_call_when_state_empty(self, plugin, fake_romm_api, fake_steamgrid_db_api):
         """base64 path is state-only — a registry row without sgdb_id never hits RomM."""
         plugin.settings["steamgriddb_api_key"] = "some-key"
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         # roms is empty — no row carries an sgdb_id for rom 42.
         # RomM/IGDB would resolve if (incorrectly) consulted — they must not be.
@@ -294,7 +295,7 @@ class TestGetSgdbArtworkBase64:
     @pytest.mark.asyncio
     async def test_no_sgdb_id_in_state(self, plugin, fake_romm_api):
         plugin.settings["steamgriddb_api_key"] = "some-key"
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         result = await plugin.get_sgdb_artwork_base64(42, 1)
 
@@ -304,7 +305,7 @@ class TestGetSgdbArtworkBase64:
     @pytest.mark.asyncio
     async def test_download_fails_returns_null(self, plugin, fake_steamgrid_db_api):
         plugin.settings["steamgriddb_api_key"] = "some-key"
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         # SGDB returns a URL but the image download fails (CDN 5xx).
         fake_steamgrid_db_api.seed_artwork(9999, "hero", "https://example.com/hero.png")
@@ -320,7 +321,7 @@ class TestGetSgdbArtworkBase64:
         import base64
 
         plugin.settings["steamgriddb_api_key"] = "some-key"
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         # Not in registry, but in pending sync with a resolved sgdb_id.
         plugin._sync_service._pending_sync[42] = {
@@ -341,7 +342,7 @@ class TestGetSgdbArtworkBase64:
     @pytest.mark.asyncio
     async def test_sgdb_id_cached_in_registry(self, plugin, uow, sgdb_artwork_cache, fake_steamgrid_db_api):
         plugin.settings["steamgriddb_api_key"] = "some-key"
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         # ROM with sgdb_id already cached on its row.
         _seed_rom(uow, 42, app_id=100001, sgdb_id=9999, name="Zelda")
@@ -371,14 +372,14 @@ class TestGetSgdbResolution:
 
     @pytest.mark.asyncio
     async def test_no_api_key(self, plugin):
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
         result = await plugin.get_sgdb_resolution(42)
         assert result == {"decision": "no_api_key"}
 
     @pytest.mark.asyncio
     async def test_use_state_when_romm_silent(self, plugin, uow, fake_romm_api):
         plugin.settings["steamgriddb_api_key"] = "some-key"
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         _seed_rom(uow, 42, app_id=1, sgdb_id=9999)
         # RomM has no sgdb_id → state wins, nothing persisted.
@@ -391,7 +392,7 @@ class TestGetSgdbResolution:
     @pytest.mark.asyncio
     async def test_use_romm_persists_when_state_empty(self, plugin, uow, fake_romm_api):
         plugin.settings["steamgriddb_api_key"] = "some-key"
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         # ROM row has no sgdb_id; RomM supplies one → persisted on the row.
         _seed_rom(uow, 42, app_id=1)
@@ -406,7 +407,7 @@ class TestGetSgdbResolution:
     @pytest.mark.asyncio
     async def test_romm_wins_over_differing_state_and_persists(self, plugin, uow, fake_romm_api):
         plugin.settings["steamgriddb_api_key"] = "some-key"
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         # Row holds an old id; RomM disagrees → RomM overwrites it.
         _seed_rom(uow, 42, app_id=1, sgdb_id=9999)
@@ -421,7 +422,7 @@ class TestGetSgdbResolution:
     @pytest.mark.asyncio
     async def test_romm_matches_state_no_persist(self, plugin, uow, fake_romm_api):
         plugin.settings["steamgriddb_api_key"] = "some-key"
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         # RomM agrees with the row → resolved, no redundant write.
         _seed_rom(uow, 42, app_id=1, sgdb_id=7777)
@@ -436,7 +437,7 @@ class TestGetSgdbResolution:
     @pytest.mark.asyncio
     async def test_unresolved_igdb_resolves_and_persists(self, plugin, uow, fake_romm_api, fake_steamgrid_db_api):
         plugin.settings["steamgriddb_api_key"] = "some-key"
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         _seed_rom(uow, 42, app_id=1, name="Zelda")
         # No sgdb_id anywhere, but RomM has an igdb_id that cross-refs.
@@ -452,7 +453,7 @@ class TestGetSgdbResolution:
     @pytest.mark.asyncio
     async def test_unresolved_needs_pick_with_candidates(self, plugin, uow, fake_romm_api, fake_steamgrid_db_api):
         plugin.settings["steamgriddb_api_key"] = "some-key"
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         _seed_rom(uow, 42, app_id=1)
         # No sgdb_id, no igdb_id → name search.
@@ -476,7 +477,7 @@ class TestGetSgdbResolution:
         self, plugin, fake_romm_api, fake_steamgrid_db_api
     ):
         plugin.settings["steamgriddb_api_key"] = "some-key"
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         fake_romm_api.roms[42] = {"id": 42, "igdb_id": 1234, "name": "Obscure Port"}
         # IGDB cross-ref has no match.
@@ -493,7 +494,7 @@ class TestSearchSgdbGames:
     @pytest.mark.asyncio
     async def test_happy_path_enriches_thumbs(self, plugin, fake_steamgrid_db_api):
         plugin.settings["steamgriddb_api_key"] = "some-key"
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         fake_steamgrid_db_api.seed_raw_response(
             "/search/autocomplete/mario",
@@ -518,7 +519,7 @@ class TestSearchSgdbGames:
 
     @pytest.mark.asyncio
     async def test_no_api_key(self, plugin):
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
         result = await plugin.search_sgdb_games("mario")
         assert result["success"] is False
         assert result["games"] == []
@@ -527,7 +528,7 @@ class TestSearchSgdbGames:
     @pytest.mark.asyncio
     async def test_network_error_returns_failure(self, plugin, fake_steamgrid_db_api):
         plugin.settings["steamgriddb_api_key"] = "some-key"
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
         fake_steamgrid_db_api.request_side_effect = ConnectionError("DNS failed")
 
         result = await plugin.search_sgdb_games("mario")
@@ -539,7 +540,7 @@ class TestSearchSgdbGames:
     @pytest.mark.asyncio
     async def test_caps_at_six_candidates(self, plugin, fake_steamgrid_db_api):
         plugin.settings["steamgriddb_api_key"] = "some-key"
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         data = [{"id": i, "name": f"Game {i}"} for i in range(1, 11)]
         fake_steamgrid_db_api.seed_raw_response("/search/autocomplete/many", {"success": True, "data": data})
@@ -565,7 +566,7 @@ class TestApplySgdbGameId:
     ):
         """A manual pick paints all four asset types into the rom's cache."""
         plugin.settings["steamgriddb_api_key"] = "some-key"
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         _seed_all_artwork(fake_steamgrid_db_api, 8888)
 
@@ -584,7 +585,7 @@ class TestApplySgdbGameId:
     async def test_clears_existing_cache_before_redownload(self, plugin, sgdb_artwork_cache, fake_steamgrid_db_api):
         """A re-pick evicts the prior PNGs first, then paints the new game's art."""
         plugin.settings["steamgriddb_api_key"] = "some-key"
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         # Stale art from a previous pick.
         for asset_type in ("hero", "logo", "grid", "icon"):
@@ -602,7 +603,7 @@ class TestApplySgdbGameId:
     async def test_persists_nothing(self, plugin, uow, sgdb_artwork_cache, fake_steamgrid_db_api):
         """A manual pick never writes the ROM row's sgdb_id."""
         plugin.settings["steamgriddb_api_key"] = "some-key"
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         _seed_rom(uow, 42, app_id=1)
         save_count_before = uow.roms.save_count
@@ -618,7 +619,7 @@ class TestApplySgdbGameId:
     @pytest.mark.asyncio
     async def test_coerces_string_args(self, plugin, sgdb_artwork_cache, fake_steamgrid_db_api):
         plugin.settings["steamgriddb_api_key"] = "some-key"
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
         _seed_all_artwork(fake_steamgrid_db_api, 8888)
 
         result = await plugin.apply_sgdb_game_id("42", "8888")
@@ -629,7 +630,7 @@ class TestApplySgdbGameId:
     @pytest.mark.asyncio
     async def test_missing_row_still_succeeds(self, plugin, sgdb_artwork_cache, fake_steamgrid_db_api):
         plugin.settings["steamgriddb_api_key"] = "some-key"
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
         _seed_all_artwork(fake_steamgrid_db_api, 8888)
 
         # No roms row for rom_id 42.
@@ -645,7 +646,7 @@ class TestApplySgdbGameId:
     async def test_partial_download_failure_still_succeeds(self, plugin, sgdb_artwork_cache, fake_steamgrid_db_api):
         """One asset failing to download must not break the pick — the rest paint."""
         plugin.settings["steamgriddb_api_key"] = "some-key"
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
         # Seed only three of the four assets — "logo" stays unseeded so its
         # download yields no data, simulating a single-asset failure.
         for asset_type in ("hero", "grid", "icon"):
@@ -677,7 +678,7 @@ class TestApplySgdbGameId:
         re-pick.
         """
         plugin.settings["steamgriddb_api_key"] = "some-key"
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         _seed_rom(uow, 42, app_id=1)
         _seed_all_artwork(fake_steamgrid_db_api, 8888)
@@ -707,7 +708,7 @@ class TestIconSupport:
         import base64
 
         plugin.settings["steamgriddb_api_key"] = "some-key"
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         # Pre-populate cache
         sgdb_artwork_cache.files[_cached_path(sgdb_artwork_cache, 42, "icon")] = b"icon png data"
@@ -723,7 +724,7 @@ class TestIconSupport:
         import base64
 
         plugin.settings["steamgriddb_api_key"] = "some-key"
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         _seed_rom(uow, 42, app_id=100001, sgdb_id=9999, name="Zelda")
 
@@ -887,7 +888,7 @@ class TestSaveShortcutIcon:
         plugin._steam_config.write_shortcut_icon = fake_write_icon  # type: ignore[method-assign]
         plugin._steam_config.read_shortcuts = _forbidden_vdf  # type: ignore[method-assign]
         plugin._steam_config.write_shortcuts = _forbidden_vdf  # type: ignore[method-assign]
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         icon_b64 = base64.b64encode(b"real icon png").decode("ascii")
         result = await plugin.save_shortcut_icon(12345, icon_b64)
@@ -899,7 +900,7 @@ class TestSaveShortcutIcon:
     @pytest.mark.asyncio
     async def test_save_shortcut_icon_invalid_base64(self, plugin):
         """Invalid base64 → canonical failure shape, no icon_path."""
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         result = await plugin.save_shortcut_icon(12345, "not-valid-base64!!!")
 
@@ -917,7 +918,7 @@ class TestSaveShortcutIcon:
             raise SteamGridDirMissingError("Cannot find Steam grid directory")
 
         plugin._steam_config.write_shortcut_icon = raise_missing  # type: ignore[method-assign]
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         icon_b64 = base64.b64encode(b"real icon png").decode("ascii")
         result = await plugin.save_shortcut_icon(12345, icon_b64)
@@ -959,7 +960,7 @@ class TestDebugLoggerProtocolSeam:
                 romm_api=p._romm_api,
                 steam_config=steam_config,
                 settings=p.settings,
-                loop=asyncio.get_event_loop(),
+                loop=running_loop(),
                 logger=decky.logger,
                 plugin_dir=decky.DECKY_PLUGIN_DIR,
                 launcher_exe=f"{decky.DECKY_USER_HOME}/.local/share/romm-tender/bin/rom-launcher",
@@ -986,7 +987,7 @@ class TestDebugLoggerProtocolSeam:
                 steam_config=steam_config,
                 sgdb_artwork_cache=sgdb_artwork_cache,
                 settings=p.settings,
-                loop=asyncio.get_event_loop(),
+                loop=running_loop(),
                 logger=decky.logger,
                 settings_persister=FakeSettingsPersister(),
                 get_pending_sync=lambda: p._sync_service._pending_sync,
@@ -1000,7 +1001,7 @@ class TestDebugLoggerProtocolSeam:
     async def test_sgdb_messages_route_through_injected_debug_logger(self, plugin_with_captured_log):
         """SGDB debug messages reach the injected ``log_debug``, not a hidden ``.info()`` seam."""
         plugin, captured = plugin_with_captured_log
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         # No API key configured -> early "skipped" debug message
         await plugin.get_sgdb_artwork_base64(42, 1)
@@ -1030,7 +1031,7 @@ class TestDebugLoggerProtocolSeam:
         import decky
 
         plugin, captured = plugin_with_captured_log
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
         # log_level=debug — pre-fix this is exactly the state where the
         # per-service ``_log_debug`` emitted via ``self._logger.info``.
         plugin.settings["log_level"] = "debug"
@@ -1211,7 +1212,7 @@ class TestReadFileAsBase64:
     @pytest.mark.asyncio
     async def test_returns_none_when_read_fails(self, plugin, sgdb_artwork_cache):
         """``read_bytes`` raising → ``None`` (frontend sees no artwork)."""
-        plugin._sgdb_service._loop = asyncio.get_event_loop()
+        plugin._sgdb_service._loop = asyncio.get_running_loop()
 
         def raising_read(_path: str) -> bytes:
             raise OSError("permission denied")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -17,6 +17,7 @@ from fakes.fake_settings_persister import FakeSettingsPersister
 from fakes.fake_sgdb_artwork_cache import FakeSgdbArtworkCache
 from fakes.fake_unit_of_work import FakeUnitOfWorkFactory
 from fakes.library_peers import FakeArtworkManager
+from fakes.running_loop import running_loop
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.debug_logger import SettingsAwareDebugLogger
@@ -135,7 +136,7 @@ def plugin():
             romm_api=p._romm_api,
             steam_config=steam_config,
             settings=p.settings,
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=decky.logger,
             plugin_dir=decky.DECKY_PLUGIN_DIR,
             launcher_exe=f"{decky.DECKY_USER_HOME}/.local/share/romm-tender/bin/rom-launcher",
@@ -161,7 +162,7 @@ def plugin():
             steam_config=steam_config,
             sgdb_artwork_cache=FakeSgdbArtworkCache(cache_root=decky.DECKY_PLUGIN_RUNTIME_DIR),
             settings=p.settings,
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=decky.logger,
             settings_persister=FakeSettingsPersister(),
             get_pending_sync=lambda: p._sync_service._pending_sync,
@@ -185,7 +186,7 @@ def plugin():
             settings=p.settings,
             romm_api=p._romm_api,
             settings_persister=p._settings_persister,
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=decky.logger,
             min_required_version=Plugin._MIN_REQUIRED_VERSION,
             forget_device=MagicMock(),
@@ -273,7 +274,7 @@ class TestConnection:
     async def test_test_connection_sets_version_on_romm_api(self, plugin):
         import decky
 
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         plugin.settings["romm_url"] = "http://romm.local"
         plugin.settings["romm_api_token"] = "rmm_token"
         plugin._romm_api.heartbeat.return_value = {"SYSTEM": {"VERSION": "4.9.0"}}
@@ -1304,7 +1305,7 @@ class TestPlaytimeFlushTaskLifecycle:
 
     def _plugin_with_playtime(self):
         p = Plugin()
-        p.loop = asyncio.get_event_loop()
+        p.loop = asyncio.get_running_loop()
         p._playtime_service = MagicMock()
         p._playtime_service.record_session_start.return_value = {"success": True}
         p._prune_service = MagicMock()

--- a/tests/test_plugin_callable_delegation.py
+++ b/tests/test_plugin_callable_delegation.py
@@ -758,7 +758,7 @@ class TestGameDetailCallableDelegation:
     @pytest.mark.asyncio
     async def test_get_cached_game_detail_delegates(self, plugin):
         # Runs on an executor worker, so the callable needs the real loop.
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         plugin._game_detail_service.get_cached_game_detail.return_value = {"detail": "x"}
         result = await plugin.get_cached_game_detail("12345")
         plugin._game_detail_service.get_cached_game_detail.assert_called_once_with("12345")
@@ -770,7 +770,7 @@ class TestGameDetailCallableDelegation:
         # bounded — a UoW, a firmware-cache read, a stat and a directory
         # listing. Running it on the loop thread stalls everything else the
         # plugin is doing for as long as the storage takes to answer.
-        plugin.loop = asyncio.get_event_loop()
+        plugin.loop = asyncio.get_running_loop()
         seen: list[int] = []
         plugin._game_detail_service.get_cached_game_detail.side_effect = lambda _app_id: (
             seen.append(threading.get_ident()) or {"found": False}

--- a/tests/test_plugin_saves.py
+++ b/tests/test_plugin_saves.py
@@ -21,6 +21,7 @@ from fakes.fake_save_api import FakeSaveApi
 from fakes.fake_save_location_reader import FakeSaveLocationReader
 from fakes.fake_unit_of_work import FakeUnitOfWorkFactory
 from fakes.library_peers import FakeArtworkManager
+from fakes.running_loop import running_loop
 from fakes.system_time import FakeClock, FakeSleeper, FakeUuidGen
 
 from adapters.gavel_native import GavelNativeAdapter
@@ -66,7 +67,7 @@ def plugin(tmp_path):
             romm_api=p._romm_api,
             steam_config=steam_config,
             settings=p.settings,
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=decky.logger,
             plugin_dir=decky.DECKY_PLUGIN_DIR,
             launcher_exe=f"{decky.DECKY_USER_HOME}/.local/share/romm-tender/bin/rom-launcher",
@@ -104,7 +105,7 @@ def plugin(tmp_path):
             resolve_upload_conflict=_GAVEL,
             compute_sync_action=_GAVEL.compute_sync_action,
             settings=p._save_settings,
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=logging.getLogger("test"),
             clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
             settings_persister=MagicMock(),
@@ -135,7 +136,7 @@ def plugin(tmp_path):
             romm_api=fake_api,
             retry=_make_retry(),
             device_id_provider=p._save_sync_service,
-            loop=asyncio.get_event_loop(),
+            loop=running_loop(),
             logger=logging.getLogger("test"),
             clock=FakeClock(now=datetime(2026, 1, 1, tzinfo=UTC)),
             log_debug=p._log_debug,
@@ -159,7 +160,7 @@ def plugin(tmp_path):
 @pytest.fixture(autouse=True)
 async def _set_event_loop(plugin):
     """Ensure plugin and service loops match the running event loop for async tests."""
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     plugin.loop = loop
     save_svc = plugin._save_sync_service
     save_svc._loop = loop
@@ -540,7 +541,7 @@ class TestPostExitSync:
             config=MigrationServiceConfig(
                 migration_file_store=MigrationFileAdapter(),
                 settings={},
-                loop=asyncio.get_event_loop(),
+                loop=asyncio.get_running_loop(),
                 logger=logging.getLogger("test"),
                 settings_persister=MagicMock(),
                 emit=MagicMock(),


### PR DESCRIPTION
pytest-asyncio 1.4.0 removed the implicit thread-default event loop that
`asyncio.get_event_loop()` answered with, so every synchronous fixture body
that asked for a loop raised `RuntimeError: no running event loop`. The suite
was pinned below 1.4 to keep working.

The tests now ask for the loop that is actually running. All 327 call sites in
`tests/` are gone: the 263 inside coroutines take `asyncio.get_running_loop()`
directly, and so do 22 synchronous helpers that are only ever entered from a
running loop.

The remaining 42 sites build a service before any loop exists — in a sync
fixture, or in a test body after every fixture has run — so there is no moment
at which the right loop could be handed over. They receive a forwarder instead
(`tests/fakes/running_loop.py`), which resolves the running loop when the
service reaches for it rather than when it is built. A service therefore lands
on the loop its own test runs on, nothing is created, and nothing is left
unclosed. The forwarder refuses when no loop is running instead of standing in
for one, which is what the whole change is about; the contract harness keeps
the real loop object, because its download service calls
`call_soon_threadsafe` from an executor thread.

The artwork tests' service took a `MagicMock` for the same reason and now takes
the forwarder too, so one rule answers for every service a test builds.

`_main` asks for the loop it is running on. Inside a coroutine both spellings
return the same object.

Ruff bans the old spelling repo-wide through TID251, with no per-file
exception, so the pattern cannot come back quietly on the next dependency
bump.

Measured with pytest-asyncio 1.4.0 installed: 8390 passed, no warnings. The
same suite on the previous commit under 1.4.0: 214 failed, 1418 errors.

Closes #806
Closes #1881
